### PR TITLE
feat: Floor CRUD API 구현

### DIFF
--- a/backend/app/routers/floors.py
+++ b/backend/app/routers/floors.py
@@ -1,0 +1,98 @@
+"""
+Floor 라우터
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.floor import (
+    FloorCreateRequest,
+    FloorResponse,
+    FloorUpdateRequest,
+)
+from app.services import floor_service
+
+router = APIRouter(tags=["floors"])
+
+
+# ============================================
+# Project-scoped (생성, 목록)
+# ============================================
+@router.post(
+    "/projects/{project_id}/floors",
+    response_model=FloorResponse,
+    response_model_by_alias=True,
+    status_code=status.HTTP_201_CREATED,
+    summary="층 생성",
+)
+def create_floor(
+    project_id: str,
+    payload: FloorCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> FloorResponse:
+    return floor_service.create_floor(db, project_id, payload, current_user)
+
+
+@router.get(
+    "/projects/{project_id}/floors",
+    summary="프로젝트의 층 목록",
+)
+def list_floors_by_project(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    items = floor_service.list_floors_by_project(db, project_id, current_user)
+    # by_alias=True로 명시적 직렬화
+    return {"items": [item.model_dump(by_alias=True, mode="json") for item in items]}
+
+
+# ============================================
+# Floor-scoped (단건)
+# ============================================
+@router.get(
+    "/floors/{floor_id}",
+    response_model=FloorResponse,
+     response_model_by_alias=True,
+    summary="층 단건 조회",
+)
+def get_floor(
+    floor_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> FloorResponse:
+    return floor_service.get_floor(db, floor_id, current_user)
+
+
+@router.patch(
+    "/floors/{floor_id}",
+    response_model=FloorResponse,
+     response_model_by_alias=True,
+    summary="층 부분 수정",
+)
+def update_floor(
+    floor_id: str,
+    payload: FloorUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> FloorResponse:
+    return floor_service.update_floor(db, floor_id, payload, current_user)
+
+
+@router.delete(
+    "/floors/{floor_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="층 삭제",
+)
+def delete_floor(
+    floor_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    floor_service.delete_floor(db, floor_id, current_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,5 +1,5 @@
 """
-Project 라우터: /projects CRUD
+Project 라우터
 """
 from __future__ import annotations
 

--- a/backend/app/schemas/floor.py
+++ b/backend/app/schemas/floor.py
@@ -1,0 +1,51 @@
+"""
+Floor 도메인 DTO
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ============================================
+# Request DTO
+# ============================================
+class FloorCreateRequest(BaseModel):
+    floor_name: str = Field(min_length=1, max_length=80)
+    floor_order: int = Field(default=0)
+    height_m: Decimal = Field(default=Decimal("2.4"), gt=0, le=Decimal("99.999"))
+
+
+class FloorUpdateRequest(BaseModel):
+    floor_name: str | None = Field(default=None, min_length=1, max_length=80)
+    floor_order: int | None = None
+    height_m: Decimal | None = Field(default=None, gt=0, le=Decimal("99.999"))
+
+
+# ============================================
+# Response DTO 
+# ============================================
+class FloorResponse(BaseModel):
+
+    id: str
+    project_id: str
+    floor_name: str = Field(
+        validation_alias="name",
+        serialization_alias="floor_name",
+    )
+    floor_order: int = Field(
+        validation_alias="floor_index",
+        serialization_alias="floor_order",
+    )
+    height_m: Decimal = Field(
+        validation_alias="default_ceiling_height_m",
+        serialization_alias="height_m",
+    )
+    created_at: datetime
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+    )

