### PR TITLE
Fix:헬퍼를 거쳐  PostGIS로 변환되어 저장되도록 수정

### DIFF
--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -17,6 +17,13 @@ from app.core.settings import (
     DEFAULT_DRAFT_SOURCE,
     DEFAULT_DRAFT_SOURCE_MODE,
 )
+from app.geometry import (
+    object_point_geom,
+    opening_line_geom,
+    room_centroid_geom,
+    room_polygon_geom,
+    wall_centerline_geom,
+)
 from app.models import (
     DraftObject,
     DraftOpening,
@@ -165,6 +172,8 @@ def save_scene_draft(
         created_by=request_dto.created_by or current_user.email,
     )
 
+    scale_ratio = float(request_dto.scene.scale_ratio or 1.0)
+
     try:
         db.add(scene_draft)
         db.flush()
@@ -176,6 +185,8 @@ def save_scene_draft(
                     room_name=str(room.get("id")) if room.get("id") is not None else None,
                     room_type=room.get("type"),
                     source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                    polygon_geom=room_polygon_geom(room, scale_ratio),
+                    centroid_geom=room_centroid_geom(room, scale_ratio),
                     metadata_json={"raw": room},
                 )
             )
@@ -189,6 +200,7 @@ def save_scene_draft(
                 height_m=_to_float(wall.get("height")),
                 material_label=wall.get("material"),
                 source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                centerline_geom=wall_centerline_geom(wall, scale_ratio),
                 metadata_json={"raw": wall},
             )
             db.add(draft_wall)
@@ -215,6 +227,7 @@ def save_scene_draft(
                     width_m=_positive(width, 0.8),
                     height_m=_positive(height, 1.2),
                     source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                    line_geom=opening_line_geom(opening, scale_ratio),
                     metadata_json={"raw": opening},
                 )
             )
@@ -227,6 +240,7 @@ def save_scene_draft(
                     object_type=obj_type,
                     confidence=_to_float(obj.get("score") or obj.get("confidence")),
                     source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
+                    point_geom=object_point_geom(obj, scale_ratio),
                     metadata_json={"raw": obj},
                 )
             )


### PR DESCRIPTION
## Summary

AI/Fusion 결과로 생성된 SceneDraft 데이터를 DB에 저장할 때, 기존에는 벽/방/개구부/객체의 공간 좌표가 대부분 `metadata_json.raw`에만 저장되고 PostGIS geometry 컬럼은 비어 있었습니다.

이번 PR에서는 `SceneDraft` 저장 단계에서 `scale_ratio`를 기준으로 픽셀 좌표를 미터 좌표계로 변환하고, 각 Draft 모델의 geometry 컬럼에 매핑하도록 수정했습니다.

## Changes

### 1. Geometry 변환 유틸 적용

`app.geometry`의 geometry 변환 함수를 `scene_draft_service.py`에 연결했습니다.

- `room_polygon_geom`
- `room_centroid_geom`
- `wall_centerline_geom`
- `opening_line_geom`
- `object_point_geom`

### 2. SceneDraft 저장 시 scale_ratio 적용

`request_dto.scene.scale_ratio` 값을 사용하여 AI/Fusion 결과의 픽셀 좌표를 미터 좌표로 변환할 수 있도록 했습니다.

```python
scale_ratio = float(request_dto.scene.scale_ratio or 1.0)
```