### PR TITLE
feat: RF Run + Job API (시뮬레이션 큐 등록 + 조회) (#36)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -59,6 +59,9 @@ class ErrorCode(StrEnum):
     MATERIAL_RF_PROFILE_NOT_FOUND = "MATERIAL_RF_PROFILE_NOT_FOUND"
     MATERIAL_HYPOTHESIS_NOT_FOUND = "MATERIAL_HYPOTHESIS_NOT_FOUND"
 
+    RF_RUN_NOT_FOUND = "RF_RUN_NOT_FOUND"
+    JOB_NOT_FOUND = "JOB_NOT_FOUND"
+
 
 class AppError(Exception):
     def __init__(self, code: ErrorCode, message: str, status_code: int):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.draft_opening import DraftOpening
 from app.models.draft_room import DraftRoom
 from app.models.draft_wall import DraftWall
 from app.models.floor import Floor
+from app.models.job import Job
 from app.models.material import Material
 from app.models.material_hypothesis import MaterialHypothesis
 from app.models.material_rf_profile import MaterialRfProfile
@@ -14,6 +15,8 @@ from app.models.object import SceneObject
 from app.models.opening import Opening
 from app.models.patch_log import PatchLog
 from app.models.project import Project
+from app.models.rf_map import RfMap
+from app.models.rf_run import RfRun
 from app.models.room import Room
 from app.models.scene_draft import SceneDraft
 from app.models.scene_version import SceneVersion
@@ -39,6 +42,9 @@ __all__ = [
     "Material",
     "MaterialRfProfile",
     "MaterialHypothesis",
+    "RfRun",
+    "RfMap",
+    "Job",
     "MeasurementLink",
     "MeasurementSession",
     "MeasurementPoint",

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    project_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    floor_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("floors.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    job_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'queued'")
+    )
+    input_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    result_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    error_message: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )

