### PR TITLE
[Feat] 이미지 분석 후 공간 초안 DB에 저장 및 에러 통일

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ POSTGRES_PASSWORD=apppass
 POSTGRES_PORT=5432
 
 DATABASE_URL=postgresql://appuser:apppass@localhost:5432/appdb
+DEFAULT_DRAFT_PROJECT_NAME=local-upload-project
+DEFAULT_DRAFT_FLOOR_NAME=default-floor
+DEFAULT_DRAFT_SOURCE=local_upload
+DEFAULT_DRAFT_SOURCE_MODE=floorplan_image
+DEFAULT_DRAFT_ANALYSIS_METHOD=fusion_service
 BACKEND_PORT=8000
 FRONTEND_PORT=5173
 AI_SERVICE_URL=http://localhost:9000

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from fastapi import HTTPException
+
+
+class ErrorCode(StrEnum):
+    INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
+    INVALID_REQUEST_BODY = "INVALID_REQUEST_BODY"
+    INVALID_FILE_EXTENSION = "INVALID_FILE_EXTENSION"
+    INVALID_PROJECT_FLOOR_INPUT = "INVALID_PROJECT_FLOOR_INPUT"
+    INVALID_UUID_FORMAT = "INVALID_UUID_FORMAT"
+    FILE_SAVE_FAILED = "FILE_SAVE_FAILED"
+    UPLOADED_FILE_NOT_FOUND = "UPLOADED_FILE_NOT_FOUND"
+    INVALID_PROJECT_ID = "INVALID_PROJECT_ID"
+    INVALID_FLOOR_ID = "INVALID_FLOOR_ID"
+    INVALID_PROJECT_FLOOR_PAIR = "INVALID_PROJECT_FLOOR_PAIR"
+    ANALYSIS_FAILED = "ANALYSIS_FAILED"
+    WALL_EXTRACTION_FAILED = "WALL_EXTRACTION_FAILED"
+    EXTERNAL_SERVICE_REQUEST_FAILED = "EXTERNAL_SERVICE_REQUEST_FAILED"
+    INVALID_EXTERNAL_RESPONSE = "INVALID_EXTERNAL_RESPONSE"
+    RF_SIMULATION_FAILED = "RF_SIMULATION_FAILED"
+    DB_CONNECTION_FAILED = "DB_CONNECTION_FAILED"
+    SCENE_DRAFT_SAVE_FAILED = "SCENE_DRAFT_SAVE_FAILED"
+
+
+class AppError(Exception):
+    def __init__(self, code: ErrorCode, message: str, status_code: int):
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def to_http_exception(exc: AppError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={"code": exc.code, "message": exc.message},
+    )

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from fastapi import HTTPException
-
 
 class ErrorCode(StrEnum):
     INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
@@ -31,10 +29,3 @@ class AppError(Exception):
         self.message = message
         self.status_code = status_code
         super().__init__(message)
-
-
-def to_http_exception(exc: AppError) -> HTTPException:
-    return HTTPException(
-        status_code=exc.status_code,
-        detail={"code": exc.code, "message": exc.message},
-    )

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -16,6 +16,11 @@ def database_url() -> str:
 
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://appuser:apppass@localhost:5432/appdb")
+DEFAULT_DRAFT_PROJECT_NAME = os.getenv("DEFAULT_DRAFT_PROJECT_NAME", "local-upload-project").strip()
+DEFAULT_DRAFT_FLOOR_NAME = os.getenv("DEFAULT_DRAFT_FLOOR_NAME", "default-floor").strip()
+DEFAULT_DRAFT_SOURCE = os.getenv("DEFAULT_DRAFT_SOURCE", "local_upload").strip()
+DEFAULT_DRAFT_SOURCE_MODE = os.getenv("DEFAULT_DRAFT_SOURCE_MODE", "floorplan_image").strip()
+DEFAULT_DRAFT_ANALYSIS_METHOD = os.getenv("DEFAULT_DRAFT_ANALYSIS_METHOD", "fusion_service").strip()
 
 
 def ai_service_url() -> str:

--- a/backend/app/routers/experiments.py
+++ b/backend/app/routers/experiments.py
@@ -2,8 +2,9 @@ from pathlib import Path
 import mimetypes
 
 import requests
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
+from app.core.errors import AppError, ErrorCode
 from app.core.settings import UPLOAD_DIR, ai_service_url, rf_server_url
 from app.services.wall_extraction import run_rule_based_wall_extraction
 
