### PR TITLE
refactor: 프론트 API 클라이언트/타입을 api명세서.md 와 정합

### DIFF
--- a/frontend/src/api/asset.ts
+++ b/frontend/src/api/asset.ts
@@ -1,8 +1,9 @@
 import { api } from './client';
 import type { UUID } from '@/types/common';
-import type { Asset, AssetListResponse, AssetType, UploadAssetParams } from '@/types/asset';
+import type { Asset, AssetType, UploadAssetParams } from '@/types/asset';
 
 export const assetApi = {
+  // §5.1 POST /floors/{floor_id}/assets (multipart)
   upload: (floorId: UUID, { file, asset_type }: UploadAssetParams) => {
     const fd = new FormData();
     fd.append('file', file);
@@ -14,12 +15,13 @@ export const assetApi = {
       .then((r) => r.data);
   },
 
+  // §5.2 GET /floors/{floor_id}/assets  — 백엔드가 plain array 반환
   listByFloor: (floorId: UUID, params?: { asset_type?: AssetType }) =>
-    api
-      .get<AssetListResponse>(`/floors/${floorId}/assets`, { params })
-      .then((r) => r.data.items),
+    api.get<Asset[]>(`/floors/${floorId}/assets`, { params }).then((r) => r.data),
 
+  // §5.3 GET /assets/{asset_id}
   get: (assetId: UUID) => api.get<Asset>(`/assets/${assetId}`).then((r) => r.data),
 
+  // §5.3 DELETE /assets/{asset_id}
   remove: (assetId: UUID) => api.delete<void>(`/assets/${assetId}`).then((r) => r.data),
 };

--- a/frontend/src/api/scene-draft.ts
+++ b/frontend/src/api/scene-draft.ts
@@ -2,13 +2,19 @@ import { api } from './client';
 import type { Paginated, UUID } from '@/types/common';
 import type {
   AnalyzeFloorplanResponse,
+  AnalyzeFromAssetResponse,
   DraftObject,
   DraftOpening,
   DraftRoom,
   DraftWall,
   SceneDraft,
   SceneDraftStatus,
+  SceneDraftSummary,
 } from '@/types/scene';
+
+// AI 분석은 수십 초 ~ 1분 이상 걸릴 수 있어 axios 글로벌 30s 로는 부족함.
+// (백엔드 비동기 전환되면 빠른 응답으로 바뀌어 이 override 가 사라질 예정)
+const ANALYZE_TIMEOUT_MS = 180_000;
 
 export interface AnalyzeFloorplanParams {
   file: File;
@@ -16,6 +22,11 @@ export interface AnalyzeFloorplanParams {
   project_id?: UUID;
   floor_id?: UUID;
   created_by?: string;
+}
+
+export interface AnalyzeFromAssetParams {
+  asset_id: UUID;
+  real_width_m: number;
 }
 
 export interface SceneDraftListParams {
@@ -27,6 +38,7 @@ export interface SceneDraftListParams {
 }
 
 export const sceneDraftApi = {
+  // §6.1 POST /upload/floorplan/analyze
   analyzeFloorplan: ({ file, ...rest }: AnalyzeFloorplanParams) => {
     const fd = new FormData();
     fd.append('file', file);
@@ -37,16 +49,32 @@ export const sceneDraftApi = {
     return api
       .post<AnalyzeFloorplanResponse>('/upload/floorplan/analyze', fd, {
         headers: { 'Content-Type': 'multipart/form-data' },
+        timeout: ANALYZE_TIMEOUT_MS,
       })
       .then((r) => r.data);
   },
 
-  list: (params?: SceneDraftListParams) =>
-    api.get<Paginated<SceneDraft>>('/scene-drafts', { params }).then((r) => r.data),
+  // §6.1.1 POST /assets/{asset_id}/analyze
+  analyzeFromAsset: ({ asset_id, real_width_m }: AnalyzeFromAssetParams) =>
+    api
+      .post<AnalyzeFromAssetResponse>(
+        `/assets/${asset_id}/analyze`,
+        { real_width_m },
+        { timeout: ANALYZE_TIMEOUT_MS },
+      )
+      .then((r) => r.data),
 
+  // §6.3 GET /scene-drafts  — 자식 배열 없는 summary 응답
+  list: (params?: SceneDraftListParams) =>
+    api.get<Paginated<SceneDraftSummary>>('/scene-drafts', { params }).then((r) => r.data),
+
+  // §6.2 GET /scene-drafts/{id}
   get: (id: UUID) => api.get<SceneDraft>(`/scene-drafts/${id}`).then((r) => r.data),
 
+  // §6.5 DELETE /scene-drafts/{id}
   remove: (id: UUID) => api.delete<void>(`/scene-drafts/${id}`).then((r) => r.data),
+
+  // §6.4 Draft 자식 리소스 CRUD ----------------------------------------------
 
   // Rooms
   patchRoom: (roomId: UUID, body: Partial<DraftRoom>) =>

--- a/frontend/src/hooks/use-scene-draft.ts
+++ b/frontend/src/hooks/use-scene-draft.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { sceneDraftApi, type AnalyzeFloorplanParams } from '@/api/scene-draft';
+import {
+  sceneDraftApi,
+  type AnalyzeFloorplanParams,
+  type AnalyzeFromAssetParams,
+} from '@/api/scene-draft';
 import type { UUID } from '@/types/common';
 
 export function useDraftsForFloor(projectId: UUID | null, floorId: UUID | null) {
@@ -24,10 +28,22 @@ export function useSceneDraft(draftId: UUID | null) {
   });
 }
 
+/** §6.1 — 신규 도면 업로드 + 즉시 분석 */
 export function useAnalyzeFloorplan() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (params: AnalyzeFloorplanParams) => sceneDraftApi.analyzeFloorplan(params),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['scene-drafts'] });
+    },
+  });
+}
+
+/** §6.1.1 — 이미 등록된 Asset 도면을 재분석. 권장 흐름. */
+export function useAnalyzeFromAsset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: AnalyzeFromAssetParams) => sceneDraftApi.analyzeFromAsset(params),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['scene-drafts'] });
     },

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -6,6 +6,7 @@ import {
   useAnalyzeFloorplan,
   useDeleteSceneDraft,
   useDraftsForFloor,
+  useSceneDraft,
 } from '@/hooks/use-scene-draft';
 import { useFloorVersions, usePromoteDraft } from '@/hooks/use-scene-version';
 import { CanvasToolbar } from '@/features/editor/CanvasToolbar';
