### PR TITLE
feat: Project CRUD API 구현

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,0 +1,92 @@
+"""
+Project 라우터: /projects CRUD
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
+from app.schemas.project import (
+    ProjectCreateRequest,
+    ProjectResponse,
+    ProjectUpdateRequest,
+)
+from app.services import project_service
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.post(
+    "",
+    response_model=ProjectResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="프로젝트 생성",
+)
+def create_project(
+    payload: ProjectCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ProjectResponse:
+    return project_service.create_project(db, payload, current_user)
+
+
+@router.get(
+    "",
+    response_model=PaginatedResponse[ProjectResponse],
+    summary="프로젝트 목록 조회 (본인 소유)",
+)
+def list_projects(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    status: str | None = Query(default=None, pattern="^(active|archived)$"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[ProjectResponse]:
+    return project_service.list_projects(
+        db, current_user, page=page, page_size=page_size, status=status
+    )
+
+
+@router.get(
+    "/{project_id}",
+    response_model=ProjectResponse,
+    summary="프로젝트 단건 조회",
+)
+def get_project(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ProjectResponse:
+    return project_service.get_project(db, project_id, current_user)
+
+
+@router.patch(
+    "/{project_id}",
+    response_model=ProjectResponse,
+    summary="프로젝트 부분 수정",
+)
+def update_project(
+    project_id: str,
+    payload: ProjectUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ProjectResponse:
+    return project_service.update_project(db, project_id, payload, current_user)
+
+
+@router.delete(
+    "/{project_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="프로젝트 삭제",
+)
+def delete_project(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    project_service.delete_project(db, project_id, current_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/pagination.py
+++ b/backend/app/schemas/pagination.py
@@ -1,0 +1,25 @@
+"""
+페이지네이션 공통 스키마
+"""
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
+
+
+class PaginationQuery(BaseModel):
+    """목록 조회 쿼리 파라미터"""
+    page: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """목록 응답: items + 페이지 정보"""
+    items: list[T]
+    page: int
+    page_size: int
+    total: int
+    

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,0 +1,38 @@
+"""
+Project 도메인 DTO
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+# ============================================
+# Request DTO
+# ============================================
+class ProjectCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=2000)
+
+
+class ProjectUpdateRequest(BaseModel):
+    """모두 optional — 부분 수정"""
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=2000)
+    status: str | None = Field(default=None, pattern="^(active|archived)$")
+
+
+# ============================================
+# Response DTO
+# ============================================
+class ProjectResponse(BaseModel):
+    id: str
+    owner_user_id: str
+    name: str
+    description: str | None
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,0 +1,122 @@
+"""
+Project 서비스: CRUD + 본인 소유 권한 체크
+"""
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
+from app.schemas.project import (
+    ProjectCreateRequest,
+    ProjectResponse,
+    ProjectUpdateRequest,
+)
+
+
+# ============================================
+# Internal Helpers
+# ============================================
+def _get_owned_project_or_404(
+    db: Session, project_id: str, current_user: User
+) -> Project:
+    
+    project = (
+        db.query(Project)
+        .filter(
+            Project.id == project_id,
+            Project.owner_user_id == current_user.id,
+        )
+        .first()
+    )
+    if project is None:
+        raise AppError(
+            ErrorCode.PROJECT_NOT_FOUND,
+            "Project not found.",
+            status_code=404,
+        )
+    return project
+
+
+# ============================================
+# Public API
+# ============================================
+def create_project(
+    db: Session,
+    payload: ProjectCreateRequest,
+    current_user: User,
+) -> ProjectResponse:
+    project = Project(
+        owner_user_id=current_user.id,
+        name=payload.name.strip(),
+        description=payload.description,
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return ProjectResponse.model_validate(project)
+
+
+def list_projects(
+    db: Session,
+    current_user: User,
+    page: int,
+    page_size: int,
+    status: str | None = None,
+) -> PaginatedResponse[ProjectResponse]:
+    base_query = db.query(Project).filter(Project.owner_user_id == current_user.id)
+    if status is not None:
+        base_query = base_query.filter(Project.status == status)
+
+    total = base_query.with_entities(func.count(Project.id)).scalar() or 0
+
+    items = (
+        base_query.order_by(Project.created_at.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+
+    return PaginatedResponse[ProjectResponse](
+        items=[ProjectResponse.model_validate(p) for p in items],
+        page=page,
+        page_size=page_size,
+        total=total,
+    )
+
+
+def get_project(
+    db: Session, project_id: str, current_user: User
+) -> ProjectResponse:
+    project = _get_owned_project_or_404(db, project_id, current_user)
+    return ProjectResponse.model_validate(project)
+
+
+def update_project(
+    db: Session,
+    project_id: str,
+    payload: ProjectUpdateRequest,
+    current_user: User,
+) -> ProjectResponse:
+    project = _get_owned_project_or_404(db, project_id, current_user)
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if "name" in update_data and update_data["name"] is not None:
+        update_data["name"] = update_data["name"].strip()
+
+    for field, value in update_data.items():
+        setattr(project, field, value)
+
+    db.commit()
+    db.refresh(project)
+    return ProjectResponse.model_validate(project)
+
+
+def delete_project(db: Session, project_id: str, current_user: User) -> None:
+    project = _get_owned_project_or_404(db, project_id, current_user)
+    db.delete(project)
+    db.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from app.routers.health import router as health_router
 from app.routers.upload import router as upload_router
 from app.routers.rf_run import router as rf_run_router
 from app.routers.auth import router as auth_router
+from app.routers.projects import router as projects_router
 from app.core.errors import AppError, ErrorCode
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -58,3 +59,4 @@ app.include_router(upload_router)
 app.include_router(experiments_router)
 app.include_router(rf_run_router)
 app.include_router(auth_router)
+app.include_router(projects_router)


### PR DESCRIPTION
## 📋 작업 내용

명세서(`API_SPEC.md` 3장)에 따라 프로젝트 CRUD API 5개 구현.

### 구현한 엔드포인트

- `POST /projects` — 프로젝트 생성 (인증 필요)
- `GET /projects` — 프로젝트 목록 (페이지네이션 + status 필터)
- `GET /projects/{project_id}` — 단건 조회
- `PATCH /projects/{project_id}` — 부분 수정 (name/description/status)
- `DELETE /projects/{project_id}` — 삭제 (204 No Content)

### 권한 정책

- 모든 엔드포인트 인증 필요 (Bearer Token)
- 본인 소유(`owner_user_id == current_user.id`) 프로젝트만 접근 가능
- 다른 사람 프로젝트 접근 시 `404 PROJECT_NOT_FOUND` (존재 여부 노출 방지)

## 🗂️ 파일 변경 요약

**신규**
- `backend/app/schemas/pagination.py` — 공통 페이지네이션 스키마 (`PaginationQuery`, `PaginatedResponse[T]`)
- `backend/app/schemas/project.py` — Create/Update/Response DTO
- `backend/app/services/project_service.py` — CRUD + 권한 체크
- `backend/app/routers/projects.py` — 라우터

**수정**
- `backend/main.py` — projects 라우터 등록

## 🧪 테스트 결과

| 테스트 | 결과 |
|---|---|
| 생성 | 201 + project 객체 ✅ |
| 단건 조회 | 200 ✅ |
| 부분 수정 (name/desc) | 200, status 보존 ✅ |
| 부분 수정 (status만) | 200, name/desc 유지 ✅ |
| 목록 + 페이지네이션 | items/page/page_size/total ✅ |
| status 필터 (archived) | 정확히 필터링 ✅ |
| 권한 차단 (남의 프로젝트 조회) | 404 PROJECT_NOT_FOUND ✅ |
| 본인 소유 필터 (목록) | 다른 유저는 빈 배열 ✅ |
| 삭제 | 204 No Content ✅ |

## 📚 명세 준거

`API_SPEC.md` §3.1 ~ §3.5 그대로 구현. 페이지네이션은 §0.5 형식 (`items/page/page_size/total`).

## 🔗 후속 작업

- Floor CRUD API (이슈 별도 예정)
- Scene Draft 단건 조회 API (이슈 별도 예정)

