### PR TITLE
feat: Scene Version API (promote + 조회 + 현재 버전 토글) (#30)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -46,6 +46,10 @@ class ErrorCode(StrEnum):
     DRAFT_OBJECT_NOT_FOUND = "DRAFT_OBJECT_NOT_FOUND"
     INVALID_GEOMETRY = "INVALID_GEOMETRY"
 
+    SCENE_VERSION_NOT_FOUND = "SCENE_VERSION_NOT_FOUND"
+    DRAFT_ALREADY_PROMOTED = "DRAFT_ALREADY_PROMOTED"
+    SCENE_VERSION_CONFLICT = "SCENE_VERSION_CONFLICT"
+
 
 class AppError(Exception):
     def __init__(self, code: ErrorCode, message: str, status_code: int):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,10 +7,14 @@ from app.models.floor import Floor
 from app.models.measurement_link import MeasurementLink
 from app.models.measurement_point import MeasurementPoint
 from app.models.measurement_session import MeasurementSession
+from app.models.object import SceneObject
+from app.models.opening import Opening
 from app.models.project import Project
+from app.models.room import Room
 from app.models.scene_draft import SceneDraft
 from app.models.scene_version import SceneVersion
 from app.models.user import User
+from app.models.wall import Wall
 
 __all__ = [
     "User",
@@ -23,6 +27,10 @@ __all__ = [
     "DraftWall",
     "DraftOpening",
     "DraftObject",
+    "Room",
+    "Wall",
+    "Opening",
+    "SceneObject",
     "MeasurementLink",
     "MeasurementSession",
     "MeasurementPoint",

--- a/backend/app/models/object.py
+++ b/backend/app/models/object.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from geoalchemy2 import Geometry
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class SceneObject(Base):
+    __tablename__ = "objects"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    object_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    source_method: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    point_geom = mapped_column(Geometry("POINT", srid=0), nullable=True)
+    z_m: Mapped[Decimal | None] = mapped_column(
+        Numeric(6, 3), nullable=True, server_default=text("0")
+    )
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    scene_version = relationship("SceneVersion", back_populates="objects")

--- a/backend/app/models/opening.py
+++ b/backend/app/models/opening.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from geoalchemy2 import Geometry
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Opening(Base):
+    __tablename__ = "openings"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    wall_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("walls.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    opening_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    width_m: Mapped[Decimal] = mapped_column(Numeric(6, 3), nullable=False)
+    height_m: Mapped[Decimal] = mapped_column(Numeric(6, 3), nullable=False)
+    sill_height_m: Mapped[Decimal | None] = mapped_column(Numeric(6, 3), nullable=True)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    source_method: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    line_geom = mapped_column(Geometry("LINESTRING", srid=0), nullable=True)
+    polygon_geom = mapped_column(Geometry("POLYGON", srid=0), nullable=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    scene_version = relationship("SceneVersion", back_populates="openings")
+    wall = relationship("Wall", back_populates="openings")

--- a/backend/app/models/room.py
+++ b/backend/app/models/room.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from geoalchemy2 import Geometry
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Room(Base):
+    __tablename__ = "rooms"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    room_name: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    room_type: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    source_method: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    polygon_geom = mapped_column(Geometry("POLYGON", srid=0), nullable=True)
+    centroid_geom = mapped_column(Geometry("POINT", srid=0), nullable=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    scene_version = relationship("SceneVersion", back_populates="rooms")

--- a/backend/app/models/scene_version.py
+++ b/backend/app/models/scene_version.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 
@@ -69,4 +69,29 @@ class SceneVersion(Base):
     created_by: Mapped[str | None] = mapped_column(String(80), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    rooms = relationship(
+        "Room",
+        back_populates="scene_version",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
+    walls = relationship(
+        "Wall",
+        back_populates="scene_version",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
+    openings = relationship(
+        "Opening",
+        back_populates="scene_version",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
+    objects = relationship(
+        "SceneObject",
+        back_populates="scene_version",
+        cascade="all, delete",
+        passive_deletes=True,
     )

--- a/backend/app/models/wall.py
+++ b/backend/app/models/wall.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from geoalchemy2 import Geometry
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Wall(Base):
+    __tablename__ = "walls"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    wall_role: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'inner'")
+    )
+    thickness_m: Mapped[Decimal] = mapped_column(
+        Numeric(6, 3), nullable=False, server_default=text("0.18")
+    )
+    height_m: Mapped[Decimal | None] = mapped_column(Numeric(6, 3), nullable=True)
+    material_label: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    source_method: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    centerline_geom = mapped_column(Geometry("LINESTRING", srid=0), nullable=True)
+    polygon_geom = mapped_column(Geometry("POLYGON", srid=0), nullable=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    scene_version = relationship("SceneVersion", back_populates="walls")
+    openings = relationship("Opening", back_populates="wall")

--- a/backend/app/routers/scene_versions.py
+++ b/backend/app/routers/scene_versions.py
@@ -1,0 +1,86 @@
+"""Scene Version 라우터"""
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.scene_version import (
+    PromoteRequest,
+    SceneVersionDetailResponse,
+    SceneVersionResponse,
+)
+from app.services import scene_version_service
+
+
+promote_router = APIRouter(prefix="/scene-drafts", tags=["scene-versions"])
+scene_versions_router = APIRouter(prefix="/scene-versions", tags=["scene-versions"])
+floor_scene_versions_router = APIRouter(prefix="/floors", tags=["scene-versions"])
+
+
+@promote_router.post(
+    "/{scene_draft_id}/promote",
+    response_model=SceneVersionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Draft → Scene Version 승격",
+)
+def promote_scene_draft(
+    payload: PromoteRequest,
+    scene_draft_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SceneVersionResponse:
+    return scene_version_service.promote(
+        db, scene_draft_id=scene_draft_id, payload=payload, user=current_user
+    )
+
+
+@scene_versions_router.get(
+    "/{version_id}",
+    response_model=SceneVersionDetailResponse,
+    summary="Scene Version 단건 조회 (rooms/walls/openings/objects 포함)",
+)
+def get_scene_version(
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SceneVersionDetailResponse:
+    return scene_version_service.get_scene_version(
+        db, version_id=version_id, user=current_user
+    )
+
+
+@scene_versions_router.patch(
+    "/{version_id}/set-current",
+    response_model=SceneVersionResponse,
+    summary="현재 활성 버전으로 설정 (같은 floor 의 다른 버전 false 처리)",
+)
+def set_current_scene_version(
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SceneVersionResponse:
+    return scene_version_service.set_current(
+        db, version_id=version_id, user=current_user
+    )
+
+
+@floor_scene_versions_router.get(
+    "/{floor_id}/scene-versions",
+    response_model=list[SceneVersionResponse],
+    summary="층의 Scene Version 목록",
+)
+def list_scene_versions_by_floor(
+    floor_id: UUID = Path(...),
+    is_current: Optional[bool] = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[SceneVersionResponse]:
+    return scene_version_service.list_by_floor(
+        db, floor_id=floor_id, user=current_user, is_current=is_current
+    )

--- a/backend/app/schemas/opening.py
+++ b/backend/app/schemas/opening.py
@@ -1,0 +1,25 @@
+"""Opening (확정본) DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class OpeningResponse(BaseModel):
+    id: UUID
+    scene_version_id: UUID
+    wall_id: Optional[UUID] = None
+    opening_type: str
+    width_m: Decimal
+    height_m: Decimal
+    sill_height_m: Optional[Decimal] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    line_geom: Optional[dict[str, Any]] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/schemas/room.py
+++ b/backend/app/schemas/room.py
@@ -1,0 +1,22 @@
+"""Room (확정본) DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class RoomResponse(BaseModel):
+    id: UUID
+    scene_version_id: UUID
+    room_name: Optional[str] = None
+    room_type: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    centroid_geom: Optional[dict[str, Any]] = None
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/schemas/scene_object.py
+++ b/backend/app/schemas/scene_object.py
@@ -1,0 +1,21 @@
+"""Scene Object (확정본) DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ObjectResponse(BaseModel):
+    id: UUID
+    scene_version_id: UUID
+    object_type: str
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    point_geom: Optional[dict[str, Any]] = None
+    z_m: Optional[Decimal] = None
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/schemas/scene_version.py
+++ b/backend/app/schemas/scene_version.py
@@ -1,0 +1,44 @@
+"""Scene Version 도메인 DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.opening import OpeningResponse
+from app.schemas.room import RoomResponse
+from app.schemas.scene_object import ObjectResponse
+from app.schemas.wall import WallResponse
+
+
+class PromoteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version_no: int = Field(..., ge=1)
+    is_current: bool = True
+
+
+class SceneVersionResponse(BaseModel):
+    id: UUID
+    project_id: UUID
+    floor_id: UUID
+    source_draft_id: Optional[UUID] = None
+    version_no: int
+    is_current: bool
+    source_mode: str
+    source_method: Optional[str] = None
+    source_asset_id: Optional[UUID] = None
+    render_scene_url: Optional[str] = None
+    rf_scene_url: Optional[str] = None
+    artifacts_json: dict[str, Any] = Field(default_factory=dict)
+    created_by: Optional[str] = None
+    created_at: datetime
+
+
+class SceneVersionDetailResponse(SceneVersionResponse):
+    rooms: list[RoomResponse] = Field(default_factory=list)
+    walls: list[WallResponse] = Field(default_factory=list)
+    openings: list[OpeningResponse] = Field(default_factory=list)
+    objects: list[ObjectResponse] = Field(default_factory=list)

--- a/backend/app/schemas/wall.py
+++ b/backend/app/schemas/wall.py
@@ -1,0 +1,24 @@
+"""Wall (확정본) DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class WallResponse(BaseModel):
+    id: UUID
+    scene_version_id: UUID
+    wall_role: str
+    thickness_m: Decimal
+    height_m: Optional[Decimal] = None
+    material_label: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    centerline_geom: Optional[dict[str, Any]] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/services/scene_version_service.py
+++ b/backend/app/services/scene_version_service.py
@@ -1,0 +1,372 @@
+"""Scene Version: promote + 조회 + set-current"""
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from app.core.errors import AppError, ErrorCode
+from app.core.geom import wkb_to_geojson
+from app.models.floor import Floor
+from app.models.object import SceneObject
+from app.models.opening import Opening
+from app.models.project import Project
+from app.models.room import Room
+from app.models.scene_draft import SceneDraft
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.models.wall import Wall
+from app.schemas.opening import OpeningResponse
+from app.schemas.room import RoomResponse
+from app.schemas.scene_object import ObjectResponse
+from app.schemas.scene_version import (
+    PromoteRequest,
+    SceneVersionDetailResponse,
+    SceneVersionResponse,
+)
+from app.schemas.wall import WallResponse
+
+
+# ---------------------------------------------------------------------------
+# 권한 체크
+# ---------------------------------------------------------------------------
+def _get_owned_scene_draft(
+    db: Session, scene_draft_id: UUID, user: User
+) -> SceneDraft:
+    stmt = (
+        select(SceneDraft)
+        .join(Project, SceneDraft.project_id == Project.id)
+        .where(
+            SceneDraft.id == str(scene_draft_id),
+            Project.owner_user_id == user.id,
+        )
+        .options(
+            selectinload(SceneDraft.draft_rooms),
+            selectinload(SceneDraft.draft_walls),
+            selectinload(SceneDraft.draft_openings),
+            selectinload(SceneDraft.draft_objects),
+        )
+    )
+    sd = db.execute(stmt).scalar_one_or_none()
+    if sd is None:
+        raise AppError(
+            ErrorCode.SCENE_DRAFT_NOT_FOUND,
+            "Scene draft not found.",
+            status_code=404,
+        )
+    return sd
+
+
+def _get_owned_scene_version(
+    db: Session, version_id: UUID, user: User, with_children: bool = False
+) -> SceneVersion:
+    stmt = (
+        select(SceneVersion)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            SceneVersion.id == str(version_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    if with_children:
+        stmt = stmt.options(
+            selectinload(SceneVersion.rooms),
+            selectinload(SceneVersion.walls),
+            selectinload(SceneVersion.openings),
+            selectinload(SceneVersion.objects),
+        )
+    sv = db.execute(stmt).scalar_one_or_none()
+    if sv is None:
+        raise AppError(
+            ErrorCode.SCENE_VERSION_NOT_FOUND,
+            "Scene version not found.",
+            status_code=404,
+        )
+    return sv
+
+
+def _get_owned_floor(db: Session, floor_id: UUID, user: User) -> Floor:
+    stmt = (
+        select(Floor)
+        .join(Project, Floor.project_id == Project.id)
+        .where(
+            Floor.id == str(floor_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    f = db.execute(stmt).scalar_one_or_none()
+    if f is None:
+        raise AppError(
+            ErrorCode.FLOOR_NOT_FOUND,
+            "Floor not found.",
+            status_code=404,
+        )
+    return f
+
+
+# ---------------------------------------------------------------------------
+# 변환 헬퍼
+# ---------------------------------------------------------------------------
+def _to_summary(sv: SceneVersion) -> SceneVersionResponse:
+    return SceneVersionResponse(
+        id=sv.id,
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        source_draft_id=sv.scene_draft_id,
+        version_no=sv.version_no,
+        is_current=sv.is_confirmed,
+        source_mode=sv.source_mode,
+        source_method=sv.source_method,
+        source_asset_id=sv.source_asset_id,
+        render_scene_url=sv.render_scene_url,
+        rf_scene_url=sv.rf_scene_url,
+        artifacts_json=sv.artifacts_json or {},
+        created_by=sv.created_by,
+        created_at=sv.created_at,
+    )
+
+
+def _room_to_response(r: Room) -> RoomResponse:
+    return RoomResponse(
+        id=r.id,
+        scene_version_id=r.scene_version_id,
+        room_name=r.room_name,
+        room_type=r.room_type,
+        confidence=r.confidence,
+        source_method=r.source_method,
+        polygon_geom=wkb_to_geojson(r.polygon_geom),
+        centroid_geom=wkb_to_geojson(r.centroid_geom),
+        metadata_json=r.metadata_json or {},
+        created_at=r.created_at,
+    )
+
+
+def _wall_to_response(w: Wall) -> WallResponse:
+    return WallResponse(
+        id=w.id,
+        scene_version_id=w.scene_version_id,
+        wall_role=w.wall_role,
+        thickness_m=w.thickness_m,
+        height_m=w.height_m,
+        material_label=w.material_label,
+        confidence=w.confidence,
+        source_method=w.source_method,
+        centerline_geom=wkb_to_geojson(w.centerline_geom),
+        polygon_geom=wkb_to_geojson(w.polygon_geom),
+        metadata_json=w.metadata_json or {},
+        created_at=w.created_at,
+    )
+
+
+def _opening_to_response(o: Opening) -> OpeningResponse:
+    return OpeningResponse(
+        id=o.id,
+        scene_version_id=o.scene_version_id,
+        wall_id=o.wall_id,
+        opening_type=o.opening_type,
+        width_m=o.width_m,
+        height_m=o.height_m,
+        sill_height_m=o.sill_height_m,
+        confidence=o.confidence,
+        source_method=o.source_method,
+        line_geom=wkb_to_geojson(o.line_geom),
+        polygon_geom=wkb_to_geojson(o.polygon_geom),
+        metadata_json=o.metadata_json or {},
+        created_at=o.created_at,
+    )
+
+
+def _object_to_response(o: SceneObject) -> ObjectResponse:
+    return ObjectResponse(
+        id=o.id,
+        scene_version_id=o.scene_version_id,
+        object_type=o.object_type,
+        confidence=o.confidence,
+        source_method=o.source_method,
+        point_geom=wkb_to_geojson(o.point_geom),
+        z_m=o.z_m,
+        metadata_json=o.metadata_json or {},
+        created_at=o.created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 퍼블릭 API
+# ---------------------------------------------------------------------------
+def promote(
+    db: Session,
+    scene_draft_id: UUID,
+    payload: PromoteRequest,
+    user: User,
+) -> SceneVersionResponse:
+    sd = _get_owned_scene_draft(db, scene_draft_id, user)
+
+    existing = db.execute(
+        select(SceneVersion).where(SceneVersion.scene_draft_id == sd.id)
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise AppError(
+            ErrorCode.DRAFT_ALREADY_PROMOTED,
+            f"Scene draft is already promoted to version {existing.version_no}.",
+            status_code=409,
+        )
+
+    if payload.is_current:
+        db.execute(
+            update(SceneVersion)
+            .where(
+                SceneVersion.floor_id == sd.floor_id,
+                SceneVersion.is_confirmed.is_(True),
+            )
+            .values(is_confirmed=False)
+        )
+
+    sv = SceneVersion(
+        project_id=sd.project_id,
+        floor_id=sd.floor_id,
+        scene_draft_id=sd.id,
+        version_no=payload.version_no,
+        is_confirmed=payload.is_current,
+        source_mode=sd.source_mode,
+        source_asset_id=sd.source_asset_id,
+        source_method=sd.source_method,
+        artifacts_json={},
+        created_by=user.email,
+    )
+    db.add(sv)
+
+    try:
+        db.flush()
+    except IntegrityError as exc:
+        db.rollback()
+        raise AppError(
+            ErrorCode.SCENE_VERSION_CONFLICT,
+            f"Version {payload.version_no} already exists for this floor.",
+            status_code=409,
+        ) from exc
+
+    draft_wall_to_wall: dict[str, str] = {}
+
+    for dr in sd.draft_rooms:
+        db.add(
+            Room(
+                scene_version_id=sv.id,
+                room_name=dr.room_name,
+                room_type=dr.room_type,
+                confidence=dr.confidence,
+                source_method=dr.source_method,
+                polygon_geom=dr.polygon_geom,
+                centroid_geom=dr.centroid_geom,
+                metadata_json=dr.metadata_json or {},
+            )
+        )
+
+    for dw in sd.draft_walls:
+        wall = Wall(
+            scene_version_id=sv.id,
+            wall_role=dw.wall_role,
+            thickness_m=dw.thickness_m,
+            height_m=dw.height_m,
+            material_label=dw.material_label,
+            confidence=dw.confidence,
+            source_method=dw.source_method,
+            centerline_geom=dw.centerline_geom,
+            polygon_geom=dw.polygon_geom,
+            metadata_json=dw.metadata_json or {},
+        )
+        db.add(wall)
+        db.flush()
+        draft_wall_to_wall[dw.id] = wall.id
+
+    for op in sd.draft_openings:
+        db.add(
+            Opening(
+                scene_version_id=sv.id,
+                wall_id=draft_wall_to_wall.get(op.wall_id) if op.wall_id else None,
+                opening_type=op.opening_type,
+                width_m=op.width_m,
+                height_m=op.height_m,
+                sill_height_m=op.sill_height_m,
+                confidence=op.confidence,
+                source_method=op.source_method,
+                line_geom=op.line_geom,
+                polygon_geom=op.polygon_geom,
+                metadata_json=op.metadata_json or {},
+            )
+        )
+
+    for ob in sd.draft_objects:
+        db.add(
+            SceneObject(
+                scene_version_id=sv.id,
+                object_type=ob.object_type,
+                confidence=ob.confidence,
+                source_method=ob.source_method,
+                point_geom=ob.point_geom,
+                z_m=ob.z_m,
+                metadata_json=ob.metadata_json or {},
+            )
+        )
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    db.refresh(sv)
+    return _to_summary(sv)
+
+
+def get_scene_version(
+    db: Session, version_id: UUID, user: User
+) -> SceneVersionDetailResponse:
+    sv = _get_owned_scene_version(db, version_id, user, with_children=True)
+    summary = _to_summary(sv)
+    return SceneVersionDetailResponse(
+        **summary.model_dump(),
+        rooms=[_room_to_response(r) for r in sv.rooms],
+        walls=[_wall_to_response(w) for w in sv.walls],
+        openings=[_opening_to_response(o) for o in sv.openings],
+        objects=[_object_to_response(o) for o in sv.objects],
+    )
+
+
+def list_by_floor(
+    db: Session,
+    floor_id: UUID,
+    user: User,
+    is_current: Optional[bool] = None,
+) -> list[SceneVersionResponse]:
+    _get_owned_floor(db, floor_id, user)
+    stmt = select(SceneVersion).where(SceneVersion.floor_id == str(floor_id))
+    if is_current is not None:
+        stmt = stmt.where(SceneVersion.is_confirmed.is_(is_current))
+    stmt = stmt.order_by(SceneVersion.version_no.desc())
+    rows = db.execute(stmt).scalars().all()
+    return [_to_summary(r) for r in rows]
+
+
+def set_current(
+    db: Session, version_id: UUID, user: User
+) -> SceneVersionResponse:
+    sv = _get_owned_scene_version(db, version_id, user)
+    db.execute(
+        update(SceneVersion)
+        .where(
+            SceneVersion.floor_id == sv.floor_id,
+            SceneVersion.id != sv.id,
+            SceneVersion.is_confirmed.is_(True),
+        )
+        .values(is_confirmed=False)
+    )
+    sv.is_confirmed = True
+    try:
+        db.commit()
+        db.refresh(sv)
+    except Exception:
+        db.rollback()
+        raise
+    return _to_summary(sv)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,11 @@ from app.routers.draft_rooms import scene_draft_rooms_router, draft_rooms_router
 from app.routers.draft_walls import scene_draft_walls_router, draft_walls_router
 from app.routers.draft_openings import scene_draft_openings_router, draft_openings_router
 from app.routers.draft_objects import scene_draft_objects_router, draft_objects_router
+from app.routers.scene_versions import (
+    promote_router,
+    scene_versions_router,
+    floor_scene_versions_router,
+)
 
 
 app = FastAPI(title="capstone2-backend", version="0.1.0")
@@ -82,3 +87,6 @@ app.include_router(scene_draft_openings_router)
 app.include_router(draft_openings_router)
 app.include_router(scene_draft_objects_router)
 app.include_router(draft_objects_router)
+app.include_router(promote_router)
+app.include_router(scene_versions_router)
+app.include_router(floor_scene_versions_router)


### PR DESCRIPTION
## Summary
- Scene Version API 4개 엔드포인트 구현 (명세 §7 준수, 모델 우선)
  - `POST /scene-drafts/{id}/promote` — Draft → Scene Version 승격, 자식 4종(rooms/walls/openings/objects) 복사
  - `GET /scene-versions/{version_id}` — 자식 포함 단건 조회
  - `GET /floors/{floor_id}/scene-versions` — 층별 목록 (`is_current` 필터)
  - `PATCH /scene-versions/{version_id}/set-current` — 활성 버전 토글, 같은 floor 의 다른 버전 자동 false
- 확정본 자식 모델 4개 신규 (`Room`, `Wall`, `Opening`, `SceneObject`) — DB 테이블에 대응
- SceneVersion relationship 추가 + `cascade="all, delete", passive_deletes=True`
- 명세 alias 매핑: `is_current` ← `is_confirmed`, `source_draft_id` ← `scene_draft_id`
- promote 로직: Draft 자식 → 확정본 복사 시 wall_id 재매핑 (draft_walls.id → walls.id)
- 에러 코드 추가: `SCENE_VERSION_NOT_FOUND`, `DRAFT_ALREADY_PROMOTED`, `SCENE_VERSION_CONFLICT`
- 권한: `scene_drafts/scene_versions/floors → projects.owner_user_id` 조인, 그 외 404

## Test plan
- [x] 다른 사용자가 promote 시도 → 404 `SCENE_DRAFT_NOT_FOUND`
- [x] 정상 promote → 201, 자식 4종 복사 확인
- [x] 같은 draft 재promote → 409 `DRAFT_ALREADY_PROMOTED`
- [x] 다른 사용자가 단건 조회 → 404 `SCENE_VERSION_NOT_FOUND`
- [x] 단건 조회 시 rooms/walls/openings/objects 포함
- [x] Opening의 `wall_id`가 새 walls.id 로 매핑되는지 검증
- [x] 두번째 promote (is_current=true) 시 첫번째 자동 false 처리
- [x] 같은 floor 의 같은 `version_no` 중복 → 409 `SCENE_VERSION_CONFLICT`
- [x] 층별 목록 정상 반환
- [x] `?is_current=true` 필터 동작
- [x] 다른 사용자 floor 의 목록 → 404 `FLOOR_NOT_FOUND`
- [x] 다른 사용자가 set-current → 404 `SCENE_VERSION_NOT_FOUND`
- [x] set-current 호출 시 같은 floor 의 다른 버전 모두 false 토글 (DB 레벨 확인)
- [x] 인증 없이 → 401 `UNAUTHORIZED`