### PR TITLE
feat: 확정본 구성 요소 CRUD + Patch Log API (#32)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -50,6 +50,11 @@ class ErrorCode(StrEnum):
     DRAFT_ALREADY_PROMOTED = "DRAFT_ALREADY_PROMOTED"
     SCENE_VERSION_CONFLICT = "SCENE_VERSION_CONFLICT"
 
+    ROOM_NOT_FOUND = "ROOM_NOT_FOUND"
+    WALL_NOT_FOUND = "WALL_NOT_FOUND"
+    OPENING_NOT_FOUND = "OPENING_NOT_FOUND"
+    OBJECT_NOT_FOUND = "OBJECT_NOT_FOUND"
+
 
 class AppError(Exception):
     def __init__(self, code: ErrorCode, message: str, status_code: int):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.measurement_point import MeasurementPoint
 from app.models.measurement_session import MeasurementSession
 from app.models.object import SceneObject
 from app.models.opening import Opening
+from app.models.patch_log import PatchLog
 from app.models.project import Project
 from app.models.room import Room
 from app.models.scene_draft import SceneDraft
@@ -31,6 +32,7 @@ __all__ = [
     "Wall",
     "Opening",
     "SceneObject",
+    "PatchLog",
     "MeasurementLink",
     "MeasurementSession",
     "MeasurementPoint",

--- a/backend/app/models/patch_log.py
+++ b/backend/app/models/patch_log.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class PatchLog(Base):
+    __tablename__ = "patch_logs"
+    __table_args__ = (
+        Index("idx_patch_logs_version_target", "scene_version_id", "target_type"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_by: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    patch_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    target_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    target_id: Mapped[str] = mapped_column(UUID(as_uuid=False), nullable=False)
+    patch_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    scene_version = relationship("SceneVersion", back_populates="patch_logs")

--- a/backend/app/models/scene_version.py
+++ b/backend/app/models/scene_version.py
@@ -95,3 +95,9 @@ class SceneVersion(Base):
         cascade="all, delete",
         passive_deletes=True,
     )
+    patch_logs = relationship(
+        "PatchLog",
+        back_populates="scene_version",
+        cascade="all, delete",
+        passive_deletes=True,
+    )

--- a/backend/app/routers/objects.py
+++ b/backend/app/routers/objects.py
@@ -1,0 +1,63 @@
+"""확정본 Object 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.scene_object import ObjectResponse, ObjectUpdate
+from app.services import object_service
+
+
+router = APIRouter(prefix="/objects", tags=["objects"])
+
+
+@router.get(
+    "/{object_id}",
+    response_model=ObjectResponse,
+    summary="확정본 Object 단건 조회",
+)
+def get_object(
+    object_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ObjectResponse:
+    return object_service.get_object(
+        db, object_id=object_id, user=current_user
+    )
+
+
+@router.patch(
+    "/{object_id}",
+    response_model=ObjectResponse,
+    summary="확정본 Object 부분 수정 (patch_log 자동 기록)",
+)
+def update_object(
+    payload: ObjectUpdate,
+    object_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ObjectResponse:
+    return object_service.update_object(
+        db, object_id=object_id, payload=payload, user=current_user
+    )
+
+
+@router.delete(
+    "/{object_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="확정본 Object 삭제 (patch_log 자동 기록)",
+)
+def delete_object(
+    object_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    object_service.delete_object(
+        db, object_id=object_id, user=current_user
+    )
+    return None

--- a/backend/app/routers/openings.py
+++ b/backend/app/routers/openings.py
@@ -1,0 +1,63 @@
+"""확정본 Opening 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.opening import OpeningResponse, OpeningUpdate
+from app.services import opening_service
+
+
+router = APIRouter(prefix="/openings", tags=["openings"])
+
+
+@router.get(
+    "/{opening_id}",
+    response_model=OpeningResponse,
+    summary="확정본 Opening 단건 조회",
+)
+def get_opening(
+    opening_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OpeningResponse:
+    return opening_service.get_opening(
+        db, opening_id=opening_id, user=current_user
+    )
+
+
+@router.patch(
+    "/{opening_id}",
+    response_model=OpeningResponse,
+    summary="확정본 Opening 부분 수정 (patch_log 자동 기록)",
+)
+def update_opening(
+    payload: OpeningUpdate,
+    opening_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OpeningResponse:
+    return opening_service.update_opening(
+        db, opening_id=opening_id, payload=payload, user=current_user
+    )
+
+
+@router.delete(
+    "/{opening_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="확정본 Opening 삭제 (patch_log 자동 기록)",
+)
+def delete_opening(
+    opening_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    opening_service.delete_opening(
+        db, opening_id=opening_id, user=current_user
+    )
+    return None

--- a/backend/app/routers/patch_logs.py
+++ b/backend/app/routers/patch_logs.py
@@ -1,0 +1,43 @@
+"""Patch Log 라우터"""
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
+from app.schemas.patch_log import PatchLogResponse
+from app.services import patch_log_service
+
+
+router = APIRouter(prefix="/scene-versions", tags=["patch-logs"])
+
+
+@router.get(
+    "/{version_id}/patch-logs",
+    response_model=PaginatedResponse[PatchLogResponse],
+    summary="Scene Version 의 수정 이력",
+)
+def list_patch_logs(
+    version_id: UUID = Path(...),
+    target_type: Optional[str] = Query(
+        default=None, description="필터: room/wall/opening/object"
+    ),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[PatchLogResponse]:
+    return patch_log_service.list_patch_logs(
+        db,
+        version_id=version_id,
+        user=current_user,
+        page=page,
+        page_size=page_size,
+        target_type=target_type,
+    )

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -1,0 +1,59 @@
+"""확정본 Room 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.room import RoomResponse, RoomUpdate
+from app.services import room_service
+
+
+router = APIRouter(prefix="/rooms", tags=["rooms"])
+
+
+@router.get(
+    "/{room_id}",
+    response_model=RoomResponse,
+    summary="확정본 Room 단건 조회",
+)
+def get_room(
+    room_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RoomResponse:
+    return room_service.get_room(db, room_id=room_id, user=current_user)
+
+
+@router.patch(
+    "/{room_id}",
+    response_model=RoomResponse,
+    summary="확정본 Room 부분 수정 (patch_log 자동 기록)",
+)
+def update_room(
+    payload: RoomUpdate,
+    room_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RoomResponse:
+    return room_service.update_room(
+        db, room_id=room_id, payload=payload, user=current_user
+    )
+
+
+@router.delete(
+    "/{room_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="확정본 Room 삭제 (patch_log 자동 기록)",
+)
+def delete_room(
+    room_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    room_service.delete_room(db, room_id=room_id, user=current_user)
+    return None

--- a/backend/app/routers/walls.py
+++ b/backend/app/routers/walls.py
@@ -1,0 +1,59 @@
+"""확정본 Wall 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.wall import WallResponse, WallUpdate
+from app.services import wall_service
+
+
+router = APIRouter(prefix="/walls", tags=["walls"])
+
+
+@router.get(
+    "/{wall_id}",
+    response_model=WallResponse,
+    summary="확정본 Wall 단건 조회",
+)
+def get_wall(
+    wall_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> WallResponse:
+    return wall_service.get_wall(db, wall_id=wall_id, user=current_user)
+
+
+@router.patch(
+    "/{wall_id}",
+    response_model=WallResponse,
+    summary="확정본 Wall 부분 수정 (patch_log 자동 기록)",
+)
+def update_wall(
+    payload: WallUpdate,
+    wall_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> WallResponse:
+    return wall_service.update_wall(
+        db, wall_id=wall_id, payload=payload, user=current_user
+    )
+
+
+@router.delete(
+    "/{wall_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="확정본 Wall 삭제 (patch_log 자동 기록)",
+)
+def delete_wall(
+    wall_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    wall_service.delete_wall(db, wall_id=wall_id, user=current_user)
+    return None

--- a/backend/app/schemas/opening.py
+++ b/backend/app/schemas/opening.py
@@ -6,7 +6,22 @@ from decimal import Decimal
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OpeningUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    wall_id: Optional[UUID] = None
+    opening_type: Optional[str] = None
+    width_m: Optional[Decimal] = None
+    height_m: Optional[Decimal] = None
+    sill_height_m: Optional[Decimal] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    line_geom: Optional[dict[str, Any]] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    metadata_json: Optional[dict[str, Any]] = None
 
 
 class OpeningResponse(BaseModel):

--- a/backend/app/schemas/patch_log.py
+++ b/backend/app/schemas/patch_log.py
@@ -1,0 +1,19 @@
+"""Patch Log DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PatchLogResponse(BaseModel):
+    id: UUID
+    scene_version_id: UUID
+    created_by: Optional[UUID] = None
+    patch_type: str
+    target_type: str
+    target_id: UUID
+    patch_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/schemas/room.py
+++ b/backend/app/schemas/room.py
@@ -6,7 +6,19 @@ from decimal import Decimal
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RoomUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    room_name: Optional[str] = None
+    room_type: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    centroid_geom: Optional[dict[str, Any]] = None
+    metadata_json: Optional[dict[str, Any]] = None
 
 
 class RoomResponse(BaseModel):

--- a/backend/app/schemas/scene_object.py
+++ b/backend/app/schemas/scene_object.py
@@ -6,7 +6,18 @@ from decimal import Decimal
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ObjectUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    object_type: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    point_geom: Optional[dict[str, Any]] = None
+    z_m: Optional[Decimal] = None
+    metadata_json: Optional[dict[str, Any]] = None
 
 
 class ObjectResponse(BaseModel):

--- a/backend/app/schemas/wall.py
+++ b/backend/app/schemas/wall.py
@@ -6,7 +6,21 @@ from decimal import Decimal
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WallUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    wall_role: Optional[str] = None
+    thickness_m: Optional[Decimal] = None
+    height_m: Optional[Decimal] = None
+    material_label: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    centerline_geom: Optional[dict[str, Any]] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    metadata_json: Optional[dict[str, Any]] = None
 
 
 class WallResponse(BaseModel):

--- a/backend/app/services/_patch_log_helpers.py
+++ b/backend/app/services/_patch_log_helpers.py
@@ -1,0 +1,104 @@
+"""확정본 구성 요소 patch_log 자동 기록 헬퍼"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.geom import wkb_to_geojson
+from app.models.object import SceneObject
+from app.models.opening import Opening
+from app.models.patch_log import PatchLog
+from app.models.room import Room
+from app.models.user import User
+from app.models.wall import Wall
+
+
+def _decimal_to_str(v: Any) -> Any:
+    if isinstance(v, Decimal):
+        return str(v)
+    return v
+
+
+def snapshot_room(r: Room) -> dict[str, Any]:
+    return {
+        "id": r.id,
+        "scene_version_id": r.scene_version_id,
+        "room_name": r.room_name,
+        "room_type": r.room_type,
+        "confidence": _decimal_to_str(r.confidence),
+        "source_method": r.source_method,
+        "polygon_geom": wkb_to_geojson(r.polygon_geom),
+        "centroid_geom": wkb_to_geojson(r.centroid_geom),
+        "metadata_json": r.metadata_json or {},
+    }
+
+
+def snapshot_wall(w: Wall) -> dict[str, Any]:
+    return {
+        "id": w.id,
+        "scene_version_id": w.scene_version_id,
+        "wall_role": w.wall_role,
+        "thickness_m": _decimal_to_str(w.thickness_m),
+        "height_m": _decimal_to_str(w.height_m),
+        "material_label": w.material_label,
+        "confidence": _decimal_to_str(w.confidence),
+        "source_method": w.source_method,
+        "centerline_geom": wkb_to_geojson(w.centerline_geom),
+        "polygon_geom": wkb_to_geojson(w.polygon_geom),
+        "metadata_json": w.metadata_json or {},
+    }
+
+
+def snapshot_opening(o: Opening) -> dict[str, Any]:
+    return {
+        "id": o.id,
+        "scene_version_id": o.scene_version_id,
+        "wall_id": o.wall_id,
+        "opening_type": o.opening_type,
+        "width_m": _decimal_to_str(o.width_m),
+        "height_m": _decimal_to_str(o.height_m),
+        "sill_height_m": _decimal_to_str(o.sill_height_m),
+        "confidence": _decimal_to_str(o.confidence),
+        "source_method": o.source_method,
+        "line_geom": wkb_to_geojson(o.line_geom),
+        "polygon_geom": wkb_to_geojson(o.polygon_geom),
+        "metadata_json": o.metadata_json or {},
+    }
+
+
+def snapshot_object(o: SceneObject) -> dict[str, Any]:
+    return {
+        "id": o.id,
+        "scene_version_id": o.scene_version_id,
+        "object_type": o.object_type,
+        "confidence": _decimal_to_str(o.confidence),
+        "source_method": o.source_method,
+        "point_geom": wkb_to_geojson(o.point_geom),
+        "z_m": _decimal_to_str(o.z_m),
+        "metadata_json": o.metadata_json or {},
+    }
+
+
+def record_patch(
+    db: Session,
+    *,
+    scene_version_id: str,
+    user: User,
+    patch_type: str,
+    target_type: str,
+    target_id: str,
+    before: Optional[dict[str, Any]],
+    after: Optional[dict[str, Any]],
+) -> None:
+    """patch_logs 에 INSERT. commit 은 호출자가 책임."""
+    log = PatchLog(
+        scene_version_id=scene_version_id,
+        created_by=user.id,
+        patch_type=patch_type,
+        target_type=target_type,
+        target_id=target_id,
+        patch_json={"before": before, "after": after},
+    )
+    db.add(log)

--- a/backend/app/services/object_service.py
+++ b/backend/app/services/object_service.py
@@ -1,0 +1,111 @@
+"""확정본 Object 단건 조회/수정/삭제 (+ patch_log 자동 기록)"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.core.geom import geojson_to_wkb
+from app.models.object import SceneObject
+from app.models.project import Project
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.schemas.scene_object import ObjectResponse, ObjectUpdate
+from app.services._patch_log_helpers import record_patch, snapshot_object
+from app.services.scene_version_service import _object_to_response
+
+
+def _get_owned_object(db: Session, object_id: UUID, user: User) -> SceneObject:
+    stmt = (
+        select(SceneObject)
+        .join(SceneVersion, SceneObject.scene_version_id == SceneVersion.id)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            SceneObject.id == str(object_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    o = db.execute(stmt).scalar_one_or_none()
+    if o is None:
+        raise AppError(
+            ErrorCode.OBJECT_NOT_FOUND,
+            "Object not found.",
+            status_code=404,
+        )
+    return o
+
+
+def get_object(db: Session, object_id: UUID, user: User) -> ObjectResponse:
+    return _object_to_response(_get_owned_object(db, object_id, user))
+
+
+def update_object(
+    db: Session,
+    object_id: UUID,
+    payload: ObjectUpdate,
+    user: User,
+) -> ObjectResponse:
+    obj = _get_owned_object(db, object_id, user)
+    before = snapshot_object(obj)
+
+    data = payload.model_dump(exclude_unset=True)
+    if "point_geom" in data:
+        obj.point_geom = geojson_to_wkb(
+            data["point_geom"], "Point", "point_geom"
+        )
+    for field in (
+        "object_type",
+        "confidence",
+        "source_method",
+        "z_m",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(obj, field, data[field])
+
+    after = snapshot_object(obj)
+    record_patch(
+        db,
+        scene_version_id=obj.scene_version_id,
+        user=user,
+        patch_type="update",
+        target_type="object",
+        target_id=obj.id,
+        before=before,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(obj)
+    except Exception:
+        db.rollback()
+        raise
+    return _object_to_response(obj)
+
+
+def delete_object(db: Session, object_id: UUID, user: User) -> None:
+    obj = _get_owned_object(db, object_id, user)
+    before = snapshot_object(obj)
+    sv_id = obj.scene_version_id
+    oid = obj.id
+
+    record_patch(
+        db,
+        scene_version_id=sv_id,
+        user=user,
+        patch_type="delete",
+        target_type="object",
+        target_id=oid,
+        before=before,
+        after=None,
+    )
+    db.delete(obj)
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/app/services/opening_service.py
+++ b/backend/app/services/opening_service.py
@@ -1,0 +1,142 @@
+"""확정본 Opening 단건 조회/수정/삭제 (+ patch_log 자동 기록)"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.core.geom import geojson_to_wkb
+from app.models.opening import Opening
+from app.models.project import Project
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.models.wall import Wall
+from app.schemas.opening import OpeningResponse, OpeningUpdate
+from app.services._patch_log_helpers import record_patch, snapshot_opening
+from app.services.scene_version_service import _opening_to_response
+
+
+def _get_owned_opening(db: Session, opening_id: UUID, user: User) -> Opening:
+    stmt = (
+        select(Opening)
+        .join(SceneVersion, Opening.scene_version_id == SceneVersion.id)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            Opening.id == str(opening_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    o = db.execute(stmt).scalar_one_or_none()
+    if o is None:
+        raise AppError(
+            ErrorCode.OPENING_NOT_FOUND,
+            "Opening not found.",
+            status_code=404,
+        )
+    return o
+
+
+def _validate_wall_belongs_to_version(
+    db: Session, wall_id: UUID, scene_version_id: str
+) -> None:
+    stmt = select(Wall).where(
+        Wall.id == str(wall_id),
+        Wall.scene_version_id == scene_version_id,
+    )
+    if db.execute(stmt).scalar_one_or_none() is None:
+        raise AppError(
+            ErrorCode.WALL_NOT_FOUND,
+            "Referenced wall does not belong to this scene version.",
+            status_code=404,
+        )
+
+
+def get_opening(db: Session, opening_id: UUID, user: User) -> OpeningResponse:
+    return _opening_to_response(_get_owned_opening(db, opening_id, user))
+
+
+def update_opening(
+    db: Session,
+    opening_id: UUID,
+    payload: OpeningUpdate,
+    user: User,
+) -> OpeningResponse:
+    opening = _get_owned_opening(db, opening_id, user)
+    before = snapshot_opening(opening)
+
+    data = payload.model_dump(exclude_unset=True)
+    if "wall_id" in data:
+        new_wall_id = data["wall_id"]
+        if new_wall_id is not None:
+            _validate_wall_belongs_to_version(
+                db, new_wall_id, opening.scene_version_id
+            )
+            opening.wall_id = str(new_wall_id)
+        else:
+            opening.wall_id = None
+    if "line_geom" in data:
+        opening.line_geom = geojson_to_wkb(
+            data["line_geom"], "LineString", "line_geom"
+        )
+    if "polygon_geom" in data:
+        opening.polygon_geom = geojson_to_wkb(
+            data["polygon_geom"], "Polygon", "polygon_geom"
+        )
+    for field in (
+        "opening_type",
+        "width_m",
+        "height_m",
+        "sill_height_m",
+        "confidence",
+        "source_method",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(opening, field, data[field])
+
+    after = snapshot_opening(opening)
+    record_patch(
+        db,
+        scene_version_id=opening.scene_version_id,
+        user=user,
+        patch_type="update",
+        target_type="opening",
+        target_id=opening.id,
+        before=before,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(opening)
+    except Exception:
+        db.rollback()
+        raise
+    return _opening_to_response(opening)
+
+
+def delete_opening(db: Session, opening_id: UUID, user: User) -> None:
+    opening = _get_owned_opening(db, opening_id, user)
+    before = snapshot_opening(opening)
+    sv_id = opening.scene_version_id
+    oid = opening.id
+
+    record_patch(
+        db,
+        scene_version_id=sv_id,
+        user=user,
+        patch_type="delete",
+        target_type="opening",
+        target_id=oid,
+        before=before,
+        after=None,
+    )
+    db.delete(opening)
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/app/services/patch_log_service.py
+++ b/backend/app/services/patch_log_service.py
@@ -1,0 +1,83 @@
+"""Patch Log 조회"""
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.patch_log import PatchLog
+from app.models.project import Project
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
+from app.schemas.patch_log import PatchLogResponse
+
+
+ALLOWED_TARGET_TYPES = {"room", "wall", "opening", "object"}
+
+
+def _get_owned_scene_version(
+    db: Session, version_id: UUID, user: User
+) -> SceneVersion:
+    stmt = (
+        select(SceneVersion)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            SceneVersion.id == str(version_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    sv = db.execute(stmt).scalar_one_or_none()
+    if sv is None:
+        raise AppError(
+            ErrorCode.SCENE_VERSION_NOT_FOUND,
+            "Scene version not found.",
+            status_code=404,
+        )
+    return sv
+
+
+def list_patch_logs(
+    db: Session,
+    version_id: UUID,
+    user: User,
+    page: int,
+    page_size: int,
+    target_type: Optional[str] = None,
+) -> PaginatedResponse[PatchLogResponse]:
+    sv = _get_owned_scene_version(db, version_id, user)
+
+    if target_type is not None and target_type not in ALLOWED_TARGET_TYPES:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            f"Invalid target_type: {target_type}. Allowed: {sorted(ALLOWED_TARGET_TYPES)}",
+            status_code=400,
+        )
+
+    base = select(PatchLog).where(PatchLog.scene_version_id == sv.id)
+    if target_type is not None:
+        base = base.where(PatchLog.target_type == target_type)
+
+    total = db.execute(
+        select(func.count()).select_from(base.subquery())
+    ).scalar_one()
+
+    rows = (
+        db.execute(
+            base.order_by(PatchLog.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        .scalars()
+        .all()
+    )
+
+    return PaginatedResponse[PatchLogResponse](
+        items=[PatchLogResponse.model_validate(r, from_attributes=True) for r in rows],
+        page=page,
+        page_size=page_size,
+        total=total,
+    )

--- a/backend/app/services/room_service.py
+++ b/backend/app/services/room_service.py
@@ -1,0 +1,115 @@
+"""확정본 Room 단건 조회/수정/삭제 (+ patch_log 자동 기록)"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.core.geom import geojson_to_wkb
+from app.models.project import Project
+from app.models.room import Room
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.schemas.room import RoomResponse, RoomUpdate
+from app.services._patch_log_helpers import record_patch, snapshot_room
+from app.services.scene_version_service import _room_to_response
+
+
+def _get_owned_room(db: Session, room_id: UUID, user: User) -> Room:
+    stmt = (
+        select(Room)
+        .join(SceneVersion, Room.scene_version_id == SceneVersion.id)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            Room.id == str(room_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    r = db.execute(stmt).scalar_one_or_none()
+    if r is None:
+        raise AppError(
+            ErrorCode.ROOM_NOT_FOUND,
+            "Room not found.",
+            status_code=404,
+        )
+    return r
+
+
+def get_room(db: Session, room_id: UUID, user: User) -> RoomResponse:
+    return _room_to_response(_get_owned_room(db, room_id, user))
+
+
+def update_room(
+    db: Session,
+    room_id: UUID,
+    payload: RoomUpdate,
+    user: User,
+) -> RoomResponse:
+    room = _get_owned_room(db, room_id, user)
+    before = snapshot_room(room)
+
+    data = payload.model_dump(exclude_unset=True)
+    if "polygon_geom" in data:
+        room.polygon_geom = geojson_to_wkb(
+            data["polygon_geom"], "Polygon", "polygon_geom"
+        )
+    if "centroid_geom" in data:
+        room.centroid_geom = geojson_to_wkb(
+            data["centroid_geom"], "Point", "centroid_geom"
+        )
+    for field in (
+        "room_name",
+        "room_type",
+        "confidence",
+        "source_method",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(room, field, data[field])
+
+    after = snapshot_room(room)
+    record_patch(
+        db,
+        scene_version_id=room.scene_version_id,
+        user=user,
+        patch_type="update",
+        target_type="room",
+        target_id=room.id,
+        before=before,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(room)
+    except Exception:
+        db.rollback()
+        raise
+    return _room_to_response(room)
+
+
+def delete_room(db: Session, room_id: UUID, user: User) -> None:
+    room = _get_owned_room(db, room_id, user)
+    before = snapshot_room(room)
+    sv_id = room.scene_version_id
+    rid = room.id
+
+    record_patch(
+        db,
+        scene_version_id=sv_id,
+        user=user,
+        patch_type="delete",
+        target_type="room",
+        target_id=rid,
+        before=before,
+        after=None,
+    )
+    db.delete(room)
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/app/services/wall_service.py
+++ b/backend/app/services/wall_service.py
@@ -1,0 +1,117 @@
+"""확정본 Wall 단건 조회/수정/삭제 (+ patch_log 자동 기록)"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.core.geom import geojson_to_wkb
+from app.models.project import Project
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.models.wall import Wall
+from app.schemas.wall import WallResponse, WallUpdate
+from app.services._patch_log_helpers import record_patch, snapshot_wall
+from app.services.scene_version_service import _wall_to_response
+
+
+def _get_owned_wall(db: Session, wall_id: UUID, user: User) -> Wall:
+    stmt = (
+        select(Wall)
+        .join(SceneVersion, Wall.scene_version_id == SceneVersion.id)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            Wall.id == str(wall_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    w = db.execute(stmt).scalar_one_or_none()
+    if w is None:
+        raise AppError(
+            ErrorCode.WALL_NOT_FOUND,
+            "Wall not found.",
+            status_code=404,
+        )
+    return w
+
+
+def get_wall(db: Session, wall_id: UUID, user: User) -> WallResponse:
+    return _wall_to_response(_get_owned_wall(db, wall_id, user))
+
+
+def update_wall(
+    db: Session,
+    wall_id: UUID,
+    payload: WallUpdate,
+    user: User,
+) -> WallResponse:
+    wall = _get_owned_wall(db, wall_id, user)
+    before = snapshot_wall(wall)
+
+    data = payload.model_dump(exclude_unset=True)
+    if "centerline_geom" in data:
+        wall.centerline_geom = geojson_to_wkb(
+            data["centerline_geom"], "LineString", "centerline_geom"
+        )
+    if "polygon_geom" in data:
+        wall.polygon_geom = geojson_to_wkb(
+            data["polygon_geom"], "Polygon", "polygon_geom"
+        )
+    for field in (
+        "wall_role",
+        "thickness_m",
+        "height_m",
+        "material_label",
+        "confidence",
+        "source_method",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(wall, field, data[field])
+
+    after = snapshot_wall(wall)
+    record_patch(
+        db,
+        scene_version_id=wall.scene_version_id,
+        user=user,
+        patch_type="update",
+        target_type="wall",
+        target_id=wall.id,
+        before=before,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(wall)
+    except Exception:
+        db.rollback()
+        raise
+    return _wall_to_response(wall)
+
+
+def delete_wall(db: Session, wall_id: UUID, user: User) -> None:
+    wall = _get_owned_wall(db, wall_id, user)
+    before = snapshot_wall(wall)
+    sv_id = wall.scene_version_id
+    wid = wall.id
+
+    record_patch(
+        db,
+        scene_version_id=sv_id,
+        user=user,
+        patch_type="delete",
+        target_type="wall",
+        target_id=wid,
+        before=before,
+        after=None,
+    )
+    db.delete(wall)
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,11 @@ from app.routers.scene_versions import (
     scene_versions_router,
     floor_scene_versions_router,
 )
+from app.routers.rooms import router as rooms_router
+from app.routers.walls import router as walls_router
+from app.routers.openings import router as openings_router
+from app.routers.objects import router as objects_router
+from app.routers.patch_logs import router as patch_logs_router
 
 
 app = FastAPI(title="capstone2-backend", version="0.1.0")
@@ -90,3 +95,8 @@ app.include_router(draft_objects_router)
 app.include_router(promote_router)
 app.include_router(scene_versions_router)
 app.include_router(floor_scene_versions_router)
+app.include_router(rooms_router)
+app.include_router(walls_router)
+app.include_router(openings_router)
+app.include_router(objects_router)
+app.include_router(patch_logs_router)

--- a/backend/migrations/versions/20260511_0005_add_patch_logs.py
+++ b/backend/migrations/versions/20260511_0005_add_patch_logs.py
@@ -1,0 +1,70 @@
+"""add patch_logs table
+
+Revision ID: 20260511_0005
+Revises: 20260510_0004
+Create Date: 2026-05-11 09:00:00
+
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260511_0005"
+down_revision: Union[str, Sequence[str], None] = "20260510_0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "patch_logs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "scene_version_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("scene_versions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_by",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("patch_type", sa.String(length=20), nullable=False),
+        sa.Column("target_type", sa.String(length=20), nullable=False),
+        sa.Column(
+            "target_id", postgresql.UUID(as_uuid=False), nullable=False
+        ),
+        sa.Column(
+            "patch_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "idx_patch_logs_version_target",
+        "patch_logs",
+        ["scene_version_id", "target_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_patch_logs_version_target", table_name="patch_logs")
+    op.drop_table("patch_logs")


### PR DESCRIPTION
## Summary
- 확정본 구성 요소 단건 CRUD 12개 + Patch Log 조회 1개 = 총 13개 엔드포인트 구현 (명세 §8, §9 준수)
  - `GET/PATCH/DELETE /rooms/{id}` + walls/openings/objects 동일 패턴
  - `GET /scene-versions/{id}/patch-logs` — 페이지네이션 + `target_type` 필터
- DB 마이그레이션: `patch_logs` 테이블 신규 (scene_version_id, created_by, patch_type, target_type, target_id, patch_json, created_at + 인덱스)
- PATCH/DELETE 시 `patch_logs` 에 자동 INSERT (`patch_json={ before, after }`, before/after 는 전체 모델 스냅샷)
- Opening PATCH 의 `wall_id` 변경 시 같은 scene_version 소속인지 검증 (다르면 404 `WALL_NOT_FOUND`)
- 공통 헬퍼 `app/services/_patch_log_helpers.py`: 4 도메인 snapshot + record_patch
- SceneVersion → patch_logs relationship 추가 (`cascade="all, delete", passive_deletes=True`)
- 에러 코드 추가: `ROOM_NOT_FOUND`, `WALL_NOT_FOUND`, `OPENING_NOT_FOUND`, `OBJECT_NOT_FOUND`
- 권한: `{도메인} → scene_versions → projects.owner_user_id` 조인, 그 외 404
- 명세 vs 모델 정책 (#30 패턴 그대로): 모델 우선, 응답에서 alias 매핑

## Test plan
- [x] 정상 GET → 200
- [x] 다른 사용자가 GET/PATCH/DELETE → 404 `*_NOT_FOUND`
- [x] PATCH 부분 업데이트 (미지정 필드 보존)
- [x] PATCH 시 `patch_logs` 에 row 자동 INSERT, before/after 정확
- [x] Opening PATCH 의 `wall_id` 가 다른 scene_version 소속이면 404 `WALL_NOT_FOUND`
- [x] 잘못된 GeoJSON → 400 `INVALID_GEOMETRY`
- [x] DELETE → 204 + `patch_logs` 에 `patch_type=delete` 기록 (after=null)
- [x] DELETE 후 GET → 404
- [x] patch_logs 페이지네이션 + `target_type` 필터 동작
- [x] 잘못된 `target_type` → 400 `INVALID_REQUEST_BODY`
- [x] 다른 사용자 scene_version 의 patch logs 조회 → 404 `SCENE_VERSION_NOT_FOUND`
- [x] 인증 없이 호출 → 401 `UNAUTHORIZED`