@@ -52,7 +53,12 @@ export default function EditorPage() {
   const [pendingFileName, setPendingFileName] = useState<string | null>(null);
   const [selected, setSelected] = useState<SelectedObject | null>(DEMO_SELECTED);
 
-  const activeDraft = draftsQuery.data?.items.find((d) => d.status === 'draft') ?? null;
+  // list 응답은 summary (자식 배열 없음). 상세는 별도 GET 으로 가져와야 함.
+  const activeDraftSummary =
+    draftsQuery.data?.items.find((d) => d.status === 'draft') ?? null;
+  const activeDraftQuery = useSceneDraft(activeDraftSummary?.id ?? null);
+  const activeDraft = activeDraftQuery.data ?? null;
+
   const versions = versionsQuery.data ?? [];
   const nextVersionNo =
     versions.length > 0 ? Math.max(...versions.map((v) => v.version_no)) + 1 : 1;
@@ -69,10 +75,11 @@ export default function EditorPage() {
   };
 
   const handlePromote = () => {
-    if (!activeDraft) return;
+    const draftId = activeDraftSummary?.id ?? activeDraft?.id;
+    if (!draftId) return;
     promote.mutate(
       {
-        draftId: activeDraft.id,
+        draftId,
         body: { version_no: nextVersionNo, is_current: true },
       },
       { onSuccess: setJustPromoted },
@@ -80,8 +87,9 @@ export default function EditorPage() {
   };
 
   const handleResetDraft = () => {
-    if (!activeDraft) return;
-    removeDraft.mutate(activeDraft.id);
+    const draftId = activeDraftSummary?.id ?? activeDraft?.id;
+    if (!draftId) return;
+    removeDraft.mutate(draftId);
   };
 
   const openFilePicker = () => fileInputRef.current?.click();
@@ -94,10 +102,11 @@ export default function EditorPage() {
     });
     return () => clearActions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeDraft?.id, nextVersionNo]);
+  }, [activeDraftSummary?.id, nextVersionNo]);
 
   const isBusy = analyze.isPending;
-  const showOverlay = !floorId || !!justPromoted || isBusy || !!activeDraft;
+  const showOverlay =
+    !floorId || !!justPromoted || isBusy || !!activeDraftSummary;
 
   return (
     <div className="flex h-full">
@@ -145,6 +154,8 @@ export default function EditorPage() {
                   readError(promote.error) ?? readError(removeDraft.error) ?? undefined
                 }
               />
+            ) : activeDraftSummary ? (
+              <BusyOverlay title="Draft 불러오는 중..." />
             ) : null}
           </OverlayLayer>
         )}

