### PR TITLE
feat: Material API (재질 목록 + RF profile + 후보 선택) (#34)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -55,6 +55,10 @@ class ErrorCode(StrEnum):
     OPENING_NOT_FOUND = "OPENING_NOT_FOUND"
     OBJECT_NOT_FOUND = "OBJECT_NOT_FOUND"
 
+    MATERIAL_NOT_FOUND = "MATERIAL_NOT_FOUND"
+    MATERIAL_RF_PROFILE_NOT_FOUND = "MATERIAL_RF_PROFILE_NOT_FOUND"
+    MATERIAL_HYPOTHESIS_NOT_FOUND = "MATERIAL_HYPOTHESIS_NOT_FOUND"
+
 
 class AppError(Exception):
     def __init__(self, code: ErrorCode, message: str, status_code: int):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,9 @@ from app.models.draft_opening import DraftOpening
 from app.models.draft_room import DraftRoom
 from app.models.draft_wall import DraftWall
 from app.models.floor import Floor
+from app.models.material import Material
+from app.models.material_hypothesis import MaterialHypothesis
+from app.models.material_rf_profile import MaterialRfProfile
 from app.models.measurement_link import MeasurementLink
 from app.models.measurement_point import MeasurementPoint
 from app.models.measurement_session import MeasurementSession
@@ -33,6 +36,9 @@ __all__ = [
     "Opening",
     "SceneObject",
     "PatchLog",
+    "Material",
+    "MaterialRfProfile",
+    "MaterialHypothesis",
     "MeasurementLink",
     "MeasurementSession",
     "MeasurementPoint",

--- a/backend/app/models/material.py
+++ b/backend/app/models/material.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Material(Base):
+    __tablename__ = "materials"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    material_code: Mapped[str] = mapped_column(
+        String(40), nullable=False, unique=True
+    )
+    material_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    category: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, server_default=text("true")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    rf_profiles = relationship(
+        "MaterialRfProfile",
+        back_populates="material",
+        cascade="all, delete",
+        passive_deletes=True,
+    )

--- a/backend/app/models/material_hypothesis.py
+++ b/backend/app/models/material_hypothesis.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class MaterialHypothesis(Base):
+    __tablename__ = "material_hypotheses"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    target_id: Mapped[str] = mapped_column(UUID(as_uuid=False), nullable=False)
+    material_name: Mapped[str] = mapped_column(String(60), nullable=False)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    source_method: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    is_selected: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, server_default=text("false")
+    )
+    evidence_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    scene_version = relationship("SceneVersion")

--- a/backend/app/models/material_rf_profile.py
+++ b/backend/app/models/material_rf_profile.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, Numeric, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class MaterialRfProfile(Base):
+    __tablename__ = "material_rf_profiles"
+    __table_args__ = (
+        Index(
+            "idx_material_rf_profiles_material_freq",
+            "material_id",
+            "freq_ghz",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    material_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("materials.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    freq_ghz: Mapped[Decimal] = mapped_column(Numeric(6, 3), nullable=False)
+    permittivity: Mapped[Decimal] = mapped_column(Numeric(8, 4), nullable=False)
+    conductivity: Mapped[Decimal] = mapped_column(Numeric(8, 6), nullable=False)
+    penetration_loss_db: Mapped[Decimal] = mapped_column(
+        Numeric(8, 3), nullable=False
+    )
+    reference_thickness_m: Mapped[Decimal] = mapped_column(
+        Numeric(6, 4), nullable=False
+    )
+    profile_version: Mapped[int] = mapped_column(
+        Integer(), nullable=False, server_default=text("1")
+    )
+    is_default: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, server_default=text("false")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    material = relationship("Material", back_populates="rf_profiles")

--- a/backend/app/routers/material_hypotheses.py
+++ b/backend/app/routers/material_hypotheses.py
@@ -1,0 +1,49 @@
+"""Material Hypothesis 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.material_hypothesis import MaterialHypothesisResponse
+from app.services import material_hypothesis_service
+
+
+wall_hypotheses_router = APIRouter(prefix="/walls", tags=["material-hypotheses"])
+hypotheses_router = APIRouter(
+    prefix="/material-hypotheses", tags=["material-hypotheses"]
+)
+
+
+@wall_hypotheses_router.get(
+    "/{wall_id}/material-hypotheses",
+    response_model=list[MaterialHypothesisResponse],
+    summary="벽의 재질 후보 목록",
+)
+def list_hypotheses_for_wall(
+    wall_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[MaterialHypothesisResponse]:
+    return material_hypothesis_service.list_hypotheses_for_wall(
+        db, wall_id=wall_id, user=current_user
+    )
+
+
+@hypotheses_router.post(
+    "/{hypothesis_id}/select",
+    response_model=MaterialHypothesisResponse,
+    summary="재질 후보 선택 (같은 wall 의 다른 후보 자동 false)",
+)
+def select_hypothesis(
+    hypothesis_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> MaterialHypothesisResponse:
+    return material_hypothesis_service.select_hypothesis(
+        db, hypothesis_id=hypothesis_id, user=current_user
+    )

--- a/backend/app/routers/materials.py
+++ b/backend/app/routers/materials.py
@@ -1,0 +1,49 @@
+"""Material 라우터"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.material import MaterialResponse, MaterialRfProfileResponse
+from app.services import material_service
+
+
+router = APIRouter(prefix="/materials", tags=["materials"])
+
+
+@router.get(
+    "",
+    response_model=list[MaterialResponse],
+    summary="재질 목록",
+)
+def list_materials(
+    is_active: Optional[bool] = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[MaterialResponse]:
+    return material_service.list_materials(db, is_active=is_active)
+
+
+@router.get(
+    "/{material_id}/rf-profile",
+    response_model=MaterialRfProfileResponse,
+    summary="재질의 RF 프로파일 (Sionna 입력용)",
+)
+def get_rf_profile(
+    material_id: UUID = Path(...),
+    freq_ghz: Optional[Decimal] = Query(
+        default=None, description="미지정 시 default profile 반환"
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> MaterialRfProfileResponse:
+    return material_service.get_rf_profile(
+        db, material_id=material_id, freq_ghz=freq_ghz
+    )

--- a/backend/app/schemas/material.py
+++ b/backend/app/schemas/material.py
@@ -1,0 +1,30 @@
+"""Material 도메인 DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class MaterialResponse(BaseModel):
+    id: UUID
+    material_code: str
+    material_name: str
+    category: Optional[str] = None
+    is_active: bool
+    created_at: datetime
+
+
+class MaterialRfProfileResponse(BaseModel):
+    id: UUID
+    material_id: UUID
+    freq_ghz: Decimal
+    permittivity: Decimal
+    conductivity: Decimal
+    penetration_loss_db: Decimal
+    reference_thickness_m: Decimal
+    profile_version: int
+    is_default: bool

--- a/backend/app/schemas/material_hypothesis.py
+++ b/backend/app/schemas/material_hypothesis.py
@@ -1,0 +1,22 @@
+"""Material Hypothesis DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class MaterialHypothesisResponse(BaseModel):
+    id: UUID
+    scene_version_id: UUID
+    target_type: str
+    target_id: UUID
+    material_name: str
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    is_selected: bool
+    evidence_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/services/material_hypothesis_service.py
+++ b/backend/app/services/material_hypothesis_service.py
@@ -1,0 +1,106 @@
+"""Material Hypothesis 조회/선택 서비스"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.material_hypothesis import MaterialHypothesis
+from app.models.project import Project
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.models.wall import Wall
+from app.schemas.material_hypothesis import MaterialHypothesisResponse
+
+
+def _get_owned_wall(db: Session, wall_id: UUID, user: User) -> Wall:
+    stmt = (
+        select(Wall)
+        .join(SceneVersion, Wall.scene_version_id == SceneVersion.id)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            Wall.id == str(wall_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    w = db.execute(stmt).scalar_one_or_none()
+    if w is None:
+        raise AppError(
+            ErrorCode.WALL_NOT_FOUND,
+            "Wall not found.",
+            status_code=404,
+        )
+    return w
+
+
+def _get_owned_hypothesis(
+    db: Session, hypothesis_id: UUID, user: User
+) -> MaterialHypothesis:
+    stmt = (
+        select(MaterialHypothesis)
+        .join(SceneVersion, MaterialHypothesis.scene_version_id == SceneVersion.id)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            MaterialHypothesis.id == str(hypothesis_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    h = db.execute(stmt).scalar_one_or_none()
+    if h is None:
+        raise AppError(
+            ErrorCode.MATERIAL_HYPOTHESIS_NOT_FOUND,
+            "Material hypothesis not found.",
+            status_code=404,
+        )
+    return h
+
+
+def list_hypotheses_for_wall(
+    db: Session, wall_id: UUID, user: User
+) -> list[MaterialHypothesisResponse]:
+    wall = _get_owned_wall(db, wall_id, user)
+    stmt = (
+        select(MaterialHypothesis)
+        .where(
+            MaterialHypothesis.scene_version_id == wall.scene_version_id,
+            MaterialHypothesis.target_type == "wall",
+            MaterialHypothesis.target_id == wall.id,
+        )
+        .order_by(MaterialHypothesis.confidence.desc().nullslast())
+    )
+    rows = db.execute(stmt).scalars().all()
+    return [
+        MaterialHypothesisResponse.model_validate(h, from_attributes=True)
+        for h in rows
+    ]
+
+
+def select_hypothesis(
+    db: Session, hypothesis_id: UUID, user: User
+) -> MaterialHypothesisResponse:
+    hypothesis = _get_owned_hypothesis(db, hypothesis_id, user)
+
+    db.execute(
+        update(MaterialHypothesis)
+        .where(
+            MaterialHypothesis.scene_version_id == hypothesis.scene_version_id,
+            MaterialHypothesis.target_type == hypothesis.target_type,
+            MaterialHypothesis.target_id == hypothesis.target_id,
+            MaterialHypothesis.id != hypothesis.id,
+            MaterialHypothesis.is_selected.is_(True),
+        )
+        .values(is_selected=False)
+    )
+    hypothesis.is_selected = True
+
+    try:
+        db.commit()
+        db.refresh(hypothesis)
+    except Exception:
+        db.rollback()
+        raise
+    return MaterialHypothesisResponse.model_validate(
+        hypothesis, from_attributes=True
+    )

--- a/backend/app/services/material_service.py
+++ b/backend/app/services/material_service.py
@@ -1,0 +1,58 @@
+"""Material 조회 서비스"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.material import Material
+from app.models.material_rf_profile import MaterialRfProfile
+from app.schemas.material import MaterialResponse, MaterialRfProfileResponse
+
+
+def list_materials(
+    db: Session, is_active: Optional[bool] = None
+) -> list[MaterialResponse]:
+    stmt = select(Material)
+    if is_active is not None:
+        stmt = stmt.where(Material.is_active.is_(is_active))
+    stmt = stmt.order_by(Material.material_code)
+    rows = db.execute(stmt).scalars().all()
+    return [MaterialResponse.model_validate(m, from_attributes=True) for m in rows]
+
+
+def get_rf_profile(
+    db: Session,
+    material_id: UUID,
+    freq_ghz: Optional[Decimal] = None,
+) -> MaterialRfProfileResponse:
+    material = db.execute(
+        select(Material).where(Material.id == str(material_id))
+    ).scalar_one_or_none()
+    if material is None:
+        raise AppError(
+            ErrorCode.MATERIAL_NOT_FOUND,
+            "Material not found.",
+            status_code=404,
+        )
+
+    stmt = select(MaterialRfProfile).where(
+        MaterialRfProfile.material_id == material.id
+    )
+    if freq_ghz is not None:
+        stmt = stmt.where(MaterialRfProfile.freq_ghz == freq_ghz)
+    else:
+        stmt = stmt.where(MaterialRfProfile.is_default.is_(True))
+
+    profile = db.execute(stmt).scalar_one_or_none()
+    if profile is None:
+        raise AppError(
+            ErrorCode.MATERIAL_RF_PROFILE_NOT_FOUND,
+            "RF profile not found for this material/frequency.",
+            status_code=404,
+        )
+    return MaterialRfProfileResponse.model_validate(profile, from_attributes=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,11 @@ from app.routers.walls import router as walls_router
 from app.routers.openings import router as openings_router
 from app.routers.objects import router as objects_router
 from app.routers.patch_logs import router as patch_logs_router
+from app.routers.materials import router as materials_router
+from app.routers.material_hypotheses import (
+    wall_hypotheses_router,
+    hypotheses_router,
+)
 
 
 app = FastAPI(title="capstone2-backend", version="0.1.0")
@@ -100,3 +105,6 @@ app.include_router(walls_router)
 app.include_router(openings_router)
 app.include_router(objects_router)
 app.include_router(patch_logs_router)
+app.include_router(materials_router)
+app.include_router(wall_hypotheses_router)
+app.include_router(hypotheses_router)

--- a/backend/migrations/versions/20260511_0006_add_materials.py
+++ b/backend/migrations/versions/20260511_0006_add_materials.py
@@ -1,0 +1,177 @@
+"""add materials + material_rf_profiles + seed default materials
+
+Revision ID: 20260511_0006
+Revises: 20260511_0005
+Create Date: 2026-05-11 14:00:00
+
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260511_0006"
+down_revision: Union[str, Sequence[str], None] = "20260511_0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SEED_MATERIALS = [
+    # (code, name, category, profiles[(freq_ghz, perm, cond, loss_db, ref_thick, is_default)])
+    (
+        "concrete",
+        "콘크리트",
+        "structural",
+        [
+            (2.4, 4.5, 0.014, 12.3, 0.20, True),
+            (5.0, 4.4, 0.030, 18.5, 0.20, False),
+        ],
+    ),
+    (
+        "drywall",
+        "석고보드",
+        "interior",
+        [
+            (2.4, 2.7, 0.005, 3.2, 0.013, True),
+            (5.0, 2.6, 0.010, 4.5, 0.013, False),
+        ],
+    ),
+    (
+        "glass",
+        "유리",
+        "glass",
+        [
+            (2.4, 6.3, 0.000, 2.0, 0.006, True),
+            (5.0, 6.2, 0.001, 3.0, 0.006, False),
+        ],
+    ),
+    (
+        "brick",
+        "벽돌",
+        "structural",
+        [
+            (2.4, 3.9, 0.020, 7.5, 0.10, True),
+            (5.0, 3.8, 0.040, 11.0, 0.10, False),
+        ],
+    ),
+    (
+        "wood",
+        "목재",
+        "interior",
+        [
+            (2.4, 2.0, 0.001, 2.8, 0.04, True),
+            (5.0, 1.9, 0.003, 4.0, 0.04, False),
+        ],
+    ),
+]
+
+
+def upgrade() -> None:
+    materials = op.create_table(
+        "materials",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("material_code", sa.String(length=40), nullable=False, unique=True),
+        sa.Column("material_name", sa.String(length=80), nullable=False),
+        sa.Column("category", sa.String(length=40), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    rf_profiles = op.create_table(
+        "material_rf_profiles",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "material_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("materials.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("freq_ghz", sa.Numeric(6, 3), nullable=False),
+        sa.Column("permittivity", sa.Numeric(8, 4), nullable=False),
+        sa.Column("conductivity", sa.Numeric(8, 6), nullable=False),
+        sa.Column("penetration_loss_db", sa.Numeric(8, 3), nullable=False),
+        sa.Column("reference_thickness_m", sa.Numeric(6, 4), nullable=False),
+        sa.Column(
+            "profile_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "idx_material_rf_profiles_material_freq",
+        "material_rf_profiles",
+        ["material_id", "freq_ghz"],
+    )
+
+    bind = op.get_bind()
+    for code, name, category, profiles in SEED_MATERIALS:
+        material_id = bind.execute(
+            sa.text(
+                "INSERT INTO materials (material_code, material_name, category) "
+                "VALUES (:code, :name, :cat) RETURNING id"
+            ),
+            {"code": code, "name": name, "cat": category},
+        ).scalar_one()
+        for freq, perm, cond, loss, thick, is_default in profiles:
+            bind.execute(
+                sa.text(
+                    "INSERT INTO material_rf_profiles "
+                    "(material_id, freq_ghz, permittivity, conductivity, "
+                    "penetration_loss_db, reference_thickness_m, is_default) "
+                    "VALUES (:mid, :freq, :perm, :cond, :loss, :thick, :is_default)"
+                ),
+                {
+                    "mid": material_id,
+                    "freq": freq,
+                    "perm": perm,
+                    "cond": cond,
+                    "loss": loss,
+                    "thick": thick,
+                    "is_default": is_default,
+                },
+            )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_material_rf_profiles_material_freq",
+        table_name="material_rf_profiles",
+    )
+    op.drop_table("material_rf_profiles")
+    op.drop_table("materials")


### PR DESCRIPTION
## Summary
- Material API 4개 엔드포인트 구현 (명세 §12 준수)
  - `GET /materials` — 사전 정의 재질 목록 (`?is_active` 필터)
  - `GET /materials/{material_id}/rf-profile` — 재질의 RF 특성 (`?freq_ghz` 미지정 시 default 반환)
  - `GET /walls/{wall_id}/material-hypotheses` — 벽의 재질 후보 목록 (confidence 내림차순)
  - `POST /material-hypotheses/{hypothesis_id}/select` — 후보 선택, 같은 wall 의 다른 후보 자동 false
- DB 마이그레이션 신규: `materials` + `material_rf_profiles` 테이블 + 시드 데이터
  - 시드: concrete / drywall / glass / brick / wood 5종, 각 2.4GHz / 5.0GHz RF profile (총 10개 row)
- 모델 3개 신규: `Material`, `MaterialRfProfile`, `MaterialHypothesis` (기존 테이블)
- 권한:
  - `/materials`, `/materials/{id}/rf-profile`: 인증만 통과하면 OK (전역 데이터)
  - `/walls/{id}/material-hypotheses`: wall → scene_version → project.owner_user_id 조인
  - `/material-hypotheses/{id}/select`: hypothesis → scene_version → project.owner_user_id 조인
- 에러 코드 추가: `MATERIAL_NOT_FOUND`, `MATERIAL_RF_PROFILE_NOT_FOUND`, `MATERIAL_HYPOTHESIS_NOT_FOUND`

## Test plan
- [x] 인증 없이 호출 → 401 `UNAUTHORIZED`
- [x] Materials 목록 정상 반환 (5개)
- [x] `?is_active=true/false` 필터 동작
- [x] RF profile 미지정 → `is_default=true` 반환
- [x] `?freq_ghz=5.0` → 해당 주파수 반환
- [x] 없는 freq → 404 `MATERIAL_RF_PROFILE_NOT_FOUND`
- [x] 없는 material → 404 `MATERIAL_NOT_FOUND`
- [x] 다른 사용자 wall hypotheses 조회 → 404 `WALL_NOT_FOUND`
- [x] hypotheses 응답 confidence 내림차순 정렬
- [x] 다른 사용자 select → 404 `MATERIAL_HYPOTHESIS_NOT_FOUND`
- [x] select 호출 시 같은 wall 의 다른 후보 자동 false 토글 (DB 레벨 확인)