@@ -14,31 +15,36 @@ router = APIRouter(prefix="/experiments", tags=["experiments"])
 def wall_rule_based(file_id: str) -> dict:
     image_path = _find_uploaded_file(file_id)
     if image_path is None:
-        raise HTTPException(status_code=404, detail="Uploaded file not found")
+        raise AppError(ErrorCode.UPLOADED_FILE_NOT_FOUND, "Uploaded file not found.", 404)
 
     try:
         mask_path = run_rule_based_wall_extraction(image_path)
         return {
             "status": "ok",
             "fileId": file_id,
-            "walls": mask_path  
+            "walls": mask_path,
         }
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise AppError(
+            ErrorCode.WALL_EXTRACTION_FAILED,
+            f"Wall extraction failed: {exc}",
+            500,
+        ) from exc
 
 
 @router.post("/wall/unet/{file_id}")
 def wall_unet(file_id: str) -> dict:
     service = ai_service_url()
     if not service:
-        return {
-            "status": "pending",
-            "message": "AI_SERVICE_URL not set. Connect external AI repo server.",
-        }
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            "AI_SERVICE_URL not set. Connect external AI repo server.",
+            503,
+        )
 
     image_path = _find_uploaded_file(file_id)
     if image_path is None:
-        raise HTTPException(status_code=404, detail="Uploaded file not found")
+        raise AppError(ErrorCode.UPLOADED_FILE_NOT_FOUND, "Uploaded file not found.", 404)
 
     return _send_file_to_ai(
         f"{service.rstrip('/')}/inference/unet",
@@ -52,14 +58,15 @@ def wall_unet(file_id: str) -> dict:
 def objects_yolo(file_id: str) -> dict:
     service = ai_service_url()
     if not service:
-        return {
-            "status": "pending",
-            "message": "AI_SERVICE_URL not set. Connect external AI repo server.",
-        }
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            "AI_SERVICE_URL not set. Connect external AI repo server.",
+            503,
+        )
 
     image_path = _find_uploaded_file(file_id)
     if image_path is None:
-        raise HTTPException(status_code=404, detail="Uploaded file not found")
+        raise AppError(ErrorCode.UPLOADED_FILE_NOT_FOUND, "Uploaded file not found.", 404)
 
     return _send_file_to_ai(
         f"{service.rstrip('/')}/inference/yolo",
@@ -73,13 +80,22 @@ def objects_yolo(file_id: str) -> dict:
 def rf_sionna_smoke() -> dict:
     service = rf_server_url()
     if not service:
-        return {
-            "status": "pending",
-            "message": "RF_SERVER_URL not set. Connect external RF repo server.",
-        }
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            "RF_SERVER_URL not set. Connect external RF repo server.",
+            503,
+        )
 
-    response = requests.post(f"{service.rstrip('/')}/sionna/smoke", timeout=60)
-    return response.json()
+    try:
+        response = requests.post(f"{service.rstrip('/')}/sionna/smoke", timeout=60)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"RF service request failed: {exc}",
+            502,
+        ) from exc
 
 
 def _find_uploaded_file(file_id: str) -> Path | None:
@@ -102,4 +118,8 @@ def _send_file_to_ai(endpoint: str, file_id: str, image_path: Path, timeout: int
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:
-        raise HTTPException(status_code=502, detail=f"AI service request failed: {exc}") from exc
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"AI service request failed: {exc}",
+            502,
+        ) from exc

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from app.core.errors import AppError, ErrorCode
 from app.db.session import get_db
 
 router = APIRouter(tags=["health"])
@@ -18,4 +19,8 @@ def health_db(db: Session = Depends(get_db)) -> dict:
         db.execute(text("SELECT 1"))
         return {"status": "ok", "db": "connected"}
     except Exception as exc:
-        return {"status": "error", "db": "disconnected", "detail": str(exc)}
+        raise AppError(
+            ErrorCode.DB_CONNECTION_FAILED,
+            f"Database connection failed: {exc}",
+            503,
+        ) from exc

