### PR TITLE
feat: Asset 기반 Scene Draft 분석 API 추가 (#41)

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -13,7 +13,11 @@ from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.asset import AssetResponse
-from app.services import asset_service
+from app.schemas.scene_draft import (
+    AnalyzeFromAssetRequest,
+    AnalyzeFromAssetResponse,
+)
+from app.services import asset_service, scene_draft_service
 
 
 
@@ -88,3 +92,22 @@ def delete_asset(
 ) -> None:
     asset_service.delete_asset(db=db, asset_id=asset_id, user=current_user)
     return None
+
+
+@assets_router.post(
+    "/{asset_id}/analyze",
+    response_model=AnalyzeFromAssetResponse,
+    summary="Asset 도면 분석 → Scene Draft 생성 (source_asset_id 채워짐)",
+)
+async def analyze_asset(
+    payload: AnalyzeFromAssetRequest,
+    asset_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> AnalyzeFromAssetResponse:
+    return await scene_draft_service.analyze_from_asset(
+        db=db,
+        asset_id=asset_id,
+        real_width_m=payload.real_width_m,
+        current_user=current_user,
+    )

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -33,6 +33,19 @@ class SaveSceneDraftRequestDTO(BaseModel):
 class SaveSceneDraftResultDTO(BaseModel):
     scene_draft_id: str
 
+
+class AnalyzeFromAssetRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    real_width_m: float = 10.0
+
+
+class AnalyzeFromAssetResponse(BaseModel):
+    status: str
+    scene_draft_id: str
+    asset_id: str
+    scene: SceneSchema
+
 # ============================================
 # 단건 조회 응답 (GET /scene-drafts/{id})
 # ============================================

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -27,10 +27,12 @@ from app.models import (
     User,
 )
 from app.schemas.scene_draft import (
+    AnalyzeFromAssetResponse,
     SaveSceneDraftRequestDTO,
     SaveSceneDraftResultDTO,
     SceneDraftDetailResponse,
-    SceneDraftSummaryResponse
+    SceneDraftSummaryResponse,
+    UploadStorageMetadataDTO,
 )
 
 
@@ -136,6 +138,7 @@ def save_scene_draft(
     db: Session,
     request_dto: SaveSceneDraftRequestDTO,
     current_user: User,
+    source_asset_id: str | None = None,
 ) -> SaveSceneDraftResultDTO:
     resolved_project_id, resolved_floor_id = _resolve_project_floor(
         db, request_dto.project_id, request_dto.floor_id, current_user,
@@ -152,7 +155,7 @@ def save_scene_draft(
         project_id=resolved_project_id,
         floor_id=resolved_floor_id,
         source_mode=DEFAULT_DRAFT_SOURCE_MODE,
-        source_asset_id=None,
+        source_asset_id=source_asset_id,
         source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
         summary_json=summary_json,
         status="draft",
@@ -237,6 +240,80 @@ def save_scene_draft(
             f"Failed to persist scene draft and draft entities: {exc}",
             500,
         ) from exc
+
+
+async def analyze_from_asset(
+    db: Session,
+    asset_id: UUID,
+    real_width_m: float,
+    current_user: User,
+) -> AnalyzeFromAssetResponse:
+    """이미 등록된 Asset 도면을 분석해서 Scene Draft 생성."""
+    from pathlib import Path
+
+    from app.services.asset_service import _get_owned_asset_or_404
+    from app.services.fusion_service import fusion_service
+
+    asset, _floor, _project = _get_owned_asset_or_404(db, asset_id, current_user)
+
+    storage_path = Path(asset.storage_url)
+    if not storage_path.exists():
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            f"Asset file not found on storage: {asset.storage_url}",
+            status_code=500,
+        )
+
+    try:
+        content = storage_path.read_bytes()
+    except OSError as exc:
+        raise AppError(
+            ErrorCode.FILE_SAVE_FAILED,
+            f"Failed to read asset file: {exc}",
+            status_code=500,
+        ) from exc
+
+    filename = storage_path.name
+
+    try:
+        scene = await fusion_service.process_image_to_scene_async(
+            image_bytes=content,
+            filename=filename,
+            real_width_m=real_width_m,
+        )
+    except AppError:
+        raise
+    except Exception as exc:
+        raise AppError(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Floorplan analysis failed: {exc}",
+            status_code=500,
+        ) from exc
+
+    request_dto = SaveSceneDraftRequestDTO(
+        scene=scene,
+        upload=UploadStorageMetadataDTO(
+            provider="local",
+            original_filename=filename,
+            content_type=asset.mime_type,
+            size_bytes=asset.file_size_bytes,
+            local_saved_path=str(storage_path),
+        ),
+        project_id=asset.project_id,
+        floor_id=asset.floor_id,
+        created_by=current_user.email,
+    )
+
+    result = save_scene_draft(
+        db, request_dto, current_user, source_asset_id=asset.id
+    )
+
+    return AnalyzeFromAssetResponse(
+        status="ok",
+        scene_draft_id=result.scene_draft_id,
+        asset_id=asset.id,
+        scene=scene,
+    )
 
 
 def get_scene_draft(


### PR DESCRIPTION
## Summary
- 신규 엔드포인트 `POST /assets/{asset_id}/analyze` 추가 (명세 §6.1.1)
  - 이미 등록된 Asset 도면을 가리켜 분석 → Scene Draft 생성
  - 응답에 `scene_draft_id`, `asset_id`, `scene` 포함
- 새 DTO: `AnalyzeFromAssetRequest` (`real_width_m`, `extra="forbid"`), `AnalyzeFromAssetResponse`
- `scene_draft_service.analyze_from_asset` 신규 함수
  - 본인 소유 asset 권한 체크 (`_get_owned_asset_or_404` 재사용)
  - asset.storage_url 에서 파일 read → AI 분석 → save_scene_draft (`source_asset_id=asset.id`)
- `save_scene_draft` 시그니처에 `source_asset_id` 옵션 추가 (기존 호출은 None 으로 동작 유지)
- 권한: asset → floor → project.owner_user_id 조인. 그 외 404 `ASSET_NOT_FOUND`
- 기존 `POST /upload/floorplan/analyze` 흐름은 그대로 유지 (호환성)

## 동작 차이

| API | 입력 | source_asset_id | 자산 등록 |
|---|---|---|---|
| `/upload/floorplan/analyze` (기존) | multipart 도면 | NULL | 안 함 |
| `/assets/{id}/analyze` (신규) | JSON `{real_width_m}` | asset_id | 사전 등록 필요 |

## Test plan
- [x] 인증 없이 호출 → 401 `UNAUTHORIZED`
- [x] 다른 사용자 asset 호출 → 404 `ASSET_NOT_FOUND`
- [x] 존재하지 않는 asset → 404 `ASSET_NOT_FOUND`
- [x] 알 수 없는 필드 (`extra="forbid"`) → 422
- [x] 본인 소유 asset 정상 분석 → 200, walls/rooms 추출됨
- [x] `scene_drafts.source_asset_id` 가 요청한 asset_id 와 일치 (DB 확인)
- [x] 같은 asset 두 번 호출 → 두 개의 다른 scene_draft 생성 (재분석 가능)
- [x] 기존 `/upload/floorplan/analyze` 호출 → `source_asset_id=NULL` 유지 (회귀 없음)