### PR TITLE
fix: 벽 추출 후처리 개선 (가장자리 제거 + 모서리 닫기)

### DIFF
--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -27,8 +27,9 @@ class FusionService:
         if p.suffix == ".npy":
             try:
                 prob = np.load(str(p))
+                # threshold 미지정 시 wall_extraction 내부에서 Otsu 로 자동 결정
                 raw_coords = wall_extractor.execute_from_prob_map(
-                    p, threshold=0.5, detections=detections
+                    p, threshold=None, detections=detections
                 )
             except Exception as e:
                 logger.error(f"❌ .npy 로드 중 오류: {e}")
@@ -98,23 +99,9 @@ class FusionService:
         target_path = ml_output.wall_segmentation.prob_map_path or ml_output.wall_segmentation.mask_path
         raw_walls = self.extract_walls_from_mask(target_path, ml_output.detections)
 
-        next_id = len(raw_walls)
-        virtual_walls = []
-        for det in ml_output.detections:
-            if det.class_name in ["door", "window"]:
-                bx1, by1, bx2, by2 = det.bbox_xyxy
-                is_horizontal = (bx2 - bx1) > (by2 - by1)
-                mid = (by1 + by2) / 2 if is_horizontal else (bx1 + bx2) / 2
-                virtual_walls.append(Wall(
-                    id=str(next_id), 
-                    x1=float(bx1) if is_horizontal else float(mid),
-                    y1=float(mid) if is_horizontal else float(by1),
-                    x2=float(bx2) if is_horizontal else float(mid),
-                    y2=float(mid) if is_horizontal else float(by2)
-                ))
-                next_id += 1
-
-        calibrated_walls = geo_service.calibrate_walls(raw_walls + virtual_walls, ml_output.detections)
+        # opening 위치는 wall_extraction._fill_opening_gaps 에서 이미 메우므로
+        # 여기서 virtual_walls 를 또 추가하지 않음 (중복 wall 방지)
+        calibrated_walls = geo_service.calibrate_walls(raw_walls, ml_output.detections)
         extracted_rooms  = geo_service.extract_rooms(calibrated_walls)
         topology_result  = topo_service.analyze(extracted_rooms, ml_output.detections)
 

--- a/backend/app/services/wall_extraction.py
+++ b/backend/app/services/wall_extraction.py
@@ -205,6 +205,21 @@ class WallExtractor:
 
     # ── 6. 짧은 선분 제거 ─────────────────────────────────────────────────
 
+    def _filter_border(self, lines: List, img_shape: Tuple, margin_ratio: float = 0.01) -> List:
+        """이미지 가장자리에 붙은 라인(캔버스 경계 잡힌 것) 제거."""
+        h, w = img_shape[:2]
+        margin = max(5, int(min(h, w) * margin_ratio))
+        result = []
+        for x1, y1, x2, y2 in lines:
+            on_left = x1 < margin and x2 < margin
+            on_right = x1 > w - margin and x2 > w - margin
+            on_top = y1 < margin and y2 < margin
+            on_bottom = y1 > h - margin and y2 > h - margin
+            if on_left or on_right or on_top or on_bottom:
+                continue
+            result.append([x1, y1, x2, y2])
+        return result
+
     def _filter_short(self, lines: List, img_shape: Tuple) -> List:
         h, w = img_shape[:2]
         if not lines:
@@ -431,8 +446,8 @@ class WallExtractor:
         snapped   = self._snap_endpoints(snapped, tol=20.0)
         filtered  = self._filter_short(snapped, skeleton.shape)
         
-        # 3. 신뢰도 필터
-        filtered  = self._filter_by_confidence(filtered, prob, min_conf=0.6)
+        # 3. 신뢰도 필터 (완화: 0.6 → 0.4. mask 자체가 이미 prob>thr 로 1차 필터된 상태)
+        filtered  = self._filter_by_confidence(filtered, prob, min_conf=0.4)
 
         filled = self._fill_opening_gaps(filtered, detections or [])
         filled = self._merge_lines(filled, pos_thresh=int(wall_thickness * 3.0))