--- a/backend/app/routers/rf_run.py
+++ b/backend/app/routers/rf_run.py
@@ -1,48 +1,61 @@
-import json
 import httpx
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import JSONResponse
+
+from fastapi import APIRouter
+
+from app.core.errors import AppError, ErrorCode
+from app.core.settings import ai_service_url
 from app.schemas.scene import SceneSchema
 
 router = APIRouter(prefix="/rf", tags=["rf"])
 
-AI_SERVER_URL = "http://localhost:9000/internal/sionna/run"
-
-
-
 @router.post("/run")
 async def run_rf_simulation(body: SceneSchema):
+    service = ai_service_url()
+    if not service:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            "AI_SERVICE_URL not set. Connect external AI repo server.",
+            503,
+        )
+
     async with httpx.AsyncClient() as client:
         all_data = body.model_dump()
-        config = all_data.pop('config')
-        antenna = all_data.pop('antenna')
-        
+        config = all_data.pop("config")
+        antenna = all_data.pop("antenna")
+
         payload = {
             "engine": "sionna_rt",
             "run_type": "run",
             "floor_id": None,
             "input": {
-                "kind": "sionna_dto",  
-                "data": {            
+                "kind": "sionna_dto",
+                "data": {
                     "config": config,
                     "antenna": antenna,
-                    "scene": all_data 
-                }
-            }
+                    "scene": all_data,
+                },
+            },
         }
-        
-        target_url = "http://localhost:9000/internal/sionna/run"
+
+        target_url = f"{service.rstrip('/')}/internal/sionna/run"
 
         try:
             response = await client.post(
                 target_url,
                 json=payload,
-                timeout=120.0
+                timeout=120.0,
             )
