### PR TITLE
fix: GET /scene-drafts/{id} 응답에 geometry 필드 추가 (#50)

### DIFF
--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -78,6 +78,8 @@ class DraftRoomResponse(BaseModel):
     room_type: str | None
     confidence: Decimal | None
     source_method: str | None
+    polygon_geom: dict[str, Any] | None = None
+    centroid_geom: dict[str, Any] | None = None
     metadata_json: dict[str, Any]
     created_at: datetime
 
@@ -93,6 +95,8 @@ class DraftWallResponse(BaseModel):
     material_label: str | None
     confidence: Decimal | None
     source_method: str | None
+    centerline_geom: dict[str, Any] | None = None
+    polygon_geom: dict[str, Any] | None = None
     metadata_json: dict[str, Any]
     created_at: datetime
 
@@ -109,6 +113,8 @@ class DraftOpeningResponse(BaseModel):
     sill_height_m: Decimal | None
     confidence: Decimal | None
     source_method: str | None
+    line_geom: dict[str, Any] | None = None
+    polygon_geom: dict[str, Any] | None = None
     metadata_json: dict[str, Any]
     created_at: datetime
 
@@ -121,6 +127,7 @@ class DraftObjectResponse(BaseModel):
     object_type: str
     confidence: Decimal | None
     source_method: str | None
+    point_geom: dict[str, Any] | None = None
     z_m: Decimal | None
     metadata_json: dict[str, Any]
     created_at: datetime

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session, selectinload
 from app.schemas.pagination import PaginatedResponse
 
 from app.core.errors import AppError, ErrorCode
+from app.core.geom import wkb_to_geojson
 from app.core.settings import (
     DEFAULT_DRAFT_ANALYSIS_METHOD,
     DEFAULT_DRAFT_FLOOR_NAME,
@@ -36,6 +37,10 @@ from app.models import (
 )
 from app.schemas.scene_draft import (
     AnalyzeFromAssetResponse,
+    DraftObjectResponse,
+    DraftOpeningResponse,
+    DraftRoomResponse,
+    DraftWallResponse,
     SaveSceneDraftRequestDTO,
     SaveSceneDraftResultDTO,
     SceneDraftDetailResponse,
@@ -361,12 +366,79 @@ def get_scene_draft(
         source_method=scene_draft.source_method,
         summary_json=scene_draft.summary_json,
         status=scene_draft.status,
-        rooms=scene_draft.draft_rooms,
-        walls=scene_draft.draft_walls,
-        openings=scene_draft.draft_openings,
-        objects=scene_draft.draft_objects,
+        rooms=[_draft_room_to_response(r) for r in scene_draft.draft_rooms],
+        walls=[_draft_wall_to_response(w) for w in scene_draft.draft_walls],
+        openings=[_draft_opening_to_response(o) for o in scene_draft.draft_openings],
+        objects=[_draft_object_to_response(o) for o in scene_draft.draft_objects],
         created_at=scene_draft.created_at,
         updated_at=scene_draft.updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ORM → DTO 변환 (WKB → GeoJSON 변환 포함)
+# ---------------------------------------------------------------------------
+def _draft_room_to_response(r: DraftRoom) -> DraftRoomResponse:
+    return DraftRoomResponse(
+        id=r.id,
+        scene_draft_id=r.scene_draft_id,
+        room_name=r.room_name,
+        room_type=r.room_type,
+        confidence=r.confidence,
+        source_method=r.source_method,
+        polygon_geom=wkb_to_geojson(r.polygon_geom),
+        centroid_geom=wkb_to_geojson(r.centroid_geom),
+        metadata_json=r.metadata_json or {},
+        created_at=r.created_at,
+    )
+
+
+def _draft_wall_to_response(w: DraftWall) -> DraftWallResponse:
+    return DraftWallResponse(
+        id=w.id,
+        scene_draft_id=w.scene_draft_id,
+        wall_role=w.wall_role,
+        thickness_m=w.thickness_m,
+        height_m=w.height_m,
+        material_label=w.material_label,
+        confidence=w.confidence,
+        source_method=w.source_method,
+        centerline_geom=wkb_to_geojson(w.centerline_geom),
+        polygon_geom=wkb_to_geojson(w.polygon_geom),
+        metadata_json=w.metadata_json or {},
+        created_at=w.created_at,
+    )
+
+
+def _draft_opening_to_response(o: DraftOpening) -> DraftOpeningResponse:
+    return DraftOpeningResponse(
+        id=o.id,
+        scene_draft_id=o.scene_draft_id,
+        wall_id=o.wall_id,
+        opening_type=o.opening_type,
+        width_m=o.width_m,
+        height_m=o.height_m,
+        sill_height_m=o.sill_height_m,
+        confidence=o.confidence,
+        source_method=o.source_method,
+        line_geom=wkb_to_geojson(o.line_geom),
+        polygon_geom=wkb_to_geojson(o.polygon_geom),
+        metadata_json=o.metadata_json or {},
+        created_at=o.created_at,
+    )
+
+
+def _draft_object_to_response(o: DraftObject) -> DraftObjectResponse:
+    return DraftObjectResponse(
+        id=o.id,
+        scene_draft_id=o.scene_draft_id,
+        object_type=o.object_type,
+        confidence=o.confidence,
+        source_method=o.source_method,
+        point_geom=wkb_to_geojson(o.point_geom),
+        z_m=o.z_m,
+        metadata_json=o.metadata_json or {},
+        created_at=o.created_at,
     )
 
 def delete_scene_draft(


### PR DESCRIPTION
## Summary
- `GET /scene-drafts/{id}` 응답에 도형 좌표 (geometry) 가 빠져서 프론트 캔버스 렌더링이 막히던 문제 해결
- 4개 자식 Response 스키마에 geometry 필드 추가:
  - `DraftRoomResponse`: `polygon_geom`, `centroid_geom`
  - `DraftWallResponse`: `centerline_geom`, `polygon_geom`
  - `DraftOpeningResponse`: `line_geom`, `polygon_geom`
  - `DraftObjectResponse`: `point_geom`
- `scene_draft_service.get_scene_draft` 에 ORM → DTO 변환 헬퍼 4개 추가 (`_draft_room_to_response` 등) — `app/core/geom.wkb_to_geojson` 으로 PostGIS WKB → GeoJSON 변환
- DB 마이그레이션 / 모델 / save 로직 변경 없음 (기존 코드가 이미 geometry 컬럼에 저장 중이었고, 응답 직렬화 단계에서만 누락됐던 것)

## 응답 예시
```json
{
  "walls": [
    {
      "id": "uuid",
      "wall_role": "outer",
      "centerline_geom": {
        "type": "LineString",
        "coordinates": [[0, 0], [10, 0]]
      },
      "polygon_geom": null,
      ...
    }
  ],
  "rooms": [
    {
      "polygon_geom": {
        "type": "Polygon",
        "coordinates": [[[0,0],[10,0],[10,5],[0,5],[0,0]]]
      },
      "centroid_geom": { "type": "Point", "coordinates": [5, 2.5] },
      ...
    }
  ]
}
```

## Test plan
- [x] 4개 응답 스키마에 geometry 필드 추가 (Optional, default null)
- [x] `GET /scene-drafts/{id}` 호출 → walls / rooms / openings / objects 각 항목에 GeoJSON 좌표 정상 반환
  - Wall `centerline_geom` → LineString
  - Room `polygon_geom` → Polygon, `centroid_geom` → Point
  - Opening `line_geom` → LineString
  - Object `point_geom` → Point
- [x] geometry 가 없는 row 는 null 로 반환 (회귀 없음)
- [x] 기존 메타 필드 (room_name/wall_role/thickness_m 등) 유지