--- a/backend/app/models/rf_map.py
+++ b/backend/app/models/rf_map.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class RfMap(Base):
+    __tablename__ = "rf_maps"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    rf_run_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("rf_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    map_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    resolution_cm: Mapped[int] = mapped_column(Integer(), nullable=False)
+    storage_url: Mapped[str] = mapped_column(Text(), nullable=False)
+    bounds_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    metrics_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    rf_run = relationship("RfRun", back_populates="rf_maps")

--- a/backend/app/models/rf_run.py
+++ b/backend/app/models/rf_run.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class RfRun(Base):
+    __tablename__ = "rf_runs"
+    __table_args__ = (
+        Index("idx_rf_runs_scene_version", "scene_version_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    project_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    floor_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("floors.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_type: Mapped[str] = mapped_column(
+        String(30), nullable=False, server_default=text("'quick_preview'")
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'queued'")
+    )
+    request_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    metrics_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    rf_maps = relationship(
+        "RfMap",
+        back_populates="rf_run",
+        cascade="all, delete",
+        passive_deletes=True,
+    )

--- a/backend/app/routers/jobs.py
+++ b/backend/app/routers/jobs.py
@@ -1,0 +1,54 @@
+"""Job 라우터"""
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.job import JobResponse
+from app.schemas.pagination import PaginatedResponse
+from app.services import job_service
+
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+@router.get(
+    "",
+    response_model=PaginatedResponse[JobResponse],
+    summary="Job 목록 (job_type/status 필터)",
+)
+def list_jobs(
+    job_type: Optional[str] = Query(default=None),
+    status: Optional[str] = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[JobResponse]:
+    return job_service.list_jobs(
+        db,
+        user=current_user,
+        page=page,
+        page_size=page_size,
+        job_type=job_type,
+        status=status,
+    )
+
+
+@router.get(
+    "/{job_id}",
+    response_model=JobResponse,
+    summary="Job 단건 조회",
+)
+def get_job(
+    job_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JobResponse:
+    return job_service.get_job(db, job_id=job_id, user=current_user)

--- a/backend/app/routers/rf_runs.py
+++ b/backend/app/routers/rf_runs.py
@@ -1,0 +1,57 @@
+"""RF Run 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.rf_map import RfMapResponse
+from app.schemas.rf_run import RfRunCreate, RfRunCreatedResponse, RfRunResponse
+from app.services import rf_run_service
+
+
+router = APIRouter(prefix="/rf-runs", tags=["rf-runs"])
+
+
+@router.post(
+    "",
+    response_model=RfRunCreatedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="RF 시뮬레이션 큐 등록",
+)
+def create_rf_run(
+    payload: RfRunCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RfRunCreatedResponse:
+    return rf_run_service.create_rf_run(db, payload=payload, user=current_user)
+
+
+@router.get(
+    "/{rf_run_id}",
+    response_model=RfRunResponse,
+    summary="RF 실행 상태/결과 조회",
+)
+def get_rf_run(
+    rf_run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RfRunResponse:
+    return rf_run_service.get_rf_run(db, rf_run_id=rf_run_id, user=current_user)
+
+
+@router.get(
+    "/{rf_run_id}/maps",
+    response_model=list[RfMapResponse],
+    summary="생성된 전파 맵 목록",
+)
+def list_rf_maps(
+    rf_run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[RfMapResponse]:
+    return rf_run_service.list_maps(db, rf_run_id=rf_run_id, user=current_user)

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,0 +1,22 @@
+"""Job DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class JobResponse(BaseModel):
+    id: UUID
+    project_id: UUID
+    floor_id: Optional[UUID] = None
+    job_type: str
+    status: str
+    input_json: dict[str, Any] = Field(default_factory=dict)
+    result_json: dict[str, Any] = Field(default_factory=dict)
+    error_message: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    created_at: datetime

--- a/backend/app/schemas/rf_map.py
+++ b/backend/app/schemas/rf_map.py
@@ -1,0 +1,19 @@
+"""RF Map DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class RfMapResponse(BaseModel):
+    id: UUID
+    rf_run_id: UUID
+    map_type: str
+    resolution_cm: int
+    storage_url: str
+    bounds_json: dict[str, Any] = Field(default_factory=dict)
+    metrics_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/app/schemas/rf_run.py
+++ b/backend/app/schemas/rf_run.py
@@ -1,0 +1,32 @@
+"""RF Run DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RfRunCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scene_version_id: UUID
+    run_type: Optional[str] = None
+    request_json: Optional[dict[str, Any]] = None
+
+
+class RfRunResponse(BaseModel):
+    id: UUID
+    project_id: UUID
+    floor_id: UUID
+    scene_version_id: UUID
+    run_type: str
+    status: str
+    request_json: dict[str, Any] = Field(default_factory=dict)
+    metrics_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+
+
+class RfRunCreatedResponse(RfRunResponse):
+    job_id: UUID

--- a/backend/app/services/job_service.py
+++ b/backend/app/services/job_service.py
@@ -1,0 +1,74 @@
+"""Job 조회"""
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.job import Job
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.job import JobResponse
+from app.schemas.pagination import PaginatedResponse
+
+
+def get_job(db: Session, job_id: UUID, user: User) -> JobResponse:
+    stmt = (
+        select(Job)
+        .join(Project, Job.project_id == Project.id)
+        .where(
+            Job.id == str(job_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    job = db.execute(stmt).scalar_one_or_none()
+    if job is None:
+        raise AppError(
+            ErrorCode.JOB_NOT_FOUND,
+            "Job not found.",
+            status_code=404,
+        )
+    return JobResponse.model_validate(job, from_attributes=True)
+
+
+def list_jobs(
+    db: Session,
+    user: User,
+    page: int,
+    page_size: int,
+    job_type: Optional[str] = None,
+    status: Optional[str] = None,
+) -> PaginatedResponse[JobResponse]:
+    base = (
+        select(Job)
+        .join(Project, Job.project_id == Project.id)
+        .where(Project.owner_user_id == user.id)
+    )
+    if job_type is not None:
+        base = base.where(Job.job_type == job_type)
+    if status is not None:
+        base = base.where(Job.status == status)
+
+    total = db.execute(
+        select(func.count()).select_from(base.subquery())
+    ).scalar_one()
+
+    rows = (
+        db.execute(
+            base.order_by(Job.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        .scalars()
+        .all()
+    )
+
+    return PaginatedResponse[JobResponse](
+        items=[JobResponse.model_validate(j, from_attributes=True) for j in rows],
+        page=page,
+        page_size=page_size,
+        total=total,
+    )

--- a/backend/app/services/rf_run_service.py
+++ b/backend/app/services/rf_run_service.py
@@ -1,0 +1,133 @@
+"""RF Run 큐 등록 + 조회"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.job import Job
+from app.models.project import Project
+from app.models.rf_map import RfMap
+from app.models.rf_run import RfRun
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.schemas.rf_map import RfMapResponse
+from app.schemas.rf_run import RfRunCreate, RfRunCreatedResponse, RfRunResponse
+
+
+def _get_owned_scene_version(
+    db: Session, scene_version_id: UUID, user: User
+) -> SceneVersion:
+    stmt = (
+        select(SceneVersion)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            SceneVersion.id == str(scene_version_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    sv = db.execute(stmt).scalar_one_or_none()
+    if sv is None:
+        raise AppError(
+            ErrorCode.SCENE_VERSION_NOT_FOUND,
+            "Scene version not found.",
+            status_code=404,
+        )
+    return sv
+
+
+def _get_owned_rf_run(db: Session, rf_run_id: UUID, user: User) -> RfRun:
+    stmt = (
+        select(RfRun)
+        .join(Project, RfRun.project_id == Project.id)
+        .where(
+            RfRun.id == str(rf_run_id),
+            Project.owner_user_id == user.id,
+        )
+    )
+    rr = db.execute(stmt).scalar_one_or_none()
+    if rr is None:
+        raise AppError(
+            ErrorCode.RF_RUN_NOT_FOUND,
+            "RF run not found.",
+            status_code=404,
+        )
+    return rr
+
+
+def _to_response(rr: RfRun) -> RfRunResponse:
+    return RfRunResponse(
+        id=rr.id,
+        project_id=rr.project_id,
+        floor_id=rr.floor_id,
+        scene_version_id=rr.scene_version_id,
+        run_type=rr.run_type,
+        status=rr.status,
+        request_json=rr.request_json or {},
+        metrics_json=rr.metrics_json or {},
+        created_at=rr.created_at,
+    )
+
+
+def create_rf_run(
+    db: Session, payload: RfRunCreate, user: User
+) -> RfRunCreatedResponse:
+    sv = _get_owned_scene_version(db, payload.scene_version_id, user)
+
+    rf_run = RfRun(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        scene_version_id=sv.id,
+        request_json=payload.request_json or {},
+        status="queued",
+    )
+    if payload.run_type is not None:
+        rf_run.run_type = payload.run_type
+    db.add(rf_run)
+    db.flush()
+
+    job = Job(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        job_type="rf_run",
+        status="queued",
+        input_json={
+            "rf_run_id": rf_run.id,
+            "scene_version_id": sv.id,
+            "request": payload.request_json or {},
+        },
+    )
+    db.add(job)
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    db.refresh(rf_run)
+    db.refresh(job)
+
+    summary = _to_response(rf_run)
+    return RfRunCreatedResponse(**summary.model_dump(), job_id=job.id)
+
+
+def get_rf_run(db: Session, rf_run_id: UUID, user: User) -> RfRunResponse:
+    return _to_response(_get_owned_rf_run(db, rf_run_id, user))
+
+
+def list_maps(
+    db: Session, rf_run_id: UUID, user: User
+) -> list[RfMapResponse]:
+    rr = _get_owned_rf_run(db, rf_run_id, user)
+    rows = (
+        db.execute(
+            select(RfMap)
+            .where(RfMap.rf_run_id == rr.id)
+            .order_by(RfMap.created_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+    return [RfMapResponse.model_validate(m, from_attributes=True) for m in rows]

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,8 @@ from app.routers.material_hypotheses import (
     wall_hypotheses_router,
     hypotheses_router,
 )
+from app.routers.rf_runs import router as rf_runs_router
+from app.routers.jobs import router as jobs_router
 
 
 app = FastAPI(title="capstone2-backend", version="0.1.0")
@@ -108,3 +110,5 @@ app.include_router(patch_logs_router)
 app.include_router(materials_router)
 app.include_router(wall_hypotheses_router)
 app.include_router(hypotheses_router)
+app.include_router(rf_runs_router)
+app.include_router(jobs_router)


### PR DESCRIPTION
## Summary
- RF Run + Job API 5개 엔드포인트 구현 (명세 §13, §15 준수)
  - `POST /rf-runs` — 시뮬레이션 큐 등록 (rf_runs + jobs row 동시 생성, status=queued, 응답 202 + job_id)
  - `GET /rf-runs/{id}` — 실행 상태/메트릭 조회
  - `GET /rf-runs/{id}/maps` — 생성된 전파 맵 목록 (created_at 내림차순)
  - `GET /jobs/{id}` — Job 단건 조회
  - `GET /jobs` — Job 목록 (job_type / status 필터, 페이지네이션)
- DB 마이그레이션 불필요 (rf_runs / rf_maps / jobs 테이블 모두 기존)
- 모델 3개 신규: `RfRun`, `RfMap`, `Job`. RfRun → RfMap relationship `cascade="all, delete", passive_deletes=True`
- 비동기 처리: POST 시 큐만 채우고 즉시 응답. 실제 Sionna 호출은 별도 worker 이슈에서 담당
- 권한:
  - POST: scene_version → project.owner_user_id 조인
  - GET rf-runs/maps: rf_run → project.owner_user_id
  - GET jobs/{id}, /jobs: project.owner_user_id 본인 소유만
- 에러 코드 추가: `RF_RUN_NOT_FOUND`, `JOB_NOT_FOUND`
- 명세 vs 모델 정책 (#30 패턴): 모델 우선. 명세 §15 의 `progress` 필드는 모델에 없어 응답에서 빠짐

## Test plan
- [x] 다른 사용자 scene_version 으로 POST → 404 `SCENE_VERSION_NOT_FOUND`
- [x] 인증 없이 호출 → 401 `UNAUTHORIZED`
- [x] 정상 POST → 202 + rf_runs/jobs row 동시 생성 (DB 레벨 확인)
- [x] 다른 사용자 rf_run 조회 → 404 `RF_RUN_NOT_FOUND`
- [x] 본인 rf_run 단건 조회 (status=queued)
- [x] 빈 maps 조회 → 200 + 빈 배열
- [x] map row INSERT 후 조회 → 정상 반환
- [x] 다른 사용자 job 조회 → 404 `JOB_NOT_FOUND`
- [x] 본인 job 단건 (`input_json.rf_run_id` 정확)
- [x] /jobs 목록 본인 소유만 반환
- [x] `?job_type=rf_run` / `?status=queued` 필터 동작
- [x] 다른 사용자 /jobs 조회 시 본인 job 안 섞임