-            
-            if response.status_code == 422:
-                print("❌ AI 서버 검증 실패 상세:", response.json())
-                
+            response.raise_for_status()
             return response.json()
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"AI 서버 통신 에러: {str(e)}")
+        except httpx.HTTPStatusError as exc:
+            raise AppError(
+                ErrorCode.RF_SIMULATION_FAILED,
+                f"RF simulation failed with status {exc.response.status_code}: {exc.response.text}",
+                502,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AppError(
+                ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+                f"AI server request failed: {exc}",
+                502,
+            ) from exc

--- a/backend/app/routers/space.py
+++ b/backend/app/routers/space.py
@@ -1,11 +1,15 @@
 import uuid
 from pathlib import Path
-from fastapi import APIRouter, File, UploadFile, HTTPException, Form
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from sqlalchemy.orm import Session
 
+from app.core.errors import AppError, ErrorCode
 from app.core.settings import UPLOAD_DIR
+from app.db.session import get_db
+from app.schemas.scene_draft import SaveSceneDraftRequestDTO, UploadStorageMetadataDTO
 from app.services.fusion_service import fusion_service
-# 변경된 경로: floorplan -> scene
 from app.schemas.scene import SceneSchema
+from app.services.scene_draft_service import save_scene_draft
 
 router = APIRouter(prefix="/space", tags=["space"])
 
@@ -14,32 +18,55 @@ ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 @router.post("/analyze", response_model=SceneSchema)
 async def analyze_floorplan(
     file: UploadFile = File(...),
-    real_width: float = Form(..., description="도면의 실제 가로 길이 (미터 단위)")
+    real_width: float = Form(..., description="도면의 실제 가로 길이 (미터 단위)"),
+    project_id: str | None = Form(default=None),
+    floor_id: str | None = Form(default=None),
+    db: Session = Depends(get_db),
 ) -> SceneSchema:
-    # 1. 파일 확장자 체크
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in ALLOWED_EXTENSIONS:
-        raise HTTPException(status_code=400, detail="PNG, JPG, JPEG 파일만 지원합니다.")
+        raise AppError(
+            ErrorCode.INVALID_FILE_EXTENSION,
+            "Only PNG, JPG, JPEG are supported.",
+            400,
+        )
 
-    # 2. 파일 저장 로직
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     file_id = str(uuid.uuid4())
     save_path = UPLOAD_DIR / f"{file_id}{suffix}"
 
     content = await file.read()
-    with save_path.open("wb") as f:
-        f.write(content)
-
     try:
-        # 3. FusionService 호출 (내부적으로 ai_response 등을 사용함)
-        result_scene = fusion_service.process_image_to_scene(
-            image_bytes=content,
-            filename=file.filename,
-            real_width_m=real_width
-        )
-        
-        return result_scene
+        with save_path.open("wb") as f:
+            f.write(content)
+    except OSError as exc:
+        raise AppError(
+            ErrorCode.FILE_SAVE_FAILED,
+            f"Failed to save uploaded file: {exc}",
+            500,
+        ) from exc
 
-    except Exception as exc:
-        # 에러 로깅 추가하면 디버깅이 더 편해요!
-        raise HTTPException(status_code=500, detail=f"도면 분석 중 오류 발생: {str(exc)}")
+    result_scene = fusion_service.process_image_to_scene(
+        image_bytes=content,
+        filename=file.filename,
+        real_width_m=real_width,
+    )
+
+    save_result = save_scene_draft(
+        db,
+        SaveSceneDraftRequestDTO(
+            scene=result_scene,
+            upload=UploadStorageMetadataDTO(
+                provider="local",
+                original_filename=file.filename,
+                content_type=file.content_type,
+                size_bytes=len(content),
+                local_saved_path=str(save_path),
+            ),
+            project_id=project_id,
+            floor_id=floor_id,
+        ),
+    )
+    result_scene.scene_draft_id = save_result.scene_draft_id
+
+    return result_scene

--- a/backend/app/routers/space.py
+++ b/backend/app/routers/space.py
@@ -46,7 +46,7 @@ async def analyze_floorplan(
             500,
         ) from exc
 
-    result_scene = fusion_service.process_image_to_scene(
+    result_scene = await fusion_service.process_image_to_scene_async(
         image_bytes=content,
         filename=file.filename,
         real_width_m=real_width,

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -1,8 +1,9 @@
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, UploadFile
 
+from app.core.errors import AppError, ErrorCode
 from app.core.settings import UPLOAD_DIR
 
 router = APIRouter(prefix="/upload", tags=["upload"])
@@ -14,15 +15,26 @@ ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".pdf"}
 async def upload_floorplan(file: UploadFile = File(...)) -> dict:
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in ALLOWED_EXTENSIONS:
-        raise HTTPException(status_code=400, detail="Only png/jpg/jpeg/pdf are allowed")
+        raise AppError(
+            ErrorCode.INVALID_FILE_EXTENSION,
+            "Only png/jpg/jpeg/pdf are allowed.",
+            400,
+        )
 
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     file_id = str(uuid.uuid4())
     save_path = UPLOAD_DIR / f"{file_id}{suffix}"
 
-    with save_path.open("wb") as f:
-        content = await file.read()
-        f.write(content)
+    try:
+        with save_path.open("wb") as f:
+            content = await file.read()
+            f.write(content)
+    except OSError as exc:
+        raise AppError(
+            ErrorCode.FILE_SAVE_FAILED,
+            f"Failed to save uploaded file: {exc}",
+            500,
+        ) from exc
 
     return {
         "status": "ok",

--- a/backend/app/schemas/scene.py
+++ b/backend/app/schemas/scene.py
@@ -51,3 +51,4 @@ class SceneSchema(BaseModel):
     rooms: List[dict]
     topology: dict = {"adjacencies": [], "connectivity": []}
     objects: List[dict] = []
+    scene_draft_id: Optional[str] = None

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from app.schemas.scene import SceneSchema
+
+
+class UploadStorageMetadataDTO(BaseModel):
+    provider: str = "local"
+    original_filename: str | None = None
+    content_type: str | None = None
+    size_bytes: int | None = None
+    local_saved_path: str | None = None
+    s3_uri: str | None = None
+    s3_bucket: str | None = None
+    s3_key: str | None = None
+
+
+class SaveSceneDraftRequestDTO(BaseModel):
+    scene: SceneSchema
+    upload: UploadStorageMetadataDTO
+    project_id: str | None = None
+    floor_id: str | None = None
+    created_by: str | None = None
+
+
+class SaveSceneDraftResultDTO(BaseModel):
+    scene_draft_id: str

--- a/backend/app/services/ai_client.py
+++ b/backend/app/services/ai_client.py
@@ -1,40 +1,49 @@
+import logging
 import requests
-import uuid 
-from typing import Dict, Any
-from app.schemas.ai_response import MlOutputDTO
+import uuid
+from typing import Any
+
+from app.core.errors import AppError, ErrorCode
+from app.core.settings import ai_service_url
+
+logger = logging.getLogger(__name__)
 
 class AIApiClient:
     def __init__(self):
-        self.base_url = "http://localhost:9000"
+        self.base_url = ai_service_url()
 
-    def fetch_ai_inference(self, image_bytes: bytes, filename: str) -> Dict[str, Any]:
-      
+    def fetch_ai_inference(self, image_bytes: bytes, filename: str) -> dict[str, Any]:
+        if not self.base_url:
+            raise AppError(
+                ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+                "AI_SERVICE_URL not set. Connect external AI repo server.",
+                503,
+            )
+
         file_id = str(uuid.uuid4())
-        
+
         files = {"file": (filename, image_bytes)}
         data = {"file_id": file_id}
-        
+
         try:
             unet_url = f"{self.base_url}/inference/unet"
             unet_res = requests.post(unet_url, files=files, data=data, timeout=300.0)
             unet_res.raise_for_status()
-            
+
             yolo_url = f"{self.base_url}/inference/yolo"
-            
-           
             yolo_res = requests.post(yolo_url, files=files, data=data, timeout=300.0)
             yolo_res.raise_for_status()
-            
+
             return {
                 "unet": unet_res.json(),
-                "yolo": yolo_res.json()
+                "yolo": yolo_res.json(),
             }
-
-        except requests.exceptions.RequestException as e:
-            print(f"❌ AI 서버 통신 오류 상세: {e}")
-            if hasattr(e, 'response') and e.response is not None:
-                print(f"상태 코드: {e.response.status_code}")
-                print(f"응답 내용: {e.response.text}")
-            raise
+        except requests.RequestException as exc:
+            logger.exception("AI inference request failed")
+            raise AppError(
+                ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+                f"AI inference request failed: {exc}",
+                502,
+            ) from exc
 
 ai_client = AIApiClient()

--- a/backend/app/services/ai_client.py
+++ b/backend/app/services/ai_client.py
@@ -1,7 +1,9 @@
 import logging
-import requests
+import asyncio
 import uuid
 from typing import Any
+
+import httpx
 
 from app.core.errors import AppError, ErrorCode
 from app.core.settings import ai_service_url
@@ -12,7 +14,7 @@ class AIApiClient:
     def __init__(self):
         self.base_url = ai_service_url()
 
-    def fetch_ai_inference(self, image_bytes: bytes, filename: str) -> dict[str, Any]:
+    async def fetch_ai_inference_async(self, image_bytes: bytes, filename: str) -> dict[str, Any]:
         if not self.base_url:
             raise AppError(
                 ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
@@ -22,24 +24,28 @@ class AIApiClient:
 
         file_id = str(uuid.uuid4())
 
-        files = {"file": (filename, image_bytes)}
-        data = {"file_id": file_id}
+        async def _post_inference(client: httpx.AsyncClient, route: str) -> dict[str, Any]:
+            response = await client.post(
+                f"{self.base_url}/{route}",
+                data={"file_id": file_id},
+                files={"file": (filename, image_bytes)},
+            )
+            response.raise_for_status()
+            return response.json()
 
         try:
-            unet_url = f"{self.base_url}/inference/unet"
-            unet_res = requests.post(unet_url, files=files, data=data, timeout=300.0)
-            unet_res.raise_for_status()
-
-            yolo_url = f"{self.base_url}/inference/yolo"
-            yolo_res = requests.post(yolo_url, files=files, data=data, timeout=300.0)
-            yolo_res.raise_for_status()
+            async with httpx.AsyncClient(timeout=300.0) as client:
+                unet_res, yolo_res = await asyncio.gather(
+                    _post_inference(client, "inference/unet"),
+                    _post_inference(client, "inference/yolo"),
+                )
 
             return {
-                "unet": unet_res.json(),
-                "yolo": yolo_res.json(),
+                "unet": unet_res,
+                "yolo": yolo_res,
             }
-        except requests.RequestException as exc:
-            logger.exception("AI inference request failed")
+        except httpx.HTTPError as exc:
+            logger.exception("Async AI inference request failed")
             raise AppError(
                 ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
                 f"AI inference request failed: {exc}",

--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import cv2
 import random
+from starlette.concurrency import run_in_threadpool
 
 from app.schemas.ai_response import MlOutputDTO, MetaDTO, WallSegmentationDTO, DetectionDTO
 from app.schemas.scene import SceneSchema, Wall, Opening, Room, Topology
@@ -47,14 +48,16 @@ class FusionService:
             ))
         return walls
 
-    def process_image_to_scene(self, image_bytes: bytes, filename: str, real_width_m: float) -> SceneSchema:
+    async def process_image_to_scene_async(
+        self, image_bytes: bytes, filename: str, real_width_m: float
+    ) -> SceneSchema:
         try:
-            ai_results = self.ai_client.fetch_ai_inference(image_bytes, filename)
+            ai_results = await self.ai_client.fetch_ai_inference_async(image_bytes, filename)
 
-            unet_res     = ai_results.get("unet", {})
-            yolo_res     = ai_results.get("yolo", {})
-            unet_output  = unet_res.get("output", {})
-            yolo_output  = yolo_res.get("output", {})
+            unet_res = ai_results.get("unet", {})
+            yolo_res = ai_results.get("yolo", {})
+            unet_output = unet_res.get("output", {})
+            yolo_output = yolo_res.get("output", {})
             unet_metrics = unet_res.get("metrics", {})
 
             ml_output = MlOutputDTO(
@@ -62,25 +65,24 @@ class FusionService:
                     sample_id=unet_res.get("fileId", "temp_id"),
                     image_name=filename,
                     original_width=unet_metrics.get("width", 1000),
-                    original_height=unet_metrics.get("height", 1000)
+                    original_height=unet_metrics.get("height", 1000),
                 ),
                 wall_segmentation=WallSegmentationDTO(
                     mask_path=unet_output.get("wallProbOverlayPath", ""),
-                    prob_map_path=unet_output.get("wallProbNpyPath", "")
+                    prob_map_path=unet_output.get("wallProbNpyPath", ""),
                 ),
                 detections=[
                     DetectionDTO(
                         id=f"det_{i}",
                         class_name=det.get("class_name"),
                         score=float(det.get("confidence", 0.0)),
-                        bbox_xyxy=det.get("bbox")
+                        bbox_xyxy=det.get("bbox"),
                     )
                     for i, det in enumerate(yolo_output.get("detections", []) or [])
-                ]
+                ],
             )
 
-            return self.run_wi_twin_pipeline(ml_output, real_width_m)
-
+            return await run_in_threadpool(self.run_wi_twin_pipeline, ml_output, real_width_m)
         except Exception as exc:
             logger.error(f"도면 분석 중 오류 발생: {exc}")
             raise

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from uuid import UUID
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.core.settings import (
+    DEFAULT_DRAFT_ANALYSIS_METHOD,
+    DEFAULT_DRAFT_FLOOR_NAME,
+    DEFAULT_DRAFT_PROJECT_NAME,
+    DEFAULT_DRAFT_SOURCE,
+    DEFAULT_DRAFT_SOURCE_MODE,
+)
+from app.models import (
+    DraftObject,
+    DraftOpening,
+    DraftRoom,
+    DraftWall,
+    Floor,
+    Project,
+    SceneDraft,
+)
+from app.schemas.scene_draft import SaveSceneDraftRequestDTO, SaveSceneDraftResultDTO
+
+
+def _to_float(value: Any, default: float | None = None) -> float | None:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _positive(value: float | None, fallback: float) -> float:
+    if value is None or value <= 0:
+        return fallback
+    return value
+
+
+def _resolve_project_floor(
+    db: Session, project_id: str | None, floor_id: str | None
+) -> tuple[str, str]:
+    if bool(project_id) ^ bool(floor_id):
+        raise AppError(
+            ErrorCode.INVALID_PROJECT_FLOOR_INPUT,
+            "project_id and floor_id must be provided together.",
+            400,
+        )
+
+    if project_id and floor_id:
+        try:
+            UUID(project_id)
+            UUID(floor_id)
+        except ValueError as exc:
+            raise AppError(
+                ErrorCode.INVALID_UUID_FORMAT,
+                "project_id and floor_id must be valid UUID strings.",
+                400,
+            ) from exc
+
+        floor = db.get(Floor, floor_id)
+        if floor is None:
+            raise AppError(
+                ErrorCode.INVALID_FLOOR_ID, "Invalid floor_id: floor not found", 400
+            )
+        if floor.project_id != project_id:
+            raise AppError(
+                ErrorCode.INVALID_PROJECT_FLOOR_PAIR,
+                "Invalid project_id/floor_id pair",
+                400,
+            )
+        if db.get(Project, project_id) is None:
+            raise AppError(
+                ErrorCode.INVALID_PROJECT_ID, "Invalid project_id: project not found", 400
+            )
+        return project_id, floor_id
+
+    project = db.scalar(
+        select(Project).where(Project.name == DEFAULT_DRAFT_PROJECT_NAME)
+    )
+    if project is None:
+        project = Project(
+            name=DEFAULT_DRAFT_PROJECT_NAME,
+            description="Auto-created project for local upload analysis flow",
+        )
+        db.add(project)
+        db.flush()
+
+    floor = db.scalar(
+        select(Floor).where(
+            Floor.project_id == project.id,
+            Floor.name == DEFAULT_DRAFT_FLOOR_NAME,
+        )
+    )
+    if floor is None:
+        floor = Floor(
+            project_id=project.id,
+            name=DEFAULT_DRAFT_FLOOR_NAME,
+            floor_index=0,
+        )
+        db.add(floor)
+        db.flush()
+
+    return project.id, floor.id
+
+
+def save_scene_draft(db: Session, request_dto: SaveSceneDraftRequestDTO) -> SaveSceneDraftResultDTO:
+    resolved_project_id, resolved_floor_id = _resolve_project_floor(
+        db, request_dto.project_id, request_dto.floor_id
+    )
+
+    summary_json = {
+        "source": DEFAULT_DRAFT_SOURCE,
+        "analysis_method": DEFAULT_DRAFT_ANALYSIS_METHOD,
+        "raw_result_version": request_dto.scene.scene_version,
+        "storage": request_dto.upload.model_dump(),
+    }
+
+    scene_draft = SceneDraft(
+        project_id=resolved_project_id,
+        floor_id=resolved_floor_id,
+        source_mode=DEFAULT_DRAFT_SOURCE_MODE,
+        source_asset_id=None,
+        source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+        summary_json=summary_json,
+        status="draft",
+        created_by=request_dto.created_by,
+    )
+
+    try:
+        db.add(scene_draft)
+        db.flush()
+
+        for room in request_dto.scene.rooms:
+            db.add(
+                DraftRoom(
+                    scene_draft_id=scene_draft.id,
+                    room_name=str(room.get("id")) if room.get("id") is not None else None,
+                    room_type=room.get("type"),
+                    source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                    metadata_json={"raw": room},
+                )
+            )
+
+        wall_id_map: dict[str, str] = {}
+        for wall in request_dto.scene.walls:
+            draft_wall = DraftWall(
+                scene_draft_id=scene_draft.id,
+                wall_role=wall.get("role", "inner"),
+                thickness_m=_positive(_to_float(wall.get("thickness"), 0.18), 0.18),
+                height_m=_to_float(wall.get("height")),
+                material_label=wall.get("material"),
+                source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                metadata_json={"raw": wall},
+            )
+            db.add(draft_wall)
+            db.flush()
+
+            if wall.get("id") is not None:
+                wall_id_map[str(wall["id"])] = draft_wall.id
+
+        for opening in request_dto.scene.openings:
+            width = _to_float(opening.get("width_m"))
+            if width is None:
+                width = abs(_to_float(opening.get("x2"), 0.0) - _to_float(opening.get("x1"), 0.0))
+
+            height = _to_float(opening.get("height_m"))
+            if height is None:
+                height = abs(_to_float(opening.get("y2"), 0.0) - _to_float(opening.get("y1"), 0.0))
+
+            wall_ref = opening.get("wall_ref")
+            db.add(
+                DraftOpening(
+                    scene_draft_id=scene_draft.id,
+                    wall_id=wall_id_map.get(str(wall_ref)) if wall_ref is not None else None,
+                    opening_type=opening.get("type", "opening"),
+                    width_m=_positive(width, 0.8),
+                    height_m=_positive(height, 1.2),
+                    source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                    metadata_json={"raw": opening},
+                )
+            )
+
+        for obj in request_dto.scene.objects:
+            obj_type = obj.get("class_name") or obj.get("type") or "unknown"
+            db.add(
+                DraftObject(
+                    scene_draft_id=scene_draft.id,
+                    object_type=obj_type,
+                    confidence=_to_float(obj.get("score") or obj.get("confidence")),
+                    source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                    metadata_json={"raw": obj},
+                )
+            )
+
+        db.commit()
+        return SaveSceneDraftResultDTO(scene_draft_id=scene_draft.id)
+    except Exception:
+        db.rollback()
+        raise AppError(
+            ErrorCode.SCENE_DRAFT_SAVE_FAILED,
+            "Failed to persist scene draft and draft entities",
+            500,
+        )

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
@@ -199,10 +200,13 @@ def save_scene_draft(db: Session, request_dto: SaveSceneDraftRequestDTO) -> Save
 
         db.commit()
         return SaveSceneDraftResultDTO(scene_draft_id=scene_draft.id)
-    except Exception:
+    except AppError:
+        db.rollback()
+        raise
+    except SQLAlchemyError as exc:
         db.rollback()
         raise AppError(
             ErrorCode.SCENE_DRAFT_SAVE_FAILED,
-            "Failed to persist scene draft and draft entities",
+            f"Failed to persist scene draft and draft entities: {exc}",
             500,
-        )
+        ) from exc

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,50 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from app.routers.experiments import router as experiments_router
 from app.routers.health import router as health_router
 from app.routers.upload import router as upload_router
