### PR TITLE
feat: Figma 기반 대시보드/시뮬레이션/실측/모바일 페이지 구현 및 에디터 폴리시

### DIFF
--- a/frontend/src/components/HelpFab.tsx
+++ b/frontend/src/components/HelpFab.tsx
@@ -1,0 +1,15 @@
+// 페이지 우하단 고정 도움말 버튼. 대시보드/실측·진단/시뮬레이션에서 공용.
+// 실제 도움말 동작은 추후 (예: 채널 안내 모달, 가이드 투어 등) 들어갈 자리.
+
+export function HelpFab({ onClick }: { onClick?: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="도움말"
+      className="fixed bottom-6 right-6 z-20 flex h-10 w-10 items-center justify-center rounded-full border bg-background text-muted-foreground shadow-md hover:bg-accent hover:text-foreground"
+    >
+      <span className="text-base font-semibold">?</span>
+    </button>
+  );
+}

--- a/frontend/src/features/dashboard/DiagnosticsList.tsx
+++ b/frontend/src/features/dashboard/DiagnosticsList.tsx
@@ -1,0 +1,121 @@
+import { AlertTriangle, AlertCircle, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type Severity = 'critical' | 'warning' | 'good' | 'weak';
+
+interface Diagnostic {
+  id: string;
+  location: string;
+  timeLabel: string;
+  severity: Severity;
+  statusText: string;
+  description: string;
+}
+
+const MOCK_DIAGNOSTICS: Diagnostic[] = [
+  {
+    id: 'd-1',
+    location: '창고 앞 구석 테이블',
+    timeLabel: '방금 전',
+    severity: 'critical',
+    statusText: '신호 끊김 (-85dBm)',
+    description: '고객 클레임 다수 발생 구역. 철제 수납장 영향 의심됨.',
+  },
+  {
+    id: 'd-2',
+    location: '카운터 포스기 주변',
+    timeLabel: '2시간 전',
+    severity: 'warning',
+    statusText: '간헐적 속도 저하',
+    description: '결제 시 지연 발생. 채널 간섭 확인 필요.',
+  },
+  {
+    id: 'd-3',
+    location: '메인 홀 중앙',
+    timeLabel: '어제',
+    severity: 'good',
+    statusText: '양호 (-45dBm)',
+    description: '특이사항 없음. 정상 서비스 중.',
+  },
+  {
+    id: 'd-4',
+    location: '화장실 앞 복도',
+    timeLabel: '3일 전',
+    severity: 'weak',
+    statusText: '신호 약함 (-72dBm)',
+    description: '콘크리트 벽체 영향으로 보임. 사용상 큰 무리는 없음.',
+  },
+];
+
+const SEVERITY_STYLES: Record<
+  Severity,
+  { dot: string; statusText: string; icon: 'warning' | 'alert' | 'dot' }
+> = {
+  critical: { dot: 'bg-red-500', statusText: 'text-red-600', icon: 'warning' },
+  warning: { dot: 'bg-orange-500', statusText: 'text-orange-600', icon: 'alert' },
+  good: { dot: 'bg-slate-300', statusText: 'text-emerald-600', icon: 'dot' },
+  weak: { dot: 'bg-slate-300', statusText: 'text-amber-600', icon: 'dot' },
+};
+
+const DOT_TONE: Record<Severity, string> = {
+  critical: 'bg-red-500',
+  warning: 'bg-orange-500',
+  good: 'bg-emerald-500',
+  weak: 'bg-amber-500',
+};
+
+export function DiagnosticsList() {
+  return (
+    <ul className="space-y-4">
+      {MOCK_DIAGNOSTICS.map((d) => (
+        <DiagnosticItem key={d.id} item={d} />
+      ))}
+      <li>
+        <button
+          type="button"
+          className="inline-flex w-full items-center justify-center gap-1 rounded-md py-2 text-sm font-medium text-primary hover:text-primary/80"
+        >
+          진단 내역 전체 보기
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </li>
+    </ul>
+  );
+}
+
+function DiagnosticItem({ item }: { item: Diagnostic }) {
+  const styles = SEVERITY_STYLES[item.severity];
+  return (
+    <li>
+      <div className="flex gap-2.5">
+        <div className="flex pt-1.5">
+          <span className={cn('block h-2 w-2 shrink-0 rounded-full', styles.dot)} />
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-start justify-between gap-2">
+            <h4 className="text-sm font-semibold text-foreground">{item.location}</h4>
+            <span className="shrink-0 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+              {item.timeLabel}
+            </span>
+          </div>
+          <div
+            className={cn(
+              'flex items-center gap-1.5 text-[13px] font-medium',
+              styles.statusText,
+            )}
+          >
+            {styles.icon === 'warning' && <AlertTriangle className="h-3.5 w-3.5" />}
+            {styles.icon === 'alert' && <AlertCircle className="h-3.5 w-3.5" />}
+            {styles.icon === 'dot' && (
+              <span className={cn('block h-2 w-2 rounded-full', DOT_TONE[item.severity])} />
+            )}
+            {item.statusText}
+          </div>
+          <p className="text-[12px] leading-relaxed text-muted-foreground">
+            {item.description}
+          </p>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/features/dashboard/FloorPreview.tsx
+++ b/frontend/src/features/dashboard/FloorPreview.tsx
@@ -1,0 +1,261 @@
+import { Maximize2, Minimize2, Loader2, Wifi } from 'lucide-react';
+
+// 백엔드/캔버스 연동 전까지의 정적 미니 도면 시각화 (Figma 시안용).
+// 좌표는 800x500 viewBox 기준.
+
+interface Props {
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+}
+
+export function FloorPreview({ expanded, onToggleExpand }: Props = {}) {
+  return (
+    <div className="relative h-full w-full rounded-md border bg-[#f8fafc] p-4 [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
+      <div className="absolute right-4 top-4 z-10">
+        <button
+          type="button"
+          onClick={onToggleExpand}
+          aria-label={expanded ? '축소' : '확대'}
+          className="flex h-8 w-8 items-center justify-center rounded-md border bg-background shadow-sm hover:bg-accent"
+        >
+          {expanded ? (
+            <Minimize2 className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Maximize2 className="h-4 w-4 text-muted-foreground" />
+          )}
+        </button>
+      </div>
+
+      <div className="relative mx-auto flex h-full max-w-3xl items-center justify-center">
+        <svg
+          viewBox="0 0 800 500"
+          preserveAspectRatio="xMidYMid meet"
+          className="h-full w-full"
+        >
+          {/* 외곽 도면 박스 */}
+          <rect
+            x="60"
+            y="80"
+            width="680"
+            height="360"
+            rx="6"
+            fill="white"
+            stroke="oklch(0.85 0 0)"
+            strokeWidth="2"
+          />
+
+          {/* 왼쪽 구획 (주방/창고 영역) */}
+          <line
+            x1="290"
+            y1="80"
+            x2="290"
+            y2="440"
+            stroke="oklch(0.88 0 0)"
+            strokeWidth="2"
+          />
+
+          {/* 주방/카운터 */}
+          <g>
+            <rect
+              x="100"
+              y="120"
+              width="160"
+              height="120"
+              rx="8"
+              fill="oklch(0.92 0 0)"
+            />
+            <text
+              x="180"
+              y="186"
+              textAnchor="middle"
+              className="fill-foreground/70"
+              style={{ fontSize: '15px', fontWeight: 500 }}
+            >
+              주방 / 카운터
+            </text>
+          </g>
+
+          {/* 창고 */}
+          <g>
+            <rect
+              x="100"
+              y="280"
+              width="160"
+              height="120"
+              rx="8"
+              fill="oklch(0.92 0 0)"
+            />
+            <text
+              x="180"
+              y="346"
+              textAnchor="middle"
+              className="fill-foreground/70"
+              style={{ fontSize: '15px', fontWeight: 500 }}
+            >
+              창고
+            </text>
+          </g>
+
+          {/* 테이블 (우상단 원) */}
+          <g>
+            <circle
+              cx="600"
+              cy="170"
+              r="44"
+              fill="oklch(0.95 0.04 256)"
+            />
+            <text
+              x="600"
+              y="176"
+              textAnchor="middle"
+              className="fill-primary/80"
+              style={{ fontSize: '13px', fontWeight: 500 }}
+            >
+              테이블
+            </text>
+          </g>
+
+          {/* 테이블 (좌하단 원) */}
+          <g>
+            <circle
+              cx="370"
+              cy="340"
+              r="40"
+              fill="oklch(0.95 0.04 256)"
+            />
+            <text
+              x="370"
+              y="346"
+              textAnchor="middle"
+              className="fill-primary/80"
+              style={{ fontSize: '13px', fontWeight: 500 }}
+            >
+              테이블
+            </text>
+          </g>
+
+          {/* 단체석 */}
+          <g>
+            <rect
+              x="620"
+              y="320"
+              width="100"
+              height="50"
+              rx="6"
+              fill="oklch(0.95 0.04 256)"
+            />
+            <text
+              x="670"
+              y="350"
+              textAnchor="middle"
+              className="fill-primary/80"
+              style={{ fontSize: '13px', fontWeight: 500 }}
+            >
+              단체석
+            </text>
+          </g>
+
+          {/* 선택된 테이블 (가운데, blue border + 핸들) */}
+          <g>
+            <rect
+              x="440"
+              y="290"
+              width="140"
+              height="80"
+              rx="4"
+              fill="white"
+              stroke="oklch(0.55 0.22 264)"
+              strokeWidth="2"
+            />
+            {/* 4 corner handles */}
+            <Handle cx={440} cy={290} />
+            <Handle cx={580} cy={290} />
+            <Handle cx={440} cy={370} />
+            <Handle cx={580} cy={370} />
+            {/* 우상단 검은 작은 탭 */}
+            <rect
+              x="565"
+              y="282"
+              width="14"
+              height="14"
+              fill="oklch(0.2 0 0)"
+            />
+            {/* 위쪽 회전 핸들 */}
+            <line
+              x1="510"
+              y1="290"
+              x2="510"
+              y2="252"
+              stroke="oklch(0.55 0.22 264)"
+              strokeWidth="2"
+            />
+            <circle
+              cx="510"
+              cy="244"
+              r="11"
+              fill="oklch(0.55 0.22 264)"
+            />
+            <text
+              x="510"
+              y="248"
+              textAnchor="middle"
+              fill="white"
+              style={{ fontSize: '11px', fontWeight: 600 }}
+            >
+              ↑
+            </text>
+          </g>
+
+          {/* AP 1 — 상단 중앙 */}
+          <ApMarker cx={430} cy={170} label="AP 1" />
+
+          {/* AP 2 — 우하단 */}
+          <ApMarker cx={680} cy={420} label="AP 2" />
+        </svg>
+
+        {/* Live preview loading 토스트 */}
+        <div className="pointer-events-none absolute bottom-2 left-1/2 -translate-x-1/2">
+          <div className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-medium text-white shadow-lg">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Live preview loading, interactions may not be saved
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Handle({ cx, cy }: { cx: number; cy: number }) {
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r="7"
+      fill="white"
+      stroke="oklch(0.55 0.22 264)"
+      strokeWidth="2"
+    />
+  );
+}
+
+function ApMarker({ cx, cy, label }: { cx: number; cy: number; label: string }) {
+  return (
+    <g>
+      <circle cx={cx} cy={cy} r="22" fill="oklch(0.55 0.22 264)" />
+      <g transform={`translate(${cx - 9}, ${cy - 9})`}>
+        <foreignObject width="18" height="18">
+          <Wifi className="h-[18px] w-[18px] text-white" />
+        </foreignObject>
+      </g>
+      <text
+        x={cx}
+        y={cy + 42}
+        textAnchor="middle"
+        className="fill-foreground"
+        style={{ fontSize: '12px', fontWeight: 600 }}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}

--- a/frontend/src/features/editor/CanvasArea.tsx
+++ b/frontend/src/features/editor/CanvasArea.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { Image as ImageIcon, Upload } from 'lucide-react';
+import { Image as ImageIcon, Ruler, Upload } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const ALLOWED_MIME = ['image/png', 'image/jpeg', 'application/pdf'];
 const ALLOWED_EXT = ['png', 'jpg', 'jpeg', 'pdf'];
+const DEFAULT_REAL_WIDTH_M = 10;
 
 function isAllowed(file: File) {
   if (ALLOWED_MIME.includes(file.type)) return true;
@@ -16,7 +17,7 @@ interface CanvasAreaProps {
   isPending?: boolean;
   errorMessage?: string;
   selectedFileName?: string | null;
-  onFile: (file: File) => void;
+  onFile: (file: File, realWidthM: number) => void;
 }
 
 export function CanvasArea({
@@ -28,14 +29,19 @@ export function CanvasArea({
 }: CanvasAreaProps) {
   const [dragOver, setDragOver] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [realWidthM, setRealWidthM] = useState<number>(DEFAULT_REAL_WIDTH_M);
 
   const accept = (f: File) => {
     if (!isAllowed(f)) {
       setLocalError('PNG / JPG / JPEG / PDF 파일만 업로드 가능합니다.');
       return;
     }
+    if (!Number.isFinite(realWidthM) || realWidthM <= 0) {
+      setLocalError('도면의 실제 가로 길이를 0보다 큰 값으로 입력해주세요.');
+      return;
+    }
     setLocalError(null);
-    onFile(f);
+    onFile(f, realWidthM);
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -95,6 +101,27 @@ export function CanvasArea({
           <Upload className="h-4 w-4" />
           {isPending ? '분석 중…' : '컴퓨터에서 도면 찾기'}
         </button>
+
+        <div className="mt-5 inline-flex items-center gap-2 rounded-lg border bg-background px-3 py-2 text-xs">
+          <Ruler className="h-3.5 w-3.5 text-muted-foreground" />
+          <label htmlFor="real-width-m" className="text-muted-foreground">
+            도면 실제 가로 길이
+          </label>
+          <input
+            id="real-width-m"
+            type="number"
+            step="0.1"
+            min="0.1"
+            value={realWidthM}
+            onChange={(e) => setRealWidthM(Number(e.target.value))}
+            disabled={isPending}
+            className="w-16 rounded-md border bg-background px-1.5 py-0.5 text-right text-xs tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          />
+          <span className="text-muted-foreground">m</span>
+        </div>
+        <p className="mt-1 max-w-md text-[11px] text-muted-foreground">
+          이미지의 가로 폭이 실제 공간에서 몇 미터인지 입력하면 스케일이 정확히 환산됩니다.
+        </p>
 
         {selectedFileName && !isPending && (
           <p className="mt-4 text-xs text-muted-foreground">

--- a/frontend/src/features/editor/CanvasToolbar.tsx
+++ b/frontend/src/features/editor/CanvasToolbar.tsx
@@ -28,9 +28,9 @@ const TOP_TOOLS: ToolDef[] = [
 ];
 
 const SHAPE_TOOLS: ToolDef[] = [
-  { id: 'rect', icon: Square, label: '사각형', onClick: 'change' },
-  { id: 'circle', icon: Circle, label: '원', onClick: 'change' },
-  { id: 'text', icon: Type, label: '텍스트', onClick: 'change' },
+  { id: 'rect', icon: Square, label: '벽/구조물', onClick: 'change' },
+  { id: 'circle', icon: Circle, label: '가구 배치', onClick: 'change' },
+  { id: 'text', icon: Type, label: '구역 라벨', onClick: 'change' },
 ];
 
 export function CanvasToolbar({ tool, onChangeTool, onUploadClick }: CanvasToolbarProps) {

--- a/frontend/src/features/measurement/DiagnosticPanel.tsx
+++ b/frontend/src/features/measurement/DiagnosticPanel.tsx
@@ -1,0 +1,120 @@
+import { Activity, AlertTriangle, ChevronRight, MapPin, QrCode } from 'lucide-react';
+
+// 우측 진단 패널 - 선택된 측정 포인트의 예측치/실측치 비교, 상세지표, 원인 분석 mock.
+// 실제로는 GET /measurement-sessions/{id}/points + simulated value 조합으로 채워질 예정.
+
+export function DiagnosticPanel() {
+  return (
+    <aside className="flex w-90 shrink-0 flex-col gap-4">
+      <CombinedDiagnosisCard />
+      <CauseAnalysisCard />
+      <MobileConnectCard />
+    </aside>
+  );
+}
+
+function CombinedDiagnosisCard() {
+  return (
+    <section className="rounded-2xl border bg-background p-5 shadow-sm">
+      <header className="mb-4 flex items-center gap-2">
+        <Activity className="h-4 w-4 text-primary" strokeWidth={2} />
+        <h3 className="text-sm font-bold">예측·실측 통합 진단</h3>
+      </header>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <MapPin className="h-4 w-4 text-red-500" />
+          <span className="text-base font-bold">
+            창고 앞 구석 <span className="text-foreground/70">(P-05)</span>
+          </span>
+        </div>
+        <span className="shrink-0 rounded-full bg-red-100 px-2.5 py-1 text-[11px] font-semibold text-red-600">
+          상태 불량
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 rounded-lg border bg-muted/30 p-3">
+        <MetricCompare label="예측치 (시뮬레이션)" value="-72" unit="dBm" />
+        <MetricCompare label="실측치 (어제 15:00)" value="-84" unit="dBm" valueColor="text-red-500" />
+      </div>
+
+      <div className="mt-4">
+        <h4 className="text-xs font-semibold text-foreground/80">상세 품질 지표</h4>
+        <div className="mt-2 grid grid-cols-3 gap-2">
+          <Metric value="55ms" label="지연시간" />
+          <Metric value="4.2Mbps" label="다운로드" />
+          <Metric value="2.4GHz" label="대역" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CauseAnalysisCard() {
+  return (
+    <section className="rounded-2xl border bg-background p-5 shadow-sm">
+      <header className="mb-3 flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 text-amber-500" strokeWidth={2} />
+        <h3 className="text-sm font-bold">원인 분석 및 조치</h3>
+      </header>
+
+      <p className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-[13px] leading-relaxed text-foreground/85">
+        예측보다 실측 수치가 훨씬 낮습니다. 창고 가벽의 전파 흡수율이 예상보다
+        높거나, 주변에 전파 간섭을 일으키는 금속성 물체가 있을 수 있습니다.
+      </p>
+
+      <button
+        type="button"
+        className="mt-4 inline-flex w-full items-center justify-between rounded-lg border px-3 py-2.5 text-sm font-medium text-foreground/80 hover:bg-accent"
+      >
+        조치 방법 확인하기
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </section>
+  );
+}
+
+function MobileConnectCard() {
+  return (
+    <section className="rounded-2xl border bg-background p-5 shadow-sm">
+      <header className="flex items-center gap-2">
+        <QrCode className="h-4 w-4 text-primary" strokeWidth={2} />
+        <h3 className="text-sm font-bold">모바일 기기 연결</h3>
+      </header>
+      <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+        새로운 실측을 시작하려면 모바일 앱에서 QR 코드를 스캔해주세요.
+      </p>
+    </section>
+  );
+}
+
+function MetricCompare({
+  label,
+  value,
+  unit,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  unit: string;
+  valueColor?: string;
+}) {
+  return (
+    <div>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-bold">
+        <span className={valueColor}>{value}</span>
+        <span className="ml-1 text-[12px] font-medium text-muted-foreground">{unit}</span>
+      </p>
+    </div>
+  );
+}
+
+function Metric({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="rounded-md border bg-background p-2 text-center">
+      <p className="text-[13px] font-bold">{value}</p>
+      <p className="mt-0.5 text-[10px] text-muted-foreground">{label}</p>
+    </div>
+  );
+}

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -1,0 +1,231 @@
+import { Wifi } from 'lucide-react';
+
+export type MeasurementView = 'path' | 'heatmap' | 'combined';
+
+interface Props {
+  view: MeasurementView;
+}
+
+// 측정 포인트 (mock). 실제로는 GET /measurement-sessions/{id}/points 응답으로 받아야 함.
+const POINTS = [
+  { id: 'P-01', x: 420, y: 180, severity: 'good' as const },
+  { id: 'P-02', x: 510, y: 180, severity: 'good' as const },
+  { id: 'P-03', x: 510, y: 280, severity: 'good' as const },
+  { id: 'P-04', x: 320, y: 280, severity: 'good' as const },
+  { id: 'P-05', x: 320, y: 380, severity: 'bad' as const },
+  { id: 'P-06', x: 510, y: 340, severity: 'warning' as const },
+  { id: 'P-07', x: 640, y: 340, severity: 'good' as const },
+  { id: 'P-08', x: 640, y: 440, severity: 'good' as const },
+];
+
+const SEVERITY_COLOR: Record<'good' | 'warning' | 'bad', string> = {
+  good: 'oklch(0.72 0.18 145)',
+  warning: 'oklch(0.78 0.15 85)',
+  bad: 'oklch(0.62 0.22 25)',
+};
+
+export function MeasurementCanvas({ view }: Props) {
+  const showHeatmap = view === 'heatmap' || view === 'combined';
+  const showPath = view === 'path' || view === 'combined';
+
+  return (
+    <div className="relative flex h-full w-full flex-col overflow-hidden rounded-md border bg-[#f8fafc] [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
+      <div className="p-4">
+        <Legend />
+      </div>
+
+      <div className="relative min-h-0 flex-1">
+        <svg
+          viewBox="0 0 800 520"
+          preserveAspectRatio="xMidYMid meet"
+          className="h-full w-full p-4"
+        >
+          <defs>
+            <radialGradient id="hot-bad" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="oklch(0.62 0.22 25)" stopOpacity="0.55" />
+              <stop offset="80%" stopColor="oklch(0.62 0.22 25)" stopOpacity="0" />
+            </radialGradient>
+            <radialGradient id="hot-warn" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="oklch(0.85 0.18 85)" stopOpacity="0.55" />
+              <stop offset="80%" stopColor="oklch(0.85 0.18 85)" stopOpacity="0" />
+            </radialGradient>
+            <radialGradient id="hot-good" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="oklch(0.72 0.18 145)" stopOpacity="0.5" />
+              <stop offset="80%" stopColor="oklch(0.72 0.18 145)" stopOpacity="0" />
+            </radialGradient>
+          </defs>
+
+          {/* 외곽 도면 */}
+          <rect
+            x="60"
+            y="100"
+            width="680"
+            height="380"
+            rx="6"
+            fill="white"
+            stroke="oklch(0.85 0 0)"
+            strokeWidth="2"
+          />
+          <line
+            x1="290"
+            y1="100"
+            x2="290"
+            y2="480"
+            stroke="oklch(0.88 0 0)"
+            strokeWidth="2"
+          />
+
+          {/* 히트맵 레이어 (heatmap, combined 탭에서만) */}
+          {showHeatmap && (
+            <g>
+              {/* 좋은 영역 (도면 가운데~우측) */}
+              <ellipse cx="480" cy="270" rx="260" ry="190" fill="url(#hot-good)" />
+              {/* 주의 영역 (가운데 약간 우측) */}
+              <ellipse cx="540" cy="340" rx="100" ry="70" fill="url(#hot-warn)" />
+              {/* 불량 영역 (좌하단 창고 앞) */}
+              <ellipse cx="180" cy="400" rx="140" ry="110" fill="url(#hot-bad)" />
+            </g>
+          )}
+
+          {/* 방/구획 */}
+          <g>
+            <rect x="100" y="140" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
+            <text
+              x="180"
+              y="196"
+              textAnchor="middle"
+              className="fill-foreground/70"
+              style={{ fontSize: '15px', fontWeight: 500 }}
+            >
+              주방 / 카운터
+            </text>
+          </g>
+          <g>
+            <rect x="100" y="280" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
+            <text
+              x="180"
+              y="336"
+              textAnchor="middle"
+              className="fill-foreground/70"
+              style={{ fontSize: '15px', fontWeight: 500 }}
+            >
+              창고
+            </text>
+          </g>
+
+          {/* 가구 */}
+          <g>
+            <circle cx="600" cy="190" r="42" fill="oklch(0.95 0.04 256)" />
+            <text
+              x="600"
+              y="196"
+              textAnchor="middle"
+              className="fill-primary/80"
+              style={{ fontSize: '13px', fontWeight: 500 }}
+            >
+              테이블
+            </text>
+          </g>
+          <g>
+            <circle cx="380" cy="380" r="38" fill="oklch(0.95 0.04 256)" />
+            <text
+              x="380"
+              y="386"
+              textAnchor="middle"
+              className="fill-primary/80"
+              style={{ fontSize: '13px', fontWeight: 500 }}
+            >
+              테이블
+            </text>
+          </g>
+          <g>
+            <rect x="610" y="370" width="90" height="48" rx="6" fill="oklch(0.95 0.04 256)" />
+            <text
+              x="655"
+              y="400"
+              textAnchor="middle"
+              className="fill-primary/80"
+              style={{ fontSize: '13px', fontWeight: 500 }}
+            >
+              단체석
+            </text>
+          </g>
+
+          {/* 검은 작은 사각형 (선택된 객체 표시 / 측정 마커 anchor) */}
+          <rect x="500" y="330" width="14" height="14" fill="oklch(0.2 0 0)" />
+
+          {/* 경로 (path, combined 탭에서만) */}
+          {showPath && (
+            <g>
+              <polyline
+                points={POINTS.map((p) => `${p.x},${p.y}`).join(' ')}
+                fill="none"
+                stroke="oklch(0.55 0.22 264)"
+                strokeWidth="2.5"
+                strokeDasharray="6 5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              {POINTS.map((p) => (
+                <circle
+                  key={p.id}
+                  cx={p.x}
+                  cy={p.y}
+                  r="8"
+                  fill={SEVERITY_COLOR[p.severity]}
+                  stroke="white"
+                  strokeWidth="2.5"
+                />
+              ))}
+            </g>
+          )}
+
+          {/* AP 마커 */}
+          <ApMarker cx={430} cy={190} label="AP 1" />
+          <ApMarker cx={685} cy={465} label="AP 2" />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="absolute left-4 top-4 z-10 inline-flex items-center gap-4 rounded-lg border bg-background/90 px-4 py-2 text-xs shadow-sm backdrop-blur">
+      <span className="font-semibold text-foreground/80">실측 포인트 범례</span>
+      <span className="h-3 w-px bg-border" />
+      <LegendDot color="bg-emerald-500" label="양호" />
+      <LegendDot color="bg-amber-400" label="주의" />
+      <LegendDot color="bg-red-500" label="불량" />
+    </div>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`block h-2.5 w-2.5 rounded-full ${color}`} />
+      <span className="text-foreground/80">{label}</span>
+    </span>
+  );
+}
+
+function ApMarker({ cx, cy, label }: { cx: number; cy: number; label: string }) {
+  return (
+    <g>
+      <circle cx={cx} cy={cy} r="22" fill="oklch(0.55 0.22 264)" />
+      <foreignObject x={cx - 9} y={cy - 9} width="18" height="18">
+        <Wifi className="h-[18px] w-[18px] text-white" />
+      </foreignObject>
+      <text
+        x={cx}
+        y={cy + 42}
+        textAnchor="middle"
+        className="fill-foreground"
+        style={{ fontSize: '12px', fontWeight: 600 }}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}

--- a/frontend/src/features/simulation/ApPaletteMenu.tsx
+++ b/frontend/src/features/simulation/ApPaletteMenu.tsx
@@ -1,0 +1,35 @@
+import { Wifi } from 'lucide-react';
+
+// "AP 추가하기" 플로팅 메뉴 (idle 상태에서만 노출).
+// 클릭 시 캔버스에 AP 마커를 떨어뜨리는 인터랙션이 들어가야 하지만, 현재는 정적 메뉴.
+
+export function ApPaletteMenu() {
+  return (
+    <div className="w-32 rounded-xl border bg-background p-3 shadow-md">
+      <h4 className="mb-2 text-center text-xs font-semibold text-foreground/80">
+        AP 추가하기
+      </h4>
+      <div className="flex flex-col items-center gap-2.5">
+        <ApOption tone="primary" label="일반 AP" />
+        <ApOption tone="indigo" label="고성능 AP" />
+      </div>
+    </div>
+  );
+}
+
+function ApOption({ tone, label }: { tone: 'primary' | 'indigo'; label: string }) {
+  const bg = tone === 'primary' ? 'bg-primary' : 'bg-indigo-600';
+  return (
+    <button
+      type="button"
+      className="flex flex-col items-center gap-1 rounded-md p-1.5 hover:bg-accent"
+    >
+      <div
+        className={`flex h-10 w-10 items-center justify-center rounded-full ${bg} text-primary-foreground shadow-sm`}
+      >
+        <Wifi className="h-4 w-4" />
+      </div>
+      <span className="text-[11px] font-medium text-foreground/80">{label}</span>
+    </button>
+  );
+}

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -1,0 +1,321 @@
+import {
+  CheckCircle2,
+  Loader2,
+  MousePointer2,
+  Maximize2,
+  Minimize2,
+  RotateCw,
+  Wifi,
+} from 'lucide-react';
+import { ApPaletteMenu } from './ApPaletteMenu';
+
+export type SimulationState = 'idle' | 'running' | 'complete';
+
+interface Props {
+  state: SimulationState;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+}
+
+export function SimulationCanvas({ state, expanded, onToggleExpand }: Props) {
+  return (
+    <div className="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border bg-[#f8fafc] [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
+      <div className="relative z-10 flex items-start justify-between gap-3 p-5">
+        <div className="flex flex-col gap-2">
+          <TopLeftBadge state={state} />
+          {state === 'complete' && (
+            <div className="inline-flex w-fit items-center gap-4 rounded-lg border bg-background/90 px-4 py-2 text-xs shadow-sm backdrop-blur">
+              <span className="font-semibold text-foreground/80">품질 예측 보기</span>
+              <span className="h-3 w-px bg-border" />
+              <LegendDot color="bg-emerald-500" label="양호" />
+              <LegendDot color="bg-amber-400" label="보통" />
+              <LegendDot color="bg-red-500" label="취약" />
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onToggleExpand}
+          aria-label={expanded ? '축소' : '확대'}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-background shadow-sm transition-colors hover:bg-accent"
+        >
+          {expanded ? (
+            <Minimize2 className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Maximize2 className="h-4 w-4 text-muted-foreground" />
+          )}
+        </button>
+      </div>
+
+      {state === 'idle' && (
+        <div className="absolute right-5 top-20 z-10">
+          <ApPaletteMenu />
+        </div>
+      )}
+
+      <div className="relative min-h-0 flex-1">
+        <div
+          className={
+            state === 'running'
+              ? 'pointer-events-none h-full w-full blur-sm'
+              : 'h-full w-full'
+          }
+        >
+          <FloorPlanSvg
+            withHeatmap={state === 'complete'}
+            withSelection={state === 'idle'}
+          />
+        </div>
+
+        {state === 'running' && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 px-6 text-center">
+            <Loader2 className="h-16 w-16 animate-spin text-primary" strokeWidth={2.5} />
+            <h3 className="text-lg font-bold">공간 기반 와이파이 품질을 분석중입니다</h3>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              도면의 구조와 장애물을 파악하여
+              <br />
+              전파 도달 범위를 계산하고 있습니다...
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TopLeftBadge({ state }: { state: SimulationState }) {
+  if (state === 'idle') {
+    return (
+      <div className="absolute left-5 top-5 z-10 inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm shadow-sm">
+        <MousePointer2 className="h-4 w-4 text-primary" />
+        <span className="font-semibold">도면 배치 모드</span>
+        <span className="text-muted-foreground">- AP와 가구를 드래그하여 이동할 수 있습니다.</span>
+      </div>
+    );
+  }
+  if (state === 'running') {
+    return (
+      <div className="absolute left-5 top-5 z-10 inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm shadow-sm">
+        <RotateCw className="h-4 w-4 animate-spin text-primary" />
+        <span className="font-semibold">전파 도달 범위 계산 중...</span>
+      </div>
+    );
+  }
+  return (
+    <div className="absolute left-5 top-5 z-10 inline-flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3.5 py-2 text-sm shadow-sm">
+      <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+      <span className="font-semibold text-emerald-700">시뮬레이션 완료 (새로운 배치)</span>
+    </div>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`block h-2.5 w-2.5 rounded-full ${color}`} />
+      <span className="text-foreground/80">{label}</span>
+    </span>
+  );
+}
+
+interface FloorPlanSvgProps {
+  withHeatmap: boolean;
+  withSelection: boolean;
+}
+
+function FloorPlanSvg({ withHeatmap, withSelection }: FloorPlanSvgProps) {
+  return (
+    <svg
+      viewBox="0 0 800 520"
+      preserveAspectRatio="xMidYMid meet"
+      className="h-full w-full p-4"
+    >
+      <defs>
+        <radialGradient id="sim-bad" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="oklch(0.62 0.22 25)" stopOpacity="0.55" />
+          <stop offset="80%" stopColor="oklch(0.62 0.22 25)" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="sim-warn" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="oklch(0.85 0.18 85)" stopOpacity="0.5" />
+          <stop offset="80%" stopColor="oklch(0.85 0.18 85)" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id="sim-good" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="oklch(0.72 0.18 145)" stopOpacity="0.5" />
+          <stop offset="80%" stopColor="oklch(0.72 0.18 145)" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      <rect
+        x="60"
+        y="100"
+        width="680"
+        height="380"
+        rx="6"
+        fill="white"
+        stroke="oklch(0.85 0 0)"
+        strokeWidth="2"
+      />
+      <line
+        x1="290"
+        y1="100"
+        x2="290"
+        y2="480"
+        stroke="oklch(0.88 0 0)"
+        strokeWidth="2"
+      />
+
+      {withHeatmap && (
+        <g>
+          <ellipse cx="500" cy="280" rx="280" ry="200" fill="url(#sim-good)" />
+          <ellipse cx="600" cy="200" rx="160" ry="120" fill="url(#sim-good)" />
+          <ellipse cx="170" cy="400" rx="160" ry="130" fill="url(#sim-bad)" />
+          <ellipse cx="540" cy="380" rx="80" ry="60" fill="url(#sim-warn)" />
+        </g>
+      )}
+
+      {/* 주방/카운터 */}
+      <g>
+        <rect x="100" y="140" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
+        <text
+          x="180"
+          y="196"
+          textAnchor="middle"
+          className="fill-foreground/70"
+          style={{ fontSize: '15px', fontWeight: 500 }}
+        >
+          주방 / 카운터
+        </text>
+      </g>
+      {/* 창고 */}
+      <g>
+        <rect x="100" y="280" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
+        <text
+          x="180"
+          y="336"
+          textAnchor="middle"
+          className="fill-foreground/70"
+          style={{ fontSize: '15px', fontWeight: 500 }}
+        >
+          창고
+        </text>
+      </g>
+
+      {/* 테이블 우상 */}
+      <g>
+        <circle cx="600" cy="190" r="42" fill="oklch(0.95 0.04 256)" />
+        <text
+          x="600"
+          y="196"
+          textAnchor="middle"
+          className="fill-primary/80"
+          style={{ fontSize: '13px', fontWeight: 500 }}
+        >
+          테이블
+        </text>
+      </g>
+      {/* 테이블 좌하 */}
+      <g>
+        <circle cx="380" cy="380" r="38" fill="oklch(0.95 0.04 256)" />
+        <text
+          x="380"
+          y="386"
+          textAnchor="middle"
+          className="fill-primary/80"
+          style={{ fontSize: '13px', fontWeight: 500 }}
+        >
+          테이블
+        </text>
+      </g>
+      {/* 단체석 */}
+      <g>
+        <rect x="610" y="370" width="90" height="48" rx="6" fill="oklch(0.95 0.04 256)" />
+        <text
+          x="655"
+          y="400"
+          textAnchor="middle"
+          className="fill-primary/80"
+          style={{ fontSize: '13px', fontWeight: 500 }}
+        >
+          단체석
+        </text>
+      </g>
+
+      {/* 선택된 사각형 (idle 일 때만 핸들 표시) */}
+      {withSelection ? (
+        <g>
+          <rect
+            x="440"
+            y="290"
+            width="140"
+            height="80"
+            rx="4"
+            fill="white"
+            stroke="oklch(0.55 0.22 264)"
+            strokeWidth="2"
+          />
+          <Handle cx={440} cy={290} />
+          <Handle cx={580} cy={290} />
+          <Handle cx={440} cy={370} />
+          <Handle cx={580} cy={370} />
+          <rect x="565" y="282" width="14" height="14" fill="oklch(0.2 0 0)" />
+          <line
+            x1="510"
+            y1="290"
+            x2="510"
+            y2="252"
+            stroke="oklch(0.55 0.22 264)"
+            strokeWidth="2"
+          />
+          <circle cx="510" cy="244" r="11" fill="oklch(0.55 0.22 264)" />
+          <text
+            x="510"
+            y="248"
+            textAnchor="middle"
+            fill="white"
+            style={{ fontSize: '11px', fontWeight: 600 }}
+          >
+            ↑
+          </text>
+        </g>
+      ) : (
+        <rect x="500" y="330" width="14" height="14" fill="oklch(0.2 0 0)" />
+      )}
+
+      <ApMarker cx={430} cy={190} label="AP 1" />
+      <ApMarker cx={685} cy={465} label="AP 2" />
+    </svg>
+  );
+}
+
+function Handle({ cx, cy }: { cx: number; cy: number }) {
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r="7"
+      fill="white"
+      stroke="oklch(0.55 0.22 264)"
+      strokeWidth="2"
+    />
+  );
+}
+
+function ApMarker({ cx, cy, label }: { cx: number; cy: number; label: string }) {
+  return (
+    <g>
+      <circle cx={cx} cy={cy} r="22" fill="oklch(0.55 0.22 264)" />
+      <foreignObject x={cx - 9} y={cy - 9} width="18" height="18">
+        <Wifi className="h-[18px] w-[18px] text-white" />
+      </foreignObject>
+      <text
+        x={cx}
+        y={cy + 42}
+        textAnchor="middle"
+        className="fill-foreground"
+        style={{ fontSize: '12px', fontWeight: 600 }}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}

--- a/frontend/src/features/simulation/SimulationHistory.tsx
+++ b/frontend/src/features/simulation/SimulationHistory.tsx
@@ -1,0 +1,66 @@
+import { ArrowLeftRight, Clock } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface SimulationHistoryItem {
+  id: string;
+  label: string;
+  timeLabel: string;
+  avgRssiDbm: number;
+  coveragePercent: number;
+  active?: boolean;
+}
+
+interface Props {
+  items: SimulationHistoryItem[];
+  showCompareButton?: boolean;
+}
+
+export function SimulationHistory({ items, showCompareButton }: Props) {
+  return (
+    <section className="rounded-2xl border bg-background p-5 shadow-sm">
+      <header className="mb-4 flex items-center gap-2">
+        <Clock className="h-4 w-4 text-foreground/70" strokeWidth={2} />
+        <h3 className="text-sm font-bold">시뮬레이션 기록</h3>
+      </header>
+
+      <ul className="space-y-3">
+        {items.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              className={cn(
+                'w-full rounded-lg border p-3 text-left transition-colors hover:border-primary/40',
+                item.active && 'border-primary/40 bg-primary/5',
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <span className="text-sm font-semibold">{item.label}</span>
+                <span className="shrink-0 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+                  {item.timeLabel}
+                </span>
+              </div>
+              <div className="mt-2 flex items-center gap-3 text-[12px] text-muted-foreground">
+                <span>
+                  평균: <span className="font-semibold text-foreground">{item.avgRssiDbm}dBm</span>
+                </span>
+                <span>
+                  커버리지:{' '}
+                  <span className="font-semibold text-foreground">{item.coveragePercent}%</span>
+                </span>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {showCompareButton && (
+        <button
+          type="button"
+          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-primary/40 bg-background py-2.5 text-sm font-semibold text-primary hover:bg-primary/5"
+        >
+          <ArrowLeftRight className="h-4 w-4" />두 시뮬레이션 결과 비교하기
+        </button>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/simulation/SimulationResultCard.tsx
+++ b/frontend/src/features/simulation/SimulationResultCard.tsx
@@ -1,0 +1,78 @@
+import { BarChart3, Save } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  avgRssiDbm: number;
+  coveragePercent: number;
+}
+
+export function SimulationResultCard({ avgRssiDbm, coveragePercent }: Props) {
+  // mock: rssi -100~-30 범위를 0~100 으로 매핑
+  const rssiFillPct = Math.max(0, Math.min(100, ((avgRssiDbm + 100) / 70) * 100));
+
+  return (
+    <section className="rounded-2xl border bg-background p-5 shadow-sm">
+      <header className="mb-4 flex items-center gap-2">
+        <BarChart3 className="h-4 w-4 text-primary" strokeWidth={2} />
+        <h3 className="text-sm font-bold">새로운 배치 예측 결과</h3>
+      </header>
+
+      <Metric
+        label="평균 신호 강도"
+        valueText={`${avgRssiDbm}`}
+        unit="dBm"
+        fillPct={rssiFillPct}
+        barColor="bg-emerald-500"
+      />
+
+      <div className="mt-5">
+        <Metric
+          label="면적 커버리지 (양호)"
+          valueText={`${coveragePercent}`}
+          unit="%"
+          fillPct={coveragePercent}
+          barColor="bg-primary"
+        />
+      </div>
+
+      <button
+        type="button"
+        className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-lg border bg-background py-2.5 text-sm font-medium text-foreground/80 hover:bg-accent"
+      >
+        <Save className="h-4 w-4 text-muted-foreground" />이 배치 시나리오 저장
+      </button>
+    </section>
+  );
+}
+
+function Metric({
+  label,
+  valueText,
+  unit,
+  fillPct,
+  barColor,
+}: {
+  label: string;
+  valueText: string;
+  unit: string;
+  fillPct: number;
+  barColor: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <span className="text-[13px] font-medium text-foreground/80">{label}</span>
+        <span className="text-2xl font-bold tabular-nums">
+          {valueText}
+          <span className="ml-1 text-xs font-medium text-muted-foreground">{unit}</span>
+        </span>
+      </div>
+      <div className="mt-1.5 h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn('h-full rounded-full transition-all', barColor)}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -94,7 +94,9 @@ export function AppLayout() {
                 <button
                   type="button"
                   onClick={editorActions.onSaveFloorplan}
-                  className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
+                  disabled={!editorActions.onSaveFloorplan}
+                  title={!editorActions.onSaveFloorplan ? '저장할 분석 결과가 없습니다' : undefined}
+                  className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
                 >
                   <Save className="h-4 w-4" />
                   도면 저장하기

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,13 +1,20 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
+  Activity,
   ChevronRight,
+  ImageOff,
   Map,
   Radio,
   Smartphone,
   type LucideIcon,
 } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
+import { HelpFab } from '@/components/HelpFab';
 import { cn } from '@/lib/utils';
+import { useAppStore } from '@/stores/app-store';
+import { FloorPreview } from '@/features/dashboard/FloorPreview';
+import { DiagnosticsList } from '@/features/dashboard/DiagnosticsList';
 
 type Tone = 'blue' | 'purple' | 'green';
 
@@ -66,38 +73,58 @@ const QUICK_ACTIONS = [
 }>;
 
 export default function DashboardPage() {
+  const projectId = useAppStore((s) => s.selectedProjectId);
+  const floorId = useAppStore((s) => s.selectedFloorId);
+  const hasFloorSelected = !!projectId && !!floorId;
+  const [expanded, setExpanded] = useState(false);
+  const toggleExpand = () => setExpanded((v) => !v);
+
   return (
-    <div className="h-full space-y-6 overflow-auto p-6">
-      <header className="space-y-1.5">
-        <h1 className="text-2xl font-semibold tracking-tight">대시보드</h1>
-        <p className="text-sm text-muted-foreground">
-          현장 앱과 연동된 매장 도면 및 최신 진단 내역을 확인하세요.
-        </p>
-      </header>
+    <div className="relative h-full overflow-auto p-6">
+      <div className="space-y-6">
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">대시보드</h1>
+          <p className="text-sm text-muted-foreground">
+            현장 앱과 연동된 매장 도면 및 최신 진단 내역을 확인하세요.
+          </p>
+        </header>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
-        <Card title="현재 작업 중인 도면" className="min-h-96">
-          <div className="flex h-full min-h-80 items-center justify-center rounded-md bg-muted/40 text-sm text-muted-foreground">
-            (도면 미리보기 — Editor 구현 후 연결)
-          </div>
-        </Card>
-
-        <div className="space-y-6">
-          <Card title="빠른 실행">
-            <ul className="space-y-3">
-              {QUICK_ACTIONS.map((a) => (
-                <QuickAction key={a.to} {...a} />
-              ))}
-            </ul>
-          </Card>
-
-          <Card title="현장 앱 최근 진단">
-            <div className="text-sm text-muted-foreground">
-              (진단 API 스펙 수신 후 연결)
+        <div
+          className={
+            expanded
+              ? 'grid grid-cols-1 gap-6'
+              : 'grid grid-cols-1 gap-6 lg:grid-cols-[2fr_minmax(320px,1fr)]'
+          }
+        >
+          <Card title="현재 작업 중인 도면" className="min-h-140">
+            <div className={expanded ? 'h-180' : 'h-120'}>
+              {hasFloorSelected ? (
+                <FloorPreview expanded={expanded} onToggleExpand={toggleExpand} />
+              ) : (
+                <FloorEmptyState hasProject={!!projectId} />
+              )}
             </div>
           </Card>
+
+          {!expanded && (
+            <div className="space-y-6">
+              <Card title="빠른 실행">
+                <ul className="space-y-3">
+                  {QUICK_ACTIONS.map((a) => (
+                    <QuickAction key={a.to} {...a} />
+                  ))}
+                </ul>
+              </Card>
+
+              <Card title="현장 앱 최근 진단">
+                {hasFloorSelected ? <DiagnosticsList /> : <DiagnosticsEmptyState />}
+              </Card>
+            </div>
+          )}
         </div>
       </div>
+
+      <HelpFab />
     </div>
   );
 }
@@ -144,3 +171,41 @@ function QuickAction({
     </li>
   );
 }
+
+function FloorEmptyState({ hasProject }: { hasProject: boolean }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 rounded-md border border-dashed bg-muted/20 p-8 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <ImageOff className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <p className="text-sm font-medium">
+        {hasProject ? '층을 선택해주세요' : '프로젝트를 먼저 선택해주세요'}
+      </p>
+      <p className="max-w-sm text-xs leading-relaxed text-muted-foreground">
+        상단 셀렉터에서 작업할 도면(층)을 선택하면 현재 작업 중인 도면 미리보기가 표시됩니다.
+      </p>
+      <Link
+        to="/editor"
+        className="mt-2 inline-flex items-center gap-1 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-accent"
+      >
+        공간 편집으로 이동
+        <ChevronRight className="h-3.5 w-3.5" />
+      </Link>
+    </div>
+  );
+}
+
+function DiagnosticsEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-6 text-center">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+        <Activity className="h-4 w-4 text-muted-foreground" />
+      </div>
+      <p className="text-sm font-medium">진단된 내역이 없습니다</p>
+      <p className="max-w-xs text-[11px] leading-relaxed text-muted-foreground">
+        모바일 앱으로 현장을 측정하면 이곳에 신호 약점 / 이상 구역이 표시됩니다.
+      </p>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { Loader2, Map as MapIcon } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { ChevronRight, Loader2, Map as MapIcon } from 'lucide-react';
 import { useAppStore } from '@/stores/app-store';
 import { useEditorStore } from '@/stores/editor-store';
 import {
@@ -63,12 +64,12 @@ export default function EditorPage() {
   const nextVersionNo =
     versions.length > 0 ? Math.max(...versions.map((v) => v.version_no)) + 1 : 1;
 
-  const handleFile = (file: File) => {
+  const handleFile = (file: File, realWidthM: number) => {
     setPendingFileName(file.name);
     if (!floorId) return;
     analyze.mutate({
       file,
-      real_width_m: 10,
+      real_width_m: realWidthM,
       project_id: projectId ?? undefined,
       floor_id: floorId,
     });
@@ -95,14 +96,17 @@ export default function EditorPage() {
   const openFilePicker = () => fileInputRef.current?.click();
 
   // Wire global header buttons (도면 불러오기 / 도면 저장하기) to this page.
+  // 저장하기는 활성 draft 가 있고 다른 mutation 이 안 돌고 있을 때만 활성화.
+  const canSave =
+    !!activeDraftSummary && !analyze.isPending && !promote.isPending && !removeDraft.isPending;
   useEffect(() => {
     registerActions({
       onLoadFloorplan: openFilePicker,
-      onSaveFloorplan: handlePromote,
+      onSaveFloorplan: canSave ? handlePromote : undefined,
     });
     return () => clearActions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeDraftSummary?.id, nextVersionNo]);
+  }, [activeDraftSummary?.id, nextVersionNo, canSave]);
 
   const isBusy = analyze.isPending;
   const showOverlay =
@@ -117,47 +121,51 @@ export default function EditorPage() {
       />
 
       <div className="relative flex flex-1 overflow-hidden">
-        <CanvasArea
-          fileInputRef={fileInputRef}
-          isPending={isBusy}
-          errorMessage={readError(analyze.error) ?? undefined}
-          selectedFileName={pendingFileName}
-          onFile={handleFile}
-        />
+        {floorId ? (
+          <>
+            <CanvasArea
+              fileInputRef={fileInputRef}
+              isPending={isBusy}
+              errorMessage={readError(analyze.error) ?? undefined}
+              selectedFileName={pendingFileName}
+              onFile={handleFile}
+            />
 
-        {showOverlay && (
-          <OverlayLayer>
-            {!floorId ? (
-              <NoFloorCard hasProject={!!projectId} />
-            ) : justPromoted ? (
-              <PromotedCard
-                version={justPromoted}
-                onReupload={() => {
-                  setJustPromoted(null);
-                  setPendingFileName(null);
-                }}
-              />
-            ) : analyze.isPending ? (
-              <BusyOverlay
-                title="도면 분석 중..."
-                subtitle="이미지 분석은 수십 초 정도 걸릴 수 있습니다."
-              />
-            ) : activeDraft ? (
-              <ReviewCard
-                draft={activeDraft}
-                nextVersionNo={nextVersionNo}
-                isPromoting={promote.isPending}
-                isResetting={removeDraft.isPending}
-                onPromote={handlePromote}
-                onReset={handleResetDraft}
-                errorMessage={
-                  readError(promote.error) ?? readError(removeDraft.error) ?? undefined
-                }
-              />
-            ) : activeDraftSummary ? (
-              <BusyOverlay title="Draft 불러오는 중..." />
-            ) : null}
-          </OverlayLayer>
+            {showOverlay && (
+              <OverlayLayer>
+                {justPromoted ? (
+                  <PromotedCard
+                    version={justPromoted}
+                    onReupload={() => {
+                      setJustPromoted(null);
+                      setPendingFileName(null);
+                    }}
+                  />
+                ) : analyze.isPending ? (
+                  <BusyOverlay
+                    title="도면 분석 중..."
+                    subtitle="이미지 분석은 수십 초 정도 걸릴 수 있습니다."
+                  />
+                ) : activeDraft ? (
+                  <ReviewCard
+                    draft={activeDraft}
+                    nextVersionNo={nextVersionNo}
+                    isPromoting={promote.isPending}
+                    isResetting={removeDraft.isPending}
+                    onPromote={handlePromote}
+                    onReset={handleResetDraft}
+                    errorMessage={
+                      readError(promote.error) ?? readError(removeDraft.error) ?? undefined
+                    }
+                  />
+                ) : activeDraftSummary ? (
+                  <BusyOverlay title="Draft 불러오는 중..." />
+                ) : null}
+              </OverlayLayer>
+            )}
+          </>
+        ) : (
+          <NoFloorScreen hasProject={!!projectId} />
         )}
       </div>
 
@@ -188,16 +196,29 @@ function BusyOverlay({ title, subtitle }: { title: string; subtitle?: string }) 
   );
 }
 
-function NoFloorCard({ hasProject }: { hasProject: boolean }) {
+function NoFloorScreen({ hasProject }: { hasProject: boolean }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed bg-card p-10 text-center shadow-sm">
-      <MapIcon className="h-8 w-8 text-muted-foreground/60" />
-      <p className="text-sm font-medium">
-        {hasProject ? '층을 선택해주세요' : '프로젝트를 먼저 선택해주세요'}
-      </p>
-      <p className="text-xs text-muted-foreground">
-        대시보드에서 작업할 도면(층)을 선택하면 편집을 시작할 수 있습니다.
-      </p>
+    <div className="flex flex-1 items-center justify-center bg-muted/30 p-10">
+      <div className="flex max-w-md flex-col items-center justify-center gap-3 rounded-xl border border-dashed bg-background p-10 text-center shadow-sm">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
+          <MapIcon className="h-6 w-6 text-primary" strokeWidth={1.8} />
+        </div>
+        <p className="text-base font-semibold">
+          {hasProject ? '층을 선택해주세요' : '프로젝트를 먼저 선택해주세요'}
+        </p>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          대시보드에서 프로젝트와 도면(층)을 선택하면
+          <br />
+          편집을 시작할 수 있습니다.
+        </p>
+        <Link
+          to="/dashboard"
+          className="mt-2 inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          대시보드로 이동
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -1,15 +1,98 @@
+import { useState } from 'react';
+import { Clock, Smartphone } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { HelpFab } from '@/components/HelpFab';
+import {
+  MeasurementCanvas,
+  type MeasurementView,
+} from '@/features/measurement/MeasurementCanvas';
+import { DiagnosticPanel } from '@/features/measurement/DiagnosticPanel';
+
+const TABS: { id: MeasurementView; label: string }[] = [
+  { id: 'path', label: '측정 경로 보기' },
+  { id: 'heatmap', label: '실측 히트맵' },
+  { id: 'combined', label: '예측·실측 통합 분석' },
+];
+
 export default function MeasurementPage() {
+  const [view, setView] = useState<MeasurementView>('path');
+
   return (
-    <div className="h-full space-y-6 overflow-auto p-6">
-      <header className="space-y-1.5">
-        <h1 className="text-2xl font-semibold tracking-tight">실측·진단</h1>
-        <p className="text-sm text-muted-foreground">
-          모바일 기기로 측정한 실제 와이파이 품질 데이터와 시뮬레이션을 통합하여 분석합니다.
-        </p>
-      </header>
-      <div className="flex h-[60vh] items-center justify-center rounded-xl border bg-muted/30 text-sm text-muted-foreground">
-        (측정 경로 / 히트맵 / 통합 분석 — 실측 API 연결 예정)
+    <div className="relative flex h-full flex-col p-6">
+      <PageHeader />
+      <div className="mt-5">
+        <Tabs view={view} onChange={setView} />
       </div>
+
+      <div className="mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">
+        <div className="min-h-0 rounded-2xl border bg-background p-4 shadow-sm">
+          <MeasurementCanvas view={view} />
+        </div>
+        <aside className="flex min-h-0 flex-col overflow-y-auto pr-1">
+          <DiagnosticPanel />
+        </aside>
+      </div>
+
+      <HelpFab />
     </div>
   );
 }
+
+function PageHeader() {
+  return (
+    <header className="flex items-start justify-between gap-4">
+      <div className="space-y-1.5">
+        <h1 className="text-2xl font-semibold tracking-tight">실측 및 진단</h1>
+        <p className="text-sm text-muted-foreground">
+          모바일 기기로 측정한 실제 와이파이 품질 데이터와 시뮬레이션을 통합하여 분석합니다.
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent"
+        >
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          이력 보기 <span className="text-muted-foreground">(어제 오후 3:15)</span>
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+        >
+          <Smartphone className="h-4 w-4" />
+          새로운 측정 시작
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function Tabs({
+  view,
+  onChange,
+}: {
+  view: MeasurementView;
+  onChange: (next: MeasurementView) => void;
+}) {
+  return (
+    <nav className="flex items-center gap-6 border-b" role="tablist">
+      {TABS.map((t) => (
+        <button
+          key={t.id}
+          role="tab"
+          aria-selected={view === t.id}
+          onClick={() => onChange(t.id)}
+          className={cn(
+            '-mb-px border-b-2 pb-3 text-sm font-semibold transition-colors',
+            view === t.id
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,13 +1,151 @@
+import { Camera, MapPin, Smartphone } from 'lucide-react';
+
+const FLOW_STEPS = [
+  '권한 동의 (시작하기 전)',
+  'QR 스캔을 통한 손쉬운 연결',
+  '직관적인 모드 선택',
+  'AR 기반 가구 스캔 UI',
+  '간단한 원클릭 와이파이 실측 수집',
+];
+
 export default function MobileAppPage() {
   return (
-    <div className="h-full space-y-6 overflow-auto p-6">
-      <header className="space-y-1.5">
-        <h1 className="text-2xl font-semibold tracking-tight">모바일 앱</h1>
-        <p className="text-sm text-muted-foreground">QR 코드로 모바일 기기 연결</p>
-      </header>
-      <div className="flex h-[60vh] items-center justify-center rounded-xl border bg-muted/30 text-sm text-muted-foreground">
-        (모바일 앱 연결 흐름 구현 예정)
+    <div className="h-full overflow-auto bg-muted/20 p-10">
+      <div className="mx-auto flex max-w-6xl items-start justify-center gap-12">
+        <PhoneMockup />
+        <InfoCard />
       </div>
+    </div>
+  );
+}
+
+function PhoneMockup() {
+  return (
+    <div className="relative w-[320px] shrink-0 rounded-[44px] border-[6px] border-foreground bg-background shadow-2xl">
+      {/* 노치 */}
+      <div className="absolute left-1/2 top-2 z-10 h-5 w-28 -translate-x-1/2 rounded-full bg-foreground" />
+
+      <div className="overflow-hidden rounded-[36px]">
+        {/* 상태바 */}
+        <div className="flex items-center justify-between px-6 pt-3 pb-1 text-[11px] font-semibold">
+          <span>12:30</span>
+          <StatusIcons />
+        </div>
+
+        {/* 본문 */}
+        <div className="flex h-[610px] flex-col px-6 pb-6 pt-8">
+          <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
+            <Smartphone className="h-6 w-6 text-primary" strokeWidth={1.8} />
+          </div>
+
+          <h2 className="text-[22px] font-bold leading-snug">
+            시작하기 전에
+            <br />
+            권한이 필요해요
+          </h2>
+
+          <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">
+            현장에서 원활하게 데이터를 수집하고 대시보드와 연결하기 위해 아래
+            권한을 허용해 주세요.
+          </p>
+
+          <ul className="mt-7 space-y-5">
+            <PermissionRow
+              icon={<Camera className="h-4 w-4" strokeWidth={1.8} />}
+              title="카메라"
+              description="웹 대시보드의 QR 코드를 스캔하고, 공간의 가구를 자동으로 인식합니다."
+            />
+            <PermissionRow
+              icon={<MapPin className="h-4 w-4" strokeWidth={1.8} />}
+              title="위치 및 주변 기기"
+              description="실제 걸어다니며 와이파이 신호 강도와 품질을 정확하게 측정합니다."
+            />
+          </ul>
+
+          <div className="flex-1" />
+
+          <button
+            type="button"
+            className="w-full rounded-xl bg-primary py-3.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+          >
+            동의하고 시작하기
+          </button>
+
+          {/* iOS 하단 핸들 */}
+          <div className="mx-auto mt-3 h-1 w-28 rounded-full bg-foreground/80" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PermissionRow({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <li className="flex items-start gap-3">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <p className="text-[13px] font-semibold">{title}</p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+function InfoCard() {
+  return (
+    <section className="w-[360px] shrink-0 rounded-2xl border bg-background p-6 shadow-sm">
+      <header className="flex items-center gap-2">
+        <Smartphone className="h-5 w-5 text-foreground" strokeWidth={1.8} />
+        <h3 className="text-base font-bold">모바일 앱 프로토타입</h3>
+      </header>
+
+      <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">
+        비전문가인 소상공인이 현장에서 간편하게 와이파이 품질을 측정하고
+        가구를 스캔할 수 있도록 돕는 Android 컴패니언 앱 디자인입니다.
+      </p>
+
+      <h4 className="mt-6 text-sm font-semibold">주요 화면 플로우</h4>
+      <ul className="mt-3 space-y-2 text-[13px] text-foreground/80">
+        {FLOW_STEPS.map((step) => (
+          <li key={step} className="flex items-start gap-2">
+            <span className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/60" />
+            <span>{step}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function StatusIcons() {
+  return (
+    <div className="flex items-center gap-1">
+      <svg width="14" height="10" viewBox="0 0 14 10" fill="currentColor">
+        <path d="M7 0a7 7 0 0 1 5 2.1l-1 1A5.6 5.6 0 0 0 7 1.4 5.6 5.6 0 0 0 3 3.1l-1-1A7 7 0 0 1 7 0Zm0 2.8a4.2 4.2 0 0 1 3 1.3l-1 1A2.8 2.8 0 0 0 7 4.2 2.8 2.8 0 0 0 5 5.1l-1-1A4.2 4.2 0 0 1 7 2.8Zm0 2.8a1.4 1.4 0 0 1 1 .4L7 7l-1-1a1.4 1.4 0 0 1 1-.4Z" />
+      </svg>
+      <svg width="14" height="10" viewBox="0 0 18 12" fill="currentColor">
+        <rect x="0" y="6" width="3" height="6" rx="1" />
+        <rect x="5" y="3" width="3" height="9" rx="1" />
+        <rect x="10" y="0" width="3" height="12" rx="1" />
+        <rect x="15" y="6" width="3" height="6" rx="1" opacity="0.4" />
+      </svg>
+      <svg width="22" height="11" viewBox="0 0 24 12" fill="none">
+        <rect x="0.5" y="0.5" width="20" height="11" rx="3" stroke="currentColor" />
+        <rect x="2" y="2" width="17" height="8" rx="1.5" fill="currentColor" />
+        <rect x="21" y="3.5" width="1.5" height="5" rx="0.75" fill="currentColor" />
+      </svg>
     </div>
   );
 }

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -1,15 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+import { Play, RotateCcw, Save } from 'lucide-react';
+import { HelpFab } from '@/components/HelpFab';
+import {
+  SimulationCanvas,
+  type SimulationState,
+} from '@/features/simulation/SimulationCanvas';
+import { SimulationResultCard } from '@/features/simulation/SimulationResultCard';
+import {
+  SimulationHistory,
+  type SimulationHistoryItem,
+} from '@/features/simulation/SimulationHistory';
+
+// 시뮬레이션 기록 mock — 실제는 RF Run + Job 목록에서 가져올 예정 (§13 / §15).
+const HISTORY_BASE: SimulationHistoryItem[] = [
+  {
+    id: 'sim-base',
+    label: '초기 배치 (어제)',
+    timeLabel: '14:20',
+    avgRssiDbm: -72,
+    coveragePercent: 65,
+  },
+];
+
+const NEW_RESULT: SimulationHistoryItem = {
+  id: 'sim-new',
+  label: '새로운 가구 배치 (방금 전)',
+  timeLabel: '오후 02:18',
+  avgRssiDbm: -62,
+  coveragePercent: 85,
+  active: true,
+};
+
+const SIM_DURATION_MS = 2500;
+
 export default function SimulationPage() {
+  const [state, setState] = useState<SimulationState>('idle');
+  const [expanded, setExpanded] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+  }, []);
+
+  const startSimulation = () => {
+    setState('running');
+    timerRef.current = window.setTimeout(() => setState('complete'), SIM_DURATION_MS);
+  };
+
+  const resetSimulation = () => {
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    setState('idle');
+  };
+
+  const history =
+    state === 'complete' ? [NEW_RESULT, ...HISTORY_BASE] : HISTORY_BASE;
+
   return (
-    <div className="h-full space-y-6 overflow-auto p-6">
-      <header className="space-y-1.5">
+    <div className="relative flex h-full flex-col p-6">
+      <PageHeader
+        state={state}
+        onStart={startSimulation}
+        onReset={resetSimulation}
+      />
+
+      <div
+        className={
+          expanded
+            ? 'mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6'
+            : 'mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]'
+        }
+      >
+        <div className="min-h-0">
+          <SimulationCanvas
+            state={state}
+            expanded={expanded}
+            onToggleExpand={() => setExpanded((v) => !v)}
+          />
+        </div>
+
+        {!expanded && (
+          <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
+            {state === 'complete' && (
+              <SimulationResultCard
+                avgRssiDbm={NEW_RESULT.avgRssiDbm}
+                coveragePercent={NEW_RESULT.coveragePercent}
+              />
+            )}
+            <SimulationHistory
+              items={history}
+              showCompareButton={state !== 'idle' && history.length >= 2}
+            />
+          </aside>
+        )}
+      </div>
+
+      <HelpFab />
+    </div>
+  );
+}
+
+function PageHeader({
+  state,
+  onStart,
+  onReset,
+}: {
+  state: SimulationState;
+  onStart: () => void;
+  onReset: () => void;
+}) {
+  return (
+    <header className="flex items-start justify-between gap-4">
+      <div className="space-y-1.5">
         <h1 className="text-2xl font-semibold tracking-tight">시뮬레이션</h1>
         <p className="text-sm text-muted-foreground">
           저장된 도면을 불러와 가구와 AP를 자유롭게 배치하고 예상 품질을 비교합니다.
         </p>
-      </header>
-      <div className="flex h-[60vh] items-center justify-center rounded-xl border bg-muted/30 text-sm text-muted-foreground">
-        (RF 시뮬레이션 + AP 배치 — RF/AP API 연결 예정)
       </div>
-    </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {state === 'idle' ? (
+          <button
+            type="button"
+            onClick={onStart}
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+          >
+            <Play className="h-4 w-4 fill-current" />
+            시뮬레이션 실행
+          </button>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={onReset}
+              className="inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent"
+            >
+              <RotateCcw className="h-4 w-4" />
+              배치 다시하기
+            </button>
+            <button
+              type="button"
+              disabled={state === 'running'}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 disabled:opacity-60"
+            >
+              <Save className="h-4 w-4" />
+              시뮬레이션 저장하기
+            </button>
+          </>
+        )}
+      </div>
+    </header>
   );
 }
+


### PR DESCRIPTION
- 대시보드: FloorPreview(미니 도면 SVG) + DiagnosticsList + 확대 토글
  + 층 미선택 시 빈 상태 처리
- 시뮬레이션: idle/running/complete 3-state 흐름 (AP 추가 메뉴 / 히트맵 /
  결과 카드 / 기록 리스트) + 확대 토글 + viewport 동적 사이징
- 실측·진단: 3 탭(경로/히트맵/통합) + 측정 포인트 SVG + 진단 패널
  + viewport 동적 사이징
- 모바일 앱: 폰 mockup + 권한 동의 화면 + 프로토타입 설명 카드
- 에디터:
  - CanvasArea 에 real_width_m 입력 UI 복귀 (하드코딩 10m 제거)
  - CanvasToolbar 라벨 변경 (벽/구조물·가구 배치·구역 라벨)
  - 헤더 "도면 저장하기" 를 활성 draft 없을 때 disabled
- 공통: HelpFab 컴포넌트 추출 (페이지별 중복 제거)