### PR TITLE
feat: Scene Draft 목록 조회 API 구현

### DIFF
--- a/backend/app/routers/scene_drafts.py
+++ b/backend/app/routers/scene_drafts.py
@@ -3,17 +3,42 @@ Scene Draft 라우터
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.scene_draft import SceneDraftDetailResponse
+from app.schemas.pagination import PaginatedResponse
+from app.schemas.scene_draft import SceneDraftDetailResponse, SceneDraftSummaryResponse
 from app.services import scene_draft_service
 
 router = APIRouter(prefix="/scene-drafts", tags=["scene-drafts"])
 
+
+@router.get(
+    "",
+    response_model=PaginatedResponse[SceneDraftSummaryResponse],
+    summary="Scene Draft 목록 조회",
+)
+def list_scene_drafts(
+    project_id: str | None = Query(default=None),
+    floor_id: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[SceneDraftSummaryResponse]:
+    return scene_draft_service.list_scene_drafts(
+        db,
+        current_user,
+        page=page,
+        page_size=page_size,
+        project_id=project_id,
+        floor_id=floor_id,
+        status=status,
+    )
 
 @router.get(
     "/{scene_draft_id}",

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -111,3 +111,18 @@ class SceneDraftDetailResponse(BaseModel):
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SceneDraftSummaryResponse(BaseModel):
+    
+    id: str
+    project_id: str
+    floor_id: str
+    source_mode: str
+    source_asset_id: str | None
+    source_method: str | None
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from uuid import UUID
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
+from app.schemas.pagination import PaginatedResponse
 
 from app.core.errors import AppError, ErrorCode
 from app.core.settings import (
@@ -29,6 +30,7 @@ from app.schemas.scene_draft import (
     SaveSceneDraftRequestDTO,
     SaveSceneDraftResultDTO,
     SceneDraftDetailResponse,
+    SceneDraftSummaryResponse
 )
 
 
@@ -278,4 +280,43 @@ def get_scene_draft(
         objects=scene_draft.draft_objects,
         created_at=scene_draft.created_at,
         updated_at=scene_draft.updated_at,
+    )
+
+def list_scene_drafts(
+    db: Session,
+    current_user: User,
+    page: int,
+    page_size: int,
+    project_id: str | None = None,
+    floor_id: str | None = None,
+    status: str | None = None,
+) -> PaginatedResponse[SceneDraftSummaryResponse]:
+    
+    base_query = (
+        db.query(SceneDraft)
+        .join(Project, SceneDraft.project_id == Project.id)
+        .filter(Project.owner_user_id == current_user.id)
+    )
+
+    if project_id is not None:
+        base_query = base_query.filter(SceneDraft.project_id == project_id)
+    if floor_id is not None:
+        base_query = base_query.filter(SceneDraft.floor_id == floor_id)
+    if status is not None:
+        base_query = base_query.filter(SceneDraft.status == status)
+
+    total = base_query.with_entities(func.count(SceneDraft.id)).scalar() or 0
+
+    items = (
+        base_query.order_by(SceneDraft.created_at.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+
+    return PaginatedResponse[SceneDraftSummaryResponse](
+        items=[SceneDraftSummaryResponse.model_validate(d) for d in items],
+        page=page,
+        page_size=page_size,
+        total=total,
     )


### PR DESCRIPTION
## 📋 작업 내용

명세서(`API_SPEC.md` §6.3)에 따라 Scene Draft 목록 조회 API 구현.

### 구현한 엔드포인트

- `GET /scene-drafts` — 본인 소유 프로젝트의 Scene Draft 목록 (페이지네이션 + 필터)

### Query 파라미터

| 파라미터 | 타입 | 기본값 | 설명 |
|---|---|---|---|
| `project_id` | uuid | - | 특정 프로젝트로 필터 (옵션) |
| `floor_id` | uuid | - | 특정 층으로 필터 (옵션) |
| `status` | string | - | draft / archived 등 (옵션) |
| `page` | int | 1 | 페이지 번호 |
| `page_size` | int | 20 (max 100) | 페이지 크기 |

### 응답 형식

명세 §0.5 페이지네이션 형식 준수. 자식 리소스(rooms/walls/openings/objects)는 **제외** — 가벼운 요약본.

```json
{
  "items": [
    {
      "id": "...",
      "project_id": "...",
      "floor_id": "...",
      "source_mode": "floorplan_image",
      "source_asset_id": null,
      "source_method": "fusion_service",
      "status": "draft",
      "created_at": "...",
      "updated_at": "..."
    }
  ],
  "page": 1,
  "page_size": 20,
  "total": 1
}
```

### 권한 정책

- 인증 필요 (Bearer Token)
- `Project.owner_user_id == current_user.id` JOIN 조건으로 본인 거만 자동 필터
- 남의 `project_id`/`floor_id` 명시해도 빈 배열 반환 (404 아님 — 목록 API는 빈 결과가 자연스러움)

## 🗂️ 파일 변경

**수정**
- `backend/app/schemas/scene_draft.py` — `SceneDraftSummaryResponse` 추가 (자식 리소스 제외)
- `backend/app/services/scene_draft_service.py` — `list_scene_drafts` 함수 추가, `func`/`PaginatedResponse` import 추가
- `backend/app/routers/scene_drafts.py` — `GET /scene-drafts` 엔드포인트 추가

## 🧪 테스트 결과

| 테스트 | 결과 |
|---|---|
| 전체 목록 (필터 없음) | 본인 draft만 반환 ✅ |
| `?status=draft` 필터 | 정상 동작 ✅ |
| `?project_id=<본인>` 필터 | 정상 동작 ✅ |
| `?project_id=<없는 UUID>` | `total: 0` 빈 배열 ✅ |
| 해커 토큰으로 조회 | `total: 0` 빈 배열 ✅ |
| 자식 리소스 미포함 확인 | rooms/walls/openings/objects 없음 ✅ |

## 📚 명세 준거

`API_SPEC.md` §6.3 그대로 구현. 페이지네이션은 §0.5 형식.

## 🔗 라우터 순서 주의

`GET /scene-drafts` (목록)를 `GET /scene-drafts/{id}` (단건) **위에** 정의.
순서 바꾸면 FastAPI가 빈 path를 `{id}`로 해석할 수 있음.