--- a/backend/app/services/floor_service.py
+++ b/backend/app/services/floor_service.py
@@ -1,0 +1,140 @@
+"""
+Floor 서비스: CRUD + 본인 소유 프로젝트 권한 체크
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.floor import Floor
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.floor import (
+    FloorCreateRequest,
+    FloorResponse,
+    FloorUpdateRequest,
+)
+
+
+# ============================================
+# Internal Helpers
+# ============================================
+def _get_owned_project_or_404(
+    db: Session, project_id: str, current_user: User
+) -> Project:
+   
+    project = (
+        db.query(Project)
+        .filter(
+            Project.id == project_id,
+            Project.owner_user_id == current_user.id,
+        )
+        .first()
+    )
+    if project is None:
+        raise AppError(
+            ErrorCode.PROJECT_NOT_FOUND,
+            "Project not found.",
+            status_code=404,
+        )
+    return project
+
+
+def _get_owned_floor_or_404(
+    db: Session, floor_id: str, current_user: User
+) -> Floor:
+    floor = (
+        db.query(Floor)
+        .join(Project, Floor.project_id == Project.id)
+        .filter(
+            Floor.id == floor_id,
+            Project.owner_user_id == current_user.id,
+        )
+        .first()
+    )
+    if floor is None:
+        raise AppError(
+            ErrorCode.FLOOR_NOT_FOUND,
+            "Floor not found.",
+            status_code=404,
+        )
+    return floor
+
+
+# ============================================
+# Public API
+# ============================================
+def create_floor(
+    db: Session,
+    project_id: str,
+    payload: FloorCreateRequest,
+    current_user: User,
+) -> FloorResponse:
+    _get_owned_project_or_404(db, project_id, current_user)
+
+    floor = Floor(
+        project_id=project_id,
+        name=payload.floor_name.strip(),
+        floor_index=payload.floor_order,
+        default_ceiling_height_m=payload.height_m,
+    )
+    db.add(floor)
+    db.commit()
+    db.refresh(floor)
+    return FloorResponse.model_validate(floor)
+
+
+def list_floors_by_project(
+    db: Session, project_id: str, current_user: User
+) -> list[FloorResponse]:
+    _get_owned_project_or_404(db, project_id, current_user)
+
+    floors = (
+        db.query(Floor)
+        .filter(Floor.project_id == project_id)
+        .order_by(Floor.floor_index.asc())
+        .all()
+    )
+    return [FloorResponse.model_validate(f) for f in floors]
+
+
+def get_floor(
+    db: Session, floor_id: str, current_user: User
+) -> FloorResponse:
+    floor = _get_owned_floor_or_404(db, floor_id, current_user)
+    return FloorResponse.model_validate(floor)
+
+
+def update_floor(
+    db: Session,
+    floor_id: str,
+    payload: FloorUpdateRequest,
+    current_user: User,
+) -> FloorResponse:
+    floor = _get_owned_floor_or_404(db, floor_id, current_user)
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    field_mapping = {
+        "floor_name": "name",
+        "floor_order": "floor_index",
+        "height_m": "default_ceiling_height_m",
+    }
+
+    for spec_field, value in update_data.items():
+        if value is None:
+            continue
+        model_field = field_mapping[spec_field]
+        if spec_field == "floor_name":
+            value = value.strip()
+        setattr(floor, model_field, value)
+
+    db.commit()
+    db.refresh(floor)
+    return FloorResponse.model_validate(floor)
+
+
+def delete_floor(db: Session, floor_id: str, current_user: User) -> None:
+    floor = _get_owned_floor_or_404(db, floor_id, current_user)
+    db.delete(floor)
+    db.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from app.routers.upload import router as upload_router
 from app.routers.rf_run import router as rf_run_router
 from app.routers.auth import router as auth_router
 from app.routers.projects import router as projects_router
+from app.routers.floors import router as floors_router
 from app.core.errors import AppError, ErrorCode
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -60,3 +61,4 @@ app.include_router(experiments_router)
 app.include_router(rf_run_router)
 app.include_router(auth_router)
 app.include_router(projects_router)
+app.include_router(floors_router)


### PR DESCRIPTION
## 📋 작업 내용

명세서(`API_SPEC.md` 4장)에 따라 층(Floor) CRUD API 5개 구현.

### 구현한 엔드포인트

- `POST /projects/{project_id}/floors` — 층 생성
- `GET /projects/{project_id}/floors` — 프로젝트의 층 목록 (floor_order ASC 정렬)
- `GET /floors/{floor_id}` — 단건 조회
- `PATCH /floors/{floor_id}` — 부분 수정
- `DELETE /floors/{floor_id}` — 삭제 (204)

### 권한 정책

- 모든 엔드포인트 인증 필요 (Bearer Token)
- 본인 소유 프로젝트의 층만 접근 가능
- 권한 없으면 `404 FLOOR_NOT_FOUND` 또는 `404 PROJECT_NOT_FOUND`

## 🔄 명세 vs 모델 필드 매핑

명세는 `floor_name/floor_order/height_m`, ORM 모델은 `name/floor_index/default_ceiling_height_m` 사용.
Pydantic v2의 `validation_alias` + `serialization_alias`로 입출력 매핑 분리.

| 명세 (응답) | 모델 (DB) |
|---|---|
| `floor_name` | `name` |
| `floor_order` | `floor_index` |
| `height_m` | `default_ceiling_height_m` |

서비스 레이어에서도 PATCH 요청 시 명세 필드 → 모델 필드 매핑 처리.

## 🗂️ 파일 변경 요약

**신규**
- `backend/app/schemas/floor.py` — Create/Update/Response DTO + alias 매핑
- `backend/app/services/floor_service.py` — CRUD + 권한 체크
- `backend/app/routers/floors.py` — 라우터 (project-scoped + floor-scoped)

**수정**
- `backend/main.py` — floors 라우터 등록

## 🧪 테스트 결과

| 테스트 | 결과 |
|---|---|
| 층 생성 | 201, alias 매핑 적용 ✅ |
| 목록 조회 | `{"items": [...]}`, floor_order ASC ✅ |
| 단건 조회 | 200 ✅ |
| PATCH 일부 필드만 수정 | 다른 필드 보존 ✅ |
| 남의 층 조회 시도 | 404 FLOOR_NOT_FOUND ✅ |
| 남의 프로젝트에 층 생성 시도 | 404 PROJECT_NOT_FOUND ✅ |
| 삭제 | 204 No Content ✅ |

## 📚 명세 준거

`API_SPEC.md` §4.1 ~ §4.3 그대로 구현. 응답 필드명은 명세대로 `floor_name/floor_order/height_m`.

## 🐛 트러블슈팅 메모

Pydantic v2에서 `Field(alias=...)`만으로는 응답 시 alias 적용이 안 됨.
→ `validation_alias` (입력) + `serialization_alias` (출력)로 분리해야 함.
→ FastAPI 라우터에는 `response_model_by_alias=True` 추가 필요.
