### PR TITLE
feat: Scene Draft 단건 조회 API + upload/analyze 인증 강화

### DIFF
--- a/backend/app/routers/scene_drafts.py
+++ b/backend/app/routers/scene_drafts.py
@@ -1,0 +1,28 @@
+"""
+Scene Draft 라우터
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.scene_draft import SceneDraftDetailResponse
+from app.services import scene_draft_service
+
+router = APIRouter(prefix="/scene-drafts", tags=["scene-drafts"])
+
+
+@router.get(
+    "/{scene_draft_id}",
+    response_model=SceneDraftDetailResponse,
+    summary="Scene Draft 단건 조회 (rooms/walls/openings/objects 포함)",
+)
+def get_scene_draft(
+    scene_draft_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SceneDraftDetailResponse:
+    return scene_draft_service.get_scene_draft(db, scene_draft_id, current_user)

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -1,4 +1,6 @@
 import uuid
+from app.api.deps import get_current_user
+from app.models.user import User
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, UploadFile
@@ -20,7 +22,6 @@ ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".pdf"}
 
 
 def _validate_and_save_file(file: UploadFile, content: bytes) -> tuple[str, Path]:
-    """확장자 검증 후 파일을 디스크에 저장하고 (file_id, save_path) 반환."""
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in ALLOWED_EXTENSIONS:
         raise AppError(
@@ -68,6 +69,7 @@ async def upload_and_analyze_floorplan(
     floor_id: str | None = Form(None),
     created_by: str | None = Form(None),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ) -> dict:
     content = await file.read()
     file_id, save_path = _validate_and_save_file(file, content)
@@ -99,7 +101,7 @@ async def upload_and_analyze_floorplan(
         created_by=created_by,
     )
 
-    result = save_scene_draft(db, request_dto)
+    result = save_scene_draft(db, request_dto, current_user)
 
     return {
         "status": "ok",

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -4,6 +4,12 @@ from pydantic import BaseModel
 
 from app.schemas.scene import SceneSchema
 
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import ConfigDict
+
 
 class UploadStorageMetadataDTO(BaseModel):
     provider: str = "local"
@@ -26,3 +32,82 @@ class SaveSceneDraftRequestDTO(BaseModel):
 
 class SaveSceneDraftResultDTO(BaseModel):
     scene_draft_id: str
+
+# ============================================
+# 단건 조회 응답 (GET /scene-drafts/{id})
+# ============================================
+
+class DraftRoomResponse(BaseModel):
+    id: str
+    scene_draft_id: str
+    room_name: str | None
+    room_type: str | None
+    confidence: Decimal | None
+    source_method: str | None
+    metadata_json: dict[str, Any]
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DraftWallResponse(BaseModel):
+    id: str
+    scene_draft_id: str
+    wall_role: str
+    thickness_m: Decimal
+    height_m: Decimal | None
+    material_label: str | None
+    confidence: Decimal | None
+    source_method: str | None
+    metadata_json: dict[str, Any]
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DraftOpeningResponse(BaseModel):
+    id: str
+    scene_draft_id: str
+    wall_id: str | None
+    opening_type: str
+    width_m: Decimal
+    height_m: Decimal
+    sill_height_m: Decimal | None
+    confidence: Decimal | None
+    source_method: str | None
+    metadata_json: dict[str, Any]
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DraftObjectResponse(BaseModel):
+    id: str
+    scene_draft_id: str
+    object_type: str
+    confidence: Decimal | None
+    source_method: str | None
+    z_m: Decimal | None
+    metadata_json: dict[str, Any]
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SceneDraftDetailResponse(BaseModel):
+    id: str
+    project_id: str
+    floor_id: str
+    source_mode: str
+    source_asset_id: str | None
+    source_method: str | None
+    summary_json: dict[str, Any]
+    status: str
+    rooms: list[DraftRoomResponse]
+    walls: list[DraftWallResponse]
+    openings: list[DraftOpeningResponse]
+    objects: list[DraftObjectResponse]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.errors import AppError, ErrorCode
 from app.core.settings import (
@@ -23,8 +23,13 @@ from app.models import (
     Floor,
     Project,
     SceneDraft,
+    User,
 )
-from app.schemas.scene_draft import SaveSceneDraftRequestDTO, SaveSceneDraftResultDTO
+from app.schemas.scene_draft import (
+    SaveSceneDraftRequestDTO,
+    SaveSceneDraftResultDTO,
+    SceneDraftDetailResponse,
+)
 
 
 def _to_float(value: Any, default: float | None = None) -> float | None:
@@ -43,7 +48,10 @@ def _positive(value: float | None, fallback: float) -> float:
 
 
 def _resolve_project_floor(
-    db: Session, project_id: str | None, floor_id: str | None
+    db: Session,
+    project_id: str | None,
+    floor_id: str | None,
+    current_user: User,
 ) -> tuple[str, str]:
     if bool(project_id) ^ bool(floor_id):
         raise AppError(
@@ -74,19 +82,32 @@ def _resolve_project_floor(
                 "Invalid project_id/floor_id pair",
                 400,
             )
-        if db.get(Project, project_id) is None:
+        project = db.get(Project, project_id)
+        if project is None:
             raise AppError(
                 ErrorCode.INVALID_PROJECT_ID, "Invalid project_id: project not found", 400
             )
+        # 본인 소유 권한 체크
+        if project.owner_user_id != current_user.id:
+            raise AppError(
+                ErrorCode.PROJECT_NOT_FOUND,
+                "Project not found.",
+                404,
+            )
         return project_id, floor_id
 
+    # default 프로젝트: 유저별로 분리해서 찾거나 생성
     project = db.scalar(
-        select(Project).where(Project.name == DEFAULT_DRAFT_PROJECT_NAME)
+        select(Project).where(
+            Project.name == DEFAULT_DRAFT_PROJECT_NAME,
+            Project.owner_user_id == current_user.id,
+        )
     )
     if project is None:
         project = Project(
             name=DEFAULT_DRAFT_PROJECT_NAME,
             description="Auto-created project for local upload analysis flow",
+            owner_user_id=current_user.id,
         )
         db.add(project)
         db.flush()
@@ -109,9 +130,13 @@ def _resolve_project_floor(
     return project.id, floor.id
 
 
-def save_scene_draft(db: Session, request_dto: SaveSceneDraftRequestDTO) -> SaveSceneDraftResultDTO:
+def save_scene_draft(
+    db: Session,
+    request_dto: SaveSceneDraftRequestDTO,
+    current_user: User,
+) -> SaveSceneDraftResultDTO:
     resolved_project_id, resolved_floor_id = _resolve_project_floor(
-        db, request_dto.project_id, request_dto.floor_id
+        db, request_dto.project_id, request_dto.floor_id, current_user,
     )
 
     summary_json = {
@@ -129,7 +154,7 @@ def save_scene_draft(db: Session, request_dto: SaveSceneDraftRequestDTO) -> Save
         source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
         summary_json=summary_json,
         status="draft",
-        created_by=request_dto.created_by,
+        created_by=request_dto.created_by or current_user.email,
     )
 
     try:
@@ -210,3 +235,47 @@ def save_scene_draft(db: Session, request_dto: SaveSceneDraftRequestDTO) -> Save
             f"Failed to persist scene draft and draft entities: {exc}",
             500,
         ) from exc
+
+
+def get_scene_draft(
+    db: Session, scene_draft_id: str, current_user: User
+) -> SceneDraftDetailResponse:
+    scene_draft = (
+        db.query(SceneDraft)
+        .join(Project, SceneDraft.project_id == Project.id)
+        .filter(
+            SceneDraft.id == scene_draft_id,
+            Project.owner_user_id == current_user.id,
+        )
+        .options(
+            selectinload(SceneDraft.draft_rooms),
+            selectinload(SceneDraft.draft_walls),
+            selectinload(SceneDraft.draft_openings),
+            selectinload(SceneDraft.draft_objects),
+        )
+        .first()
+    )
+
+    if scene_draft is None:
+        raise AppError(
+            ErrorCode.SCENE_DRAFT_NOT_FOUND,
+            "Scene draft not found.",
+            status_code=404,
+        )
+
+    return SceneDraftDetailResponse(
+        id=scene_draft.id,
+        project_id=scene_draft.project_id,
+        floor_id=scene_draft.floor_id,
+        source_mode=scene_draft.source_mode,
+        source_asset_id=scene_draft.source_asset_id,
+        source_method=scene_draft.source_method,
+        summary_json=scene_draft.summary_json,
+        status=scene_draft.status,
+        rooms=scene_draft.draft_rooms,
+        walls=scene_draft.draft_walls,
+        openings=scene_draft.draft_openings,
+        objects=scene_draft.draft_objects,
+        created_at=scene_draft.created_at,
+        updated_at=scene_draft.updated_at,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from app.routers.rf_run import router as rf_run_router
 from app.routers.auth import router as auth_router
 from app.routers.projects import router as projects_router
 from app.routers.floors import router as floors_router
+from app.routers.scene_drafts import router as scene_drafts_router
 from app.core.errors import AppError, ErrorCode
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -62,3 +63,4 @@ app.include_router(rf_run_router)
 app.include_router(auth_router)
 app.include_router(projects_router)
 app.include_router(floors_router)
+app.include_router(scene_drafts_router)


### PR DESCRIPTION
## 📋 작업 내용

### 1. Scene Draft 단건 조회 API 구현 (명세 §6.2)

- `GET /scene-drafts/{scene_draft_id}` — 인증 필요, 본인 소유 프로젝트의 draft만 조회
- 자식 리소스(`rooms`, `walls`, `openings`, `objects`) 함께 반환
- `selectinload`로 N+1 쿼리 방지

### 2. `POST /upload/floorplan/analyze` 인증 추가

기존 라우터에 인증 의존성이 빠져있어서 토큰 없이도 호출 가능했음. 명세 §6.1 (🔒 표시)에 맞춰 인증 강제.

- 라우터에 `current_user: User = Depends(get_current_user)` 추가
- `save_scene_draft(db, request_dto, current_user)` 시그니처 확장
- `created_by`는 클라이언트가 안 보내도 `current_user.email`로 자동 설정

### 3. default 프로젝트 user별 분리

기존: `local-upload-project`라는 프로젝트 하나를 모든 사용자가 공유 → 9주차 인증 도입 후 owner_user_id 미설정으로 권한 문제 발생.

수정 후:
- default 프로젝트를 `(name, owner_user_id)` 조합으로 조회/생성
- 명시적으로 `project_id` 보낸 경우에도 본인 소유 체크 (남의 거 → 404)

## 🗂️ 파일 변경 요약

**신규**
- `backend/app/routers/scene_drafts.py` — `GET /scene-drafts/{id}` 라우터

**수정**
- `backend/app/schemas/scene_draft.py` — `SceneDraftDetailResponse` 등 응답 DTO 추가
- `backend/app/services/scene_draft_service.py` — `get_scene_draft` 함수 추가, `_resolve_project_floor` 권한 체크 + user별 default 프로젝트
- `backend/app/routers/upload.py` — `current_user` 의존성 추가
- `backend/main.py` — scene_drafts 라우터 등록

## 🧪 테스트 결과

| 테스트 | 결과 |
|---|---|
| 토큰 없이 `/upload/floorplan/analyze` | 401 UNAUTHORIZED ✅ |
| 토큰으로 도면 분석 → 본인 프로젝트 자동 생성 | 200 + scene_draft_id ✅ |
| 본인 draft 조회 | 200 + 자식 리소스 (walls 39, openings 28, objects 2) ✅ |
| 응답 형식 명세 §6.2 일치 | id/project_id/floor_id/source_*/summary_json/status/rooms/walls/openings/objects/created_at/updated_at ✅ |
| `metadata_json["raw"]`에 좌표 다 포함 | ✅ (프론트가 그대로 사용 가능) |

## 📚 명세 준거

- §6.1 (`POST /upload/floorplan/analyze`) — 🔒 인증 필수 적용
- §6.2 (`GET /scene-drafts/{id}`) — 응답 구조 그대로

## ⚠️ 알려진 한계 (후속 작업)

- `geometry` 컬럼 (polygon_geom 등)은 NULL 상태. 좌표는 `metadata_json["raw"]`에 들어있음. 11주차 promote(`scene_versions`로 승격) 시점에 PostGIS geometry 채우는 로직 추가 예정.
- `rooms[]`는 현재 빈 배열로 추출됨 (fusion_service 한계). 

## 🔗 관련 명세 정정

- 응답 wrapper 형식: `{status, scene_draft_id, scene: {...}}` 으로 nested (§6.1 그대로)
- `walls[].id`는 `"0"`, `"1"`... 숫자 문자열
- `openings[].type`은 `"door" | "window"`
- 좌표는 픽셀 단위, 미터 변환 시 `scene.scale_ratio` 곱셈