-from app.routers.space import router as space_router 
-from app.routers.rf_run import router as rf_run_router  
+from app.routers.space import router as space_router
+from app.routers.rf_run import router as rf_run_router
+from app.core.errors import AppError, ErrorCode
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from fastapi import Request
 
 app = FastAPI(title="capstone2-backend", version="0.1.0")
+
+
+@app.exception_handler(AppError)
+async def app_error_handler(_request: Request, exc: AppError) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"code": exc.code, "message": exc.message},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_error_handler(
+    _request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=422,
+        content={
+            "code": ErrorCode.INVALID_REQUEST_BODY,
+            "message": "Request validation failed.",
+            "details": exc.errors(),
+        },
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(_request: Request, _exc: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content={
+            "code": ErrorCode.INTERNAL_SERVER_ERROR,
+            "message": "Internal server error.",
+        },
+    )
 
 app.include_router(health_router)
 app.include_router(upload_router)
 app.include_router(experiments_router)
 app.include_router(space_router)
-app.include_router(rf_run_router)  
+app.include_router(rf_run_router)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ greenlet==3.3.2
 geoalchemy2==0.18.0
 h11==0.16.0
 httptools==0.7.1
+httpx==0.28.1
 idna==3.11
 Mako==1.3.10
 MarkupSafe==3.0.3


### PR DESCRIPTION
## 작업 내용
이미지 분석 결과를 DB의 draft 구조에 실제로 저장하는 로직을 추가하고, 백엔드 전반의 예외 처리를 AppError 기반으로 통일

## 변경 사항
**1. 분석 결과 draft 저장 로직 추가**
- `scene_draft_service.py` 추가
- `/space/analyze`에서 분석 결과를 반환만 하지 않고 scene_drafts, draft_rooms, draft_walls, draft_openings, draft_objects에 저장하도록 연결
- 응답 SceneSchema에 scene_draft_id를 포함하도록 확장

**2. 로컬 업로드 기반 기본 draft 저장 흐름 지원**
- project_id, floor_id가 없는 경우 사용할 기본 프로젝트/층 이름 설정 추가
- local upload 기반 메타데이터를 summary_json에 저장하도록 구성
- 추후 S3/Asset 연결 전에도 draft 저장 흐름을 먼저 사용할 수 있도록 정리

**3. 공통 에러 처리 체계 도입**
- AppError, ErrorCode 추가
- `main.py`에 전역 exception handler 추가

**4. 라우터별 예외 처리 정리**
upload.py, space.py, experiments.py, rf_run.py, health.py에서 HTTPException 위주 처리 대신 AppError 기반 처리로 정리
외부 AI/RF 서비스 호출 실패 시 상태 코드와 메시지를 명확히 전달하도록 수정

## 확인 방법
1. DB 실행 및 migration 적용
2. backend 실행
3. `/space/analyze`로 이미지 업로드
4. 응답의 scene_draft_id 확인
5. DB에서 scene_drafts, draft_rooms, draft_walls, draft_openings, draft_objects row 생성 확인

## 참고
현재 draft 저장은 local upload 기준이며 source_asset_id는 비워 둡니다.
추후 S3/Asset 저장 로직이 추가되면 scene_drafts.source_asset_id와 연결할 예정