@@ -448,6 +463,21 @@ class WallExtractor:
                     float((p1 - v * 10)[0]), float((p1 - v * 10)[1]),
                     float((p2 + v * 10)[0]), float((p2 + v * 10)[1]),
                 ])
+
+        # 끊긴 끝점 → 가장 가까운 직각 벽으로 연장
+        result = self._snap_intersections(result, tol=40.0)
+        result = self._snap_endpoints(result, tol=35.0)
+        # dangling extend 전에 H/V 강제 정렬 + 비축 라인 제거 (대각선 부작용 차단)
+        result = self._snap_to_hv(result)
+        result = self._filter_hv(result, angle_thresh=5.0)
+        result = self._extend_dangling_endpoints(result, max_extend=200.0, snap_tol=15.0)
+        result = self._snap_intersections(result, tol=20.0)
+
+        # 잔여 중복 라인 합치기 (1~2픽셀 차이로 안 합쳐진 것들) + 길이 0 제거
+        result = self._merge_lines(result, pos_thresh=10)
+        result = [l for l in result if (l[2] - l[0]) ** 2 + (l[3] - l[1]) ** 2 >= 1.0]
+        # 이미지 가장자리에 잡힌 캔버스 경계 라인 제거
+        result = self._filter_border(result, skeleton.shape, margin_ratio=0.01)
 
         self._save_debug(skeleton, result, detections or [])
         return result


### PR DESCRIPTION
## Summary
벽 추출 후처리(`wall_extraction.py`) 알고리즘 개선. 동일 도면에서 walls 39 → 9, rooms 0 → 3.

### 주요 변경
- `_extend_dangling_endpoints` 호출을 `execute_from_prob_map` 끝에 추가 (mask 버전과 동일하게) — 끊긴 벽 끝점이 가까운 직각 벽으로 자동 연장 → 외곽 박스 닫힘 → rooms 추출 가능
- `_snap_to_hv` + `_filter_hv(angle_thresh=5)` 를 dangling extend 전에 추가 — 대각선 부작용 차단
- 끝부분에 `_merge_lines(pos_thresh=10)` + 길이 0 라인 제거 — `_snap_endpoints` 가 만든 zero-length wall 제거
- `_filter_border` 신규 — 캔버스 경계에 잡힌 외곽 점선 제거
- `_filter_by_confidence` `min_conf` 0.6 → 0.4 — mask 단계에서 이미 1차 필터된 라인을 다시 0.6 컷 하던 이중 필터링 완화
- `fusion_service` 의 `virtual_walls` 추가 로직 제거 — `wall_extraction._fill_opening_gaps` 와 중복으로 들어가면서 짧은 벽 ~27개 추가 발생하던 문제 해결

### 결과 (동일 도면 기준)
| 지표 | 이전 | 이후 |
|---|---|---|
| walls | 39 | 9 |
| rooms | 0 | 3 |
| 가장자리 노이즈 | 큰 라인 다수 | 거의 사라짐 |
| 외곽 박스 | 4모서리 끊김 | 닫힘 |
| 길이 0 wall | 2개 | 0 |
| opening 위치 중복 가짜 wall | 다수 | 없음 |

## Test plan
- [x] AI 서버(UNet+YOLO) 띄우고 동일 도면 분석 — walls 9, rooms 3, 외곽 닫힘 확인
- [x] 디버그 이미지 (`backend/data/masks/eee.png`) 시각 확인 — 외곽 박스 깔끔, 내부 가로/세로 분리벽 잡힘
- [x] 가장자리 캔버스 경계 라인 제거 확인
- [x] zero-length wall 제거 확인 (min_len > 0)

### 알려진 한계
- UNet 출력 자체에 약한 내부 분리벽 신호 한계 → 일부 방은 사용자가 `PATCH /draft-walls/{id}` 등으로 직접 보강 필요
- 다른 도면들 케이스별 추가 튜닝 가능