--- a/frontend/src/types/asset.ts
+++ b/frontend/src/types/asset.ts
@@ -2,15 +2,16 @@ import type { ISODateString, UUID } from './common';
 
 export type AssetType = 'floorplan' | 'photo' | 'document' | string;
 
+// §5.1 응답 (POST /floors/{floor_id}/assets) 및 §5.3 GET /assets/{id}
 export interface Asset {
   id: UUID;
-  floor_id: UUID;
+  floor_id: UUID | null;
   uploaded_by: UUID | null;
   asset_type: AssetType;
-  source_format: string;
+  source_format: string | null;
   storage_url: string;
-  mime_type: string;
-  file_size_bytes: number;
+  mime_type: string | null;
+  file_size_bytes: number | null;
   metadata_json: Record<string, unknown>;
   created_at: ISODateString;
 }
@@ -18,9 +19,4 @@ export interface Asset {
 export interface UploadAssetParams {
   file: File;
   asset_type: AssetType;
-}
-
-/** Asset list response is a plain `{ items }` envelope (not paginated). */
-export interface AssetListResponse {
-  items: Asset[];
 }

--- a/frontend/src/types/scene.ts
+++ b/frontend/src/types/scene.ts
@@ -3,86 +3,192 @@ import type { ISODateString, UUID } from './common';
 export type SceneDraftStatus = 'draft' | 'promoted' | 'archived';
 export type SceneSourceMode = 'floorplan_image' | 'manual' | string;
 
+// ============================================
+// Draft child entities (GET /scene-drafts/{id})
+// 백엔드 SceneDraftDetailResponse 의 nested 응답 모양과 일치.
+// Decimal 필드는 pydantic v2 가 JSON 직렬화 시 문자열로 내려보냄.
+// 도형은 현재 응답에 직접 노출되지 않음 — metadata_json.raw 에 보존 (백엔드 합의 사항).
+// ============================================
+
+export interface DraftRoom {
+  id: UUID;
+  scene_draft_id: UUID;
+  room_name: string | null;
+  room_type: string | null;
+  confidence: string | null;
+  source_method: string | null;
+  polygon_geom?: Record<string, unknown> | null;
+  centroid_geom?: Record<string, unknown> | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
+}
+
 export interface DraftWall {
   id: UUID;
   scene_draft_id: UUID;
-  start: { x: number; y: number };
-  end: { x: number; y: number };
-  thickness?: number;
-  material_id?: UUID | null;
-  metadata_json?: Record<string, unknown>;
+  wall_role: string;
+  thickness_m: string;
+  height_m: string | null;
+  material_label: string | null;
+  confidence: string | null;
+  source_method: string | null;
+  centerline_geom?: Record<string, unknown> | null;
+  polygon_geom?: Record<string, unknown> | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
 }
 
 export interface DraftOpening {
   id: UUID;
   scene_draft_id: UUID;
-  wall_id?: UUID | null;
-  type?: 'door' | 'window' | string;
-  position?: { x: number; y: number };
-  width?: number;
-  metadata_json?: Record<string, unknown>;
-}
-
-export interface DraftRoom {
-  id: UUID;
-  scene_draft_id: UUID;
-  room_type?: string;
-  polygon?: Array<{ x: number; y: number }>;
-  metadata_json?: Record<string, unknown>;
+  wall_id: UUID | null;
+  opening_type: string;
+  width_m: string;
+  height_m: string;
+  sill_height_m: string | null;
+  confidence: string | null;
+  source_method: string | null;
+  line_geom?: Record<string, unknown> | null;
+  polygon_geom?: Record<string, unknown> | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
 }
 
 export interface DraftObject {
   id: UUID;
   scene_draft_id: UUID;
-  object_type?: string;
-  bbox?: { x: number; y: number; w: number; h: number; rotation?: number };
-  material_id?: UUID | null;
-  metadata_json?: Record<string, unknown>;
+  object_type: string;
+  confidence: string | null;
+  source_method: string | null;
+  point_geom?: Record<string, unknown> | null;
+  z_m: string | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
 }
 
-export interface SceneDraft {
+// ============================================
+// Scene Draft  §6
+// 목록(§6.3)과 단건(§6.2) 응답 모양이 다름:
+//  - SceneDraftSummary: 메타만 (rooms/walls/openings/objects 없음)
+//  - SceneDraft (detail): 자식 배열 포함
+// ============================================
+
+export interface SceneDraftSummary {
   id: UUID;
   project_id: UUID;
   floor_id: UUID;
   source_mode: SceneSourceMode;
   source_asset_id: UUID | null;
-  source_method: string;
-  summary_json: Record<string, unknown>;
+  source_method: string | null;
   status: SceneDraftStatus;
-  rooms: DraftRoom[];
-  walls: DraftWall[];
-  openings: DraftOpening[];
-  objects: DraftObject[];
   created_at: ISODateString;
   updated_at: ISODateString;
 }
 
+export interface SceneDraft extends SceneDraftSummary {
+  summary_json: Record<string, unknown>;
+  rooms: DraftRoom[];
+  walls: DraftWall[];
+  openings: DraftOpening[];
+  objects: DraftObject[];
+}
+
+// ============================================
+// Raw scene returned by analyze endpoints (immediate response)
+// fusion_service 가 내려주는 픽셀 좌표 모양 (DB 저장 전 원본).
+// §6.1 POST /upload/floorplan/analyze, §6.1.1 POST /assets/{id}/analyze
+// ============================================
+
+export interface SceneWall {
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  thickness?: number;
+  height?: number;
+  role?: string;
+  material?: string;
+}
+
+export interface SceneOpening {
+  id: string;
+  type: 'door' | 'window' | string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  wall_ref?: string | null;
+}
+
+export interface SceneRoom {
+  id: string;
+  points: Array<[number, number]>;
+  center: [number, number];
+  area: number;
+}
+
+export interface SceneObjectRaw {
+  id: string;
+  class_name?: string;
+  score?: number;
+  bbox_xyxy?: [number, number, number, number];
+  [key: string]: unknown;
+}
+
+export interface AnalyzedScene {
+  scale_ratio: number;
+  walls: SceneWall[];
+  openings: SceneOpening[];
+  rooms: SceneRoom[];
+  topology: Record<string, unknown>;
+  objects: SceneObjectRaw[];
+  scene_draft_id?: string | null;
+  scene_version?: string;
+  units?: string;
+  sourceType?: string;
+}
+
+// §6.1
 export interface AnalyzeFloorplanResponse {
   status: 'ok' | string;
   scene_draft_id: UUID;
   fileId: UUID;
   savedPath: string;
-  scene: {
-    scale_ratio: number;
-    walls: DraftWall[];
-    openings: DraftOpening[];
-    rooms: DraftRoom[];
-    topology: Record<string, unknown>;
-    objects: DraftObject[];
-  };
+  scene: AnalyzedScene;
 }
+
+// §6.1.1
+export interface AnalyzeFromAssetResponse {
+  status: 'ok' | string;
+  scene_draft_id: UUID;
+  asset_id: UUID;
+  scene: AnalyzedScene;
+}
+
+// ============================================
+// Scene Version  §7  (v0.2 명세 반영)
+// preview_3d_url / parametric_scene_url 제거됨.
+// preview_2d_url → render_scene_url 로 명칭 통일.
+// rf_scene_url, artifacts_json 추가.
+// ============================================
 
 export interface SceneVersion {
   id: UUID;
+  project_id: UUID;
   floor_id: UUID;
   source_draft_id: UUID;
-  created_by: UUID | null;
   version_no: number;
   is_current: boolean;
-  preview_2d_url: string | null;
-  preview_3d_url: string | null;
-  parametric_scene_url: string | null;
+  source_mode: SceneSourceMode;
+  source_method: string | null;
+  source_asset_id: UUID | null;
+  render_scene_url: string | null;
+  rf_scene_url: string | null;
+  artifacts_json: Record<string, unknown>;
+  created_by: string | null;
   created_at: ISODateString;
+  // §7.2 detail 응답에서만 포함
   rooms?: DraftRoom[];
   walls?: DraftWall[];
   openings?: DraftOpening[];


### PR DESCRIPTION
- SceneVersion v0.2 반영 (preview_*_url 제거, render_scene_url/
  rf_scene_url/artifacts_json/project_id/source_* 추가)
- Draft 자식 타입을 백엔드 실제 응답 모양으로 재정의 + SceneDraftSummary
  분리 (§6.3 목록과 §6.2 단건 응답 차이)
- §6.1.1 analyzeFromAsset API/훅 신설, analyze 호출에 per-call timeout
  180s 적용
- Asset listByFloor 반환을 Asset[] 로 정정 (백엔드 plain array 모양)
- EditorPage: 목록 summary 에서 활성 draft 의 detail 을 별도 fetch 해서
  ReviewCard 에 전달