### PR TITLE
feat: 공통 UX(토스트/프로필/알림) + 캔버스 컴포넌트 props 추출

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { QueryProvider } from '@/providers/QueryProvider';
 import { AppRouter } from '@/routes/AppRouter';
+import { Toaster } from '@/components/Toaster';
 
 export default function App() {
   return (
     <QueryProvider>
       <AppRouter />
+      <Toaster />
     </QueryProvider>
   );
 }

--- a/frontend/src/api/scene-draft.ts
+++ b/frontend/src/api/scene-draft.ts
@@ -12,9 +12,12 @@ import type {
   SceneDraftSummary,
 } from '@/types/scene';
 
-// AI 분석은 수십 초 ~ 1분 이상 걸릴 수 있어 axios 글로벌 30s 로는 부족함.
-// (백엔드 비동기 전환되면 빠른 응답으로 바뀌어 이 override 가 사라질 예정)
-const ANALYZE_TIMEOUT_MS = 180_000;
+// AI 분석:
+//  - 콜드 스타트 (SageMaker 컨테이너 새로 띄울 때) 약 10분
+//  - 웜 상태에서는 추론 ~3초
+// 글로벌 30s 로는 콜드 스타트는 물론, 일반 분석도 부족함.
+// 백엔드 비동기 전환 (Job 큐 + 폴링) 끝나면 이 override 가 사라질 예정.
+const ANALYZE_TIMEOUT_MS = 900_000; // 15분
 
 export interface AnalyzeFloorplanParams {
   file: File;

--- a/frontend/src/components/Toaster.tsx
+++ b/frontend/src/components/Toaster.tsx
@@ -1,0 +1,66 @@
+import { CheckCircle2, Info, X, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useToastStore, type Toast, type ToastKind } from '@/stores/toast-store';
+
+const KIND_STYLES: Record<ToastKind, { icon: typeof CheckCircle2; iconClass: string; ring: string }> = {
+  success: {
+    icon: CheckCircle2,
+    iconClass: 'text-emerald-500',
+    ring: 'ring-emerald-200',
+  },
+  error: {
+    icon: XCircle,
+    iconClass: 'text-red-500',
+    ring: 'ring-red-200',
+  },
+  info: {
+    icon: Info,
+    iconClass: 'text-primary',
+    ring: 'ring-primary/30',
+  },
+};
+
+export function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-50 flex w-full max-w-sm flex-col gap-2">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={() => dismiss(t.id)} />
+      ))}
+    </div>
+  );
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  const style = KIND_STYLES[toast.kind];
+  const Icon = style.icon;
+  return (
+    <div
+      role="status"
+      className={cn(
+        'pointer-events-auto flex items-start gap-3 rounded-xl border bg-background p-3.5 shadow-lg ring-1',
+        style.ring,
+      )}
+    >
+      <Icon className={cn('mt-0.5 h-5 w-5 shrink-0', style.iconClass)} />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold">{toast.title}</p>
+        {toast.description && (
+          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+            {toast.description}
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="닫기"
+        className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/DiagnosticsList.tsx
+++ b/frontend/src/features/dashboard/DiagnosticsList.tsx
@@ -1,54 +1,24 @@
 import { AlertTriangle, AlertCircle, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-type Severity = 'critical' | 'warning' | 'good' | 'weak';
+export type DiagnosticSeverity = 'critical' | 'warning' | 'good' | 'weak';
 
-interface Diagnostic {
+export interface Diagnostic {
   id: string;
   location: string;
   timeLabel: string;
-  severity: Severity;
+  severity: DiagnosticSeverity;
   statusText: string;
   description: string;
 }
 
-const MOCK_DIAGNOSTICS: Diagnostic[] = [
-  {
-    id: 'd-1',
-    location: '창고 앞 구석 테이블',
-    timeLabel: '방금 전',
-    severity: 'critical',
-    statusText: '신호 끊김 (-85dBm)',
-    description: '고객 클레임 다수 발생 구역. 철제 수납장 영향 의심됨.',
-  },
-  {
-    id: 'd-2',
-    location: '카운터 포스기 주변',
-    timeLabel: '2시간 전',
-    severity: 'warning',
-    statusText: '간헐적 속도 저하',
-    description: '결제 시 지연 발생. 채널 간섭 확인 필요.',
-  },
-  {
-    id: 'd-3',
-    location: '메인 홀 중앙',
-    timeLabel: '어제',
-    severity: 'good',
-    statusText: '양호 (-45dBm)',
-    description: '특이사항 없음. 정상 서비스 중.',
-  },
-  {
-    id: 'd-4',
-    location: '화장실 앞 복도',
-    timeLabel: '3일 전',
-    severity: 'weak',
-    statusText: '신호 약함 (-72dBm)',
-    description: '콘크리트 벽체 영향으로 보임. 사용상 큰 무리는 없음.',
-  },
-];
+interface Props {
+  items: Diagnostic[];
+  onSeeAll?: () => void;
+}
 
 const SEVERITY_STYLES: Record<
-  Severity,
+  DiagnosticSeverity,
   { dot: string; statusText: string; icon: 'warning' | 'alert' | 'dot' }
 > = {
   critical: { dot: 'bg-red-500', statusText: 'text-red-600', icon: 'warning' },
@@ -57,22 +27,23 @@ const SEVERITY_STYLES: Record<
   weak: { dot: 'bg-slate-300', statusText: 'text-amber-600', icon: 'dot' },
 };
 
-const DOT_TONE: Record<Severity, string> = {
+const DOT_TONE: Record<DiagnosticSeverity, string> = {
   critical: 'bg-red-500',
   warning: 'bg-orange-500',
   good: 'bg-emerald-500',
   weak: 'bg-amber-500',
 };
 
-export function DiagnosticsList() {
+export function DiagnosticsList({ items, onSeeAll }: Props) {
   return (
     <ul className="space-y-4">
-      {MOCK_DIAGNOSTICS.map((d) => (
+      {items.map((d) => (
         <DiagnosticItem key={d.id} item={d} />
       ))}
       <li>
         <button
           type="button"
+          onClick={onSeeAll}
           className="inline-flex w-full items-center justify-center gap-1 rounded-md py-2 text-sm font-medium text-primary hover:text-primary/80"
         >
           진단 내역 전체 보기

--- a/frontend/src/features/dashboard/FloorPreview.tsx
+++ b/frontend/src/features/dashboard/FloorPreview.tsx
@@ -1,14 +1,14 @@
 import { Maximize2, Minimize2, Loader2, Wifi } from 'lucide-react';
-
-// 백엔드/캔버스 연동 전까지의 정적 미니 도면 시각화 (Figma 시안용).
-// 좌표는 800x500 viewBox 기준.
+import type { FloorAp, FloorObject, FloorRoom, FloorScene } from '@/types/floor-scene';
 
 interface Props {
+  scene: FloorScene;
   expanded?: boolean;
   onToggleExpand?: () => void;
 }
 
-export function FloorPreview({ expanded, onToggleExpand }: Props = {}) {
+export function FloorPreview({ scene, expanded, onToggleExpand }: Props) {
+  const { viewBox } = scene;
   return (
     <div className="relative h-full w-full rounded-md border bg-[#f8fafc] p-4 [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
       <div className="absolute right-4 top-4 z-10">
@@ -28,192 +28,47 @@ export function FloorPreview({ expanded, onToggleExpand }: Props = {}) {
 
       <div className="relative mx-auto flex h-full max-w-3xl items-center justify-center">
         <svg
-          viewBox="0 0 800 500"
+          viewBox={`0 0 ${viewBox.width} ${viewBox.height}`}
           preserveAspectRatio="xMidYMid meet"
           className="h-full w-full"
         >
-          {/* 외곽 도면 박스 */}
+          {/* 외곽 도면 */}
           <rect
             x="60"
             y="80"
-            width="680"
-            height="360"
+            width={viewBox.width - 120}
+            height={viewBox.height - 140}
             rx="6"
             fill="white"
             stroke="oklch(0.85 0 0)"
             strokeWidth="2"
           />
-
-          {/* 왼쪽 구획 (주방/창고 영역) */}
           <line
             x1="290"
             y1="80"
             x2="290"
-            y2="440"
+            y2={viewBox.height - 60}
             stroke="oklch(0.88 0 0)"
             strokeWidth="2"
           />
 
-          {/* 주방/카운터 */}
-          <g>
-            <rect
-              x="100"
-              y="120"
-              width="160"
-              height="120"
-              rx="8"
-              fill="oklch(0.92 0 0)"
-            />
-            <text
-              x="180"
-              y="186"
-              textAnchor="middle"
-              className="fill-foreground/70"
-              style={{ fontSize: '15px', fontWeight: 500 }}
-            >
-              주방 / 카운터
-            </text>
-          </g>
+          {scene.rooms.map((room) => (
+            <RoomShape key={room.id} room={room} />
+          ))}
 
-          {/* 창고 */}
-          <g>
-            <rect
-              x="100"
-              y="280"
-              width="160"
-              height="120"
-              rx="8"
-              fill="oklch(0.92 0 0)"
-            />
-            <text
-              x="180"
-              y="346"
-              textAnchor="middle"
-              className="fill-foreground/70"
-              style={{ fontSize: '15px', fontWeight: 500 }}
-            >
-              창고
-            </text>
-          </g>
+          {scene.objects.map((obj) =>
+            obj.id === scene.selectedObjectId ? (
+              <SelectedObject key={obj.id} obj={obj} />
+            ) : (
+              <FurnitureShape key={obj.id} obj={obj} />
+            ),
+          )}
 
-          {/* 테이블 (우상단 원) */}
-          <g>
-            <circle
-              cx="600"
-              cy="170"
-              r="44"
-              fill="oklch(0.95 0.04 256)"
-            />
-            <text
-              x="600"
-              y="176"
-              textAnchor="middle"
-              className="fill-primary/80"
-              style={{ fontSize: '13px', fontWeight: 500 }}
-            >
-              테이블
-            </text>
-          </g>
-
-          {/* 테이블 (좌하단 원) */}
-          <g>
-            <circle
-              cx="370"
-              cy="340"
-              r="40"
-              fill="oklch(0.95 0.04 256)"
-            />
-            <text
-              x="370"
-              y="346"
-              textAnchor="middle"
-              className="fill-primary/80"
-              style={{ fontSize: '13px', fontWeight: 500 }}
-            >
-              테이블
-            </text>
-          </g>
-
-          {/* 단체석 */}
-          <g>
-            <rect
-              x="620"
-              y="320"
-              width="100"
-              height="50"
-              rx="6"
-              fill="oklch(0.95 0.04 256)"
-            />
-            <text
-              x="670"
-              y="350"
-              textAnchor="middle"
-              className="fill-primary/80"
-              style={{ fontSize: '13px', fontWeight: 500 }}
-            >
-              단체석
-            </text>
-          </g>
-
-          {/* 선택된 테이블 (가운데, blue border + 핸들) */}
-          <g>
-            <rect
-              x="440"
-              y="290"
-              width="140"
-              height="80"
-              rx="4"
-              fill="white"
-              stroke="oklch(0.55 0.22 264)"
-              strokeWidth="2"
-            />
-            {/* 4 corner handles */}
-            <Handle cx={440} cy={290} />
-            <Handle cx={580} cy={290} />
-            <Handle cx={440} cy={370} />
-            <Handle cx={580} cy={370} />
-            {/* 우상단 검은 작은 탭 */}
-            <rect
-              x="565"
-              y="282"
-              width="14"
-              height="14"
-              fill="oklch(0.2 0 0)"
-            />
-            {/* 위쪽 회전 핸들 */}
-            <line
-              x1="510"
-              y1="290"
-              x2="510"
-              y2="252"
-              stroke="oklch(0.55 0.22 264)"
-              strokeWidth="2"
-            />
-            <circle
-              cx="510"
-              cy="244"
-              r="11"
-              fill="oklch(0.55 0.22 264)"
-            />
-            <text
-              x="510"
-              y="248"
-              textAnchor="middle"
-              fill="white"
-              style={{ fontSize: '11px', fontWeight: 600 }}
-            >
-              ↑
-            </text>
-          </g>
-
-          {/* AP 1 — 상단 중앙 */}
-          <ApMarker cx={430} cy={170} label="AP 1" />
-
-          {/* AP 2 — 우하단 */}
-          <ApMarker cx={680} cy={420} label="AP 2" />
+          {scene.aps.map((ap) => (
+            <ApMarker key={ap.id} ap={ap} />
+          ))}
         </svg>
 
-        {/* Live preview loading 토스트 */}
         <div className="pointer-events-none absolute bottom-2 left-1/2 -translate-x-1/2">
           <div className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-medium text-white shadow-lg">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -222,6 +77,109 @@ export function FloorPreview({ expanded, onToggleExpand }: Props = {}) {
         </div>
       </div>
     </div>
+  );
+}
+
+function RoomShape({ room }: { room: FloorRoom }) {
+  return (
+    <g>
+      <rect
+        x={room.x}
+        y={room.y}
+        width={room.width}
+        height={room.height}
+        rx="8"
+        fill="oklch(0.92 0 0)"
+      />
+      <text
+        x={room.x + room.width / 2}
+        y={room.y + room.height / 2 + 6}
+        textAnchor="middle"
+        className="fill-foreground/70"
+        style={{ fontSize: '15px', fontWeight: 500 }}
+      >
+        {room.label}
+      </text>
+    </g>
+  );
+}
+
+function FurnitureShape({ obj }: { obj: FloorObject }) {
+  if (obj.shape === 'circle') {
+    const { cx = 0, cy = 0, r = 30 } = obj;
+    return (
+      <g>
+        <circle cx={cx} cy={cy} r={r} fill="oklch(0.95 0.04 256)" />
+        <text
+          x={cx}
+          y={cy + 6}
+          textAnchor="middle"
+          className="fill-primary/80"
+          style={{ fontSize: '13px', fontWeight: 500 }}
+        >
+          {obj.label}
+        </text>
+      </g>
+    );
+  }
+  const { x = 0, y = 0, width = 0, height = 0 } = obj;
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} rx="6" fill="oklch(0.95 0.04 256)" />
+      <text
+        x={x + width / 2}
+        y={y + height / 2 + 5}
+        textAnchor="middle"
+        className="fill-primary/80"
+        style={{ fontSize: '13px', fontWeight: 500 }}
+      >
+        {obj.label}
+      </text>
+    </g>
+  );
+}
+
+function SelectedObject({ obj }: { obj: FloorObject }) {
+  // 현재는 rect 만 지원 (Figma 시안 기준).
+  if (obj.shape !== 'rect') return <FurnitureShape obj={obj} />;
+  const { x = 0, y = 0, width = 0, height = 0 } = obj;
+  const cxCenter = x + width / 2;
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx="4"
+        fill="white"
+        stroke="oklch(0.55 0.22 264)"
+        strokeWidth="2"
+      />
+      <Handle cx={x} cy={y} />
+      <Handle cx={x + width} cy={y} />
+      <Handle cx={x} cy={y + height} />
+      <Handle cx={x + width} cy={y + height} />
+      <rect x={x + width - 15} y={y - 8} width="14" height="14" fill="oklch(0.2 0 0)" />
+      <line
+        x1={cxCenter}
+        y1={y}
+        x2={cxCenter}
+        y2={y - 38}
+        stroke="oklch(0.55 0.22 264)"
+        strokeWidth="2"
+      />
+      <circle cx={cxCenter} cy={y - 46} r="11" fill="oklch(0.55 0.22 264)" />
+      <text
+        x={cxCenter}
+        y={y - 42}
+        textAnchor="middle"
+        fill="white"
+        style={{ fontSize: '11px', fontWeight: 600 }}
+      >
+        ↑
+      </text>
+    </g>
   );
 }
 
@@ -238,23 +196,21 @@ function Handle({ cx, cy }: { cx: number; cy: number }) {
   );
 }
 
-function ApMarker({ cx, cy, label }: { cx: number; cy: number; label: string }) {
+function ApMarker({ ap }: { ap: FloorAp }) {
   return (
     <g>
-      <circle cx={cx} cy={cy} r="22" fill="oklch(0.55 0.22 264)" />
-      <g transform={`translate(${cx - 9}, ${cy - 9})`}>
-        <foreignObject width="18" height="18">
-          <Wifi className="h-[18px] w-[18px] text-white" />
-        </foreignObject>
-      </g>
+      <circle cx={ap.cx} cy={ap.cy} r="22" fill="oklch(0.55 0.22 264)" />
+      <foreignObject x={ap.cx - 9} y={ap.cy - 9} width="18" height="18">
+        <Wifi className="h-[18px] w-[18px] text-white" />
+      </foreignObject>
       <text
-        x={cx}
-        y={cy + 42}
+        x={ap.cx}
+        y={ap.cy + 42}
         textAnchor="middle"
         className="fill-foreground"
         style={{ fontSize: '12px', fontWeight: 600 }}
       >
-        {label}
+        {ap.label}
       </text>
     </g>
   );

--- a/frontend/src/features/dashboard/mocks.ts
+++ b/frontend/src/features/dashboard/mocks.ts
@@ -1,0 +1,59 @@
+import type { FloorScene } from '@/types/floor-scene';
+
+// 백엔드 GET /scene-versions/{id} (도형 노출 후) 로 교체될 예정.
+export const MOCK_DASHBOARD_FLOOR_SCENE: FloorScene = {
+  viewBox: { width: 800, height: 500 },
+  rooms: [
+    { id: 'room-kitchen', label: '주방 / 카운터', x: 100, y: 120, width: 160, height: 120 },
+    { id: 'room-storage', label: '창고', x: 100, y: 280, width: 160, height: 120 },
+  ],
+  objects: [
+    { id: 'obj-table-1', label: '테이블', shape: 'circle', cx: 600, cy: 170, r: 44 },
+    { id: 'obj-table-2', label: '테이블', shape: 'circle', cx: 370, cy: 340, r: 40 },
+    { id: 'obj-group', label: '단체석', shape: 'rect', x: 620, y: 320, width: 100, height: 50 },
+    { id: 'obj-selected', label: '', shape: 'rect', x: 440, y: 290, width: 140, height: 80 },
+  ],
+  aps: [
+    { id: 'ap-1', label: 'AP 1', cx: 430, cy: 170, tone: 'primary' },
+    { id: 'ap-2', label: 'AP 2', cx: 680, cy: 420, tone: 'primary' },
+  ],
+  selectedObjectId: 'obj-selected',
+};
+
+// 백엔드 진단 엔드포인트는 명세에 없음. 추후 별도 협의 필요.
+import type { Diagnostic } from './DiagnosticsList';
+
+export const MOCK_DIAGNOSTICS: Diagnostic[] = [
+  {
+    id: 'd-1',
+    location: '창고 앞 구석 테이블',
+    timeLabel: '방금 전',
+    severity: 'critical',
+    statusText: '신호 끊김 (-85dBm)',
+    description: '고객 클레임 다수 발생 구역. 철제 수납장 영향 의심됨.',
+  },
+  {
+    id: 'd-2',
+    location: '카운터 포스기 주변',
+    timeLabel: '2시간 전',
+    severity: 'warning',
+    statusText: '간헐적 속도 저하',
+    description: '결제 시 지연 발생. 채널 간섭 확인 필요.',
+  },
+  {
+    id: 'd-3',
+    location: '메인 홀 중앙',
+    timeLabel: '어제',
+    severity: 'good',
+    statusText: '양호 (-45dBm)',
+    description: '특이사항 없음. 정상 서비스 중.',
+  },
+  {
+    id: 'd-4',
+    location: '화장실 앞 복도',
+    timeLabel: '3일 전',
+    severity: 'weak',
+    statusText: '신호 약함 (-72dBm)',
+    description: '콘크리트 벽체 영향으로 보임. 사용상 큰 무리는 없음.',
+  },
+];

--- a/frontend/src/features/header/NotificationsMenu.tsx
+++ b/frontend/src/features/header/NotificationsMenu.tsx
@@ -1,0 +1,132 @@
+import { Bell, CheckCheck, ChevronRight } from 'lucide-react';
+import { Popover } from '@/components/ui/Popover';
+import { cn } from '@/lib/utils';
+
+type NotificationKind = 'analysis' | 'measurement' | 'simulation' | 'system';
+
+interface Notification {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  description: string;
+  timeLabel: string;
+  unread: boolean;
+}
+
+// 백엔드 알림 엔드포인트 없음. 추후 별도 협의 시 useQuery 로 교체 예정.
+const MOCK_NOTIFICATIONS: Notification[] = [
+  {
+    id: 'n-1',
+    kind: 'analysis',
+    title: '도면 분석 완료',
+    description: '1층 도면 분석이 완료되었습니다.',
+    timeLabel: '방금 전',
+    unread: true,
+  },
+  {
+    id: 'n-2',
+    kind: 'measurement',
+    title: '새 실측 데이터 수신',
+    description: '카운터 주변 17개 포인트 측정됨.',
+    timeLabel: '12분 전',
+    unread: true,
+  },
+  {
+    id: 'n-3',
+    kind: 'simulation',
+    title: '시뮬레이션 완료',
+    description: '평균 -62dBm, 커버리지 85%',
+    timeLabel: '어제',
+    unread: false,
+  },
+];
+
+const KIND_DOT: Record<NotificationKind, string> = {
+  analysis: 'bg-primary',
+  measurement: 'bg-emerald-500',
+  simulation: 'bg-violet-500',
+  system: 'bg-slate-400',
+};
+
+export function NotificationsMenu() {
+  const unreadCount = MOCK_NOTIFICATIONS.filter((n) => n.unread).length;
+  return (
+    <Popover
+      align="end"
+      contentClassName="w-80 p-0"
+      trigger={({ toggle }) => (
+        <button
+          onClick={toggle}
+          aria-label="알림"
+          className="relative rounded-md p-2 hover:bg-accent"
+        >
+          <Bell className="h-5 w-5 text-muted-foreground" />
+          {unreadCount > 0 && (
+            <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-destructive" />
+          )}
+        </button>
+      )}
+    >
+      {({ close }) => (
+        <div className="flex max-h-96 flex-col">
+          <header className="flex items-center justify-between border-b px-4 py-3">
+            <h3 className="text-sm font-semibold">알림</h3>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <CheckCheck className="h-3 w-3" />
+              모두 읽음
+            </button>
+          </header>
+
+          <ul className="flex-1 overflow-y-auto">
+            {MOCK_NOTIFICATIONS.length === 0 ? (
+              <li className="px-4 py-8 text-center text-xs text-muted-foreground">
+                새 알림이 없습니다.
+              </li>
+            ) : (
+              MOCK_NOTIFICATIONS.map((n) => (
+                <li key={n.id}>
+                  <button
+                    type="button"
+                    onClick={close}
+                    className="flex w-full items-start gap-2.5 border-b px-4 py-3 text-left hover:bg-accent/40"
+                  >
+                    <span
+                      className={cn(
+                        'mt-1.5 block h-2 w-2 shrink-0 rounded-full',
+                        n.unread ? KIND_DOT[n.kind] : 'bg-transparent ring-1 ring-border',
+                      )}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-start justify-between gap-2">
+                        <p className="truncate text-sm font-medium">{n.title}</p>
+                        <span className="shrink-0 text-[10px] text-muted-foreground">
+                          {n.timeLabel}
+                        </span>
+                      </div>
+                      <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                        {n.description}
+                      </p>
+                    </div>
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+
+          <footer className="border-t p-2">
+            <button
+              type="button"
+              className="inline-flex w-full items-center justify-center gap-1 rounded-md py-1.5 text-xs font-medium text-primary hover:bg-primary/5"
+            >
+              전체 알림 보기
+              <ChevronRight className="h-3 w-3" />
+            </button>
+          </footer>
+        </div>
+      )}
+    </Popover>
+  );
+}

--- a/frontend/src/features/header/ProfileMenu.tsx
+++ b/frontend/src/features/header/ProfileMenu.tsx
@@ -1,0 +1,82 @@
+import { LogIn, LogOut, Settings, User } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Popover } from '@/components/ui/Popover';
+import { useAuthStore } from '@/stores/auth-store';
+import { useLogout } from '@/hooks/use-auth';
+
+export function ProfileMenu() {
+  const user = useAuthStore((s) => s.user);
+  const logout = useLogout();
+  const isAuthed = !!user;
+
+  return (
+    <Popover
+      align="end"
+      contentClassName="w-64 p-0"
+      trigger={({ toggle }) => (
+        <button
+          onClick={toggle}
+          aria-label="프로필"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-muted text-muted-foreground hover:bg-accent"
+        >
+          {user?.name ? (
+            <span className="text-xs font-medium">{user.name.slice(0, 1)}</span>
+          ) : (
+            <User className="h-4 w-4" />
+          )}
+        </button>
+      )}
+    >
+      {({ close }) => (
+        <div>
+          <div className="border-b p-3.5">
+            <p className="truncate text-sm font-semibold">
+              {isAuthed ? user.name : '게스트'}
+            </p>
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {isAuthed ? user.email : '로그인되지 않음'}
+            </p>
+          </div>
+          <ul className="py-1">
+            <li>
+              <Link
+                to="/settings"
+                onClick={close}
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-accent"
+              >
+                <Settings className="h-3.5 w-3.5 text-muted-foreground" />
+                설정
+              </Link>
+            </li>
+            {isAuthed ? (
+              <li>
+                <button
+                  type="button"
+                  onClick={() => {
+                    close();
+                    logout();
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-destructive/5"
+                >
+                  <LogOut className="h-3.5 w-3.5" />
+                  로그아웃
+                </button>
+              </li>
+            ) : (
+              <li>
+                <Link
+                  to="/auth/login"
+                  onClick={close}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm font-medium text-primary hover:bg-primary/5"
+                >
+                  <LogIn className="h-3.5 w-3.5" />
+                  로그인
+                </Link>
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+    </Popover>
+  );
+}

--- a/frontend/src/features/measurement/DiagnosticPanel.tsx
+++ b/frontend/src/features/measurement/DiagnosticPanel.tsx
@@ -1,19 +1,31 @@
 import { Activity, AlertTriangle, ChevronRight, MapPin, QrCode } from 'lucide-react';
+import type { PointDiagnosis } from './mocks';
 
-// 우측 진단 패널 - 선택된 측정 포인트의 예측치/실측치 비교, 상세지표, 원인 분석 mock.
-// 실제로는 GET /measurement-sessions/{id}/points + simulated value 조합으로 채워질 예정.
+interface Props {
+  diagnosis: PointDiagnosis;
+  onShowFix?: () => void;
+}
 
-export function DiagnosticPanel() {
+const SEVERITY_BADGE: Record<PointDiagnosis['severity'], { bg: string; text: string; label: string }> = {
+  bad: { bg: 'bg-red-100', text: 'text-red-600', label: '상태 불량' },
+  warning: { bg: 'bg-amber-100', text: 'text-amber-700', label: '주의 필요' },
+  good: { bg: 'bg-emerald-100', text: 'text-emerald-700', label: '양호' },
+};
+
+export function DiagnosticPanel({ diagnosis, onShowFix }: Props) {
   return (
     <aside className="flex w-90 shrink-0 flex-col gap-4">
-      <CombinedDiagnosisCard />
-      <CauseAnalysisCard />
+      <CombinedDiagnosisCard diagnosis={diagnosis} />
+      <CauseAnalysisCard diagnosis={diagnosis} onShowFix={onShowFix} />
       <MobileConnectCard />
     </aside>
   );
 }
 
-function CombinedDiagnosisCard() {
+function CombinedDiagnosisCard({ diagnosis }: { diagnosis: PointDiagnosis }) {
+  const badge = SEVERITY_BADGE[diagnosis.severity];
+  const measuredColor = diagnosis.severity === 'bad' ? 'text-red-500' : 'text-foreground';
+
   return (
     <section className="rounded-2xl border bg-background p-5 shadow-sm">
       <header className="mb-4 flex items-center gap-2">
@@ -25,32 +37,50 @@ function CombinedDiagnosisCard() {
         <div className="flex items-center gap-1.5">
           <MapPin className="h-4 w-4 text-red-500" />
           <span className="text-base font-bold">
-            창고 앞 구석 <span className="text-foreground/70">(P-05)</span>
+            {diagnosis.pointLabel}{' '}
+            <span className="text-foreground/70">({diagnosis.pointCode})</span>
           </span>
         </div>
-        <span className="shrink-0 rounded-full bg-red-100 px-2.5 py-1 text-[11px] font-semibold text-red-600">
-          상태 불량
+        <span
+          className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold ${badge.bg} ${badge.text}`}
+        >
+          {badge.label}
         </span>
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-3 rounded-lg border bg-muted/30 p-3">
-        <MetricCompare label="예측치 (시뮬레이션)" value="-72" unit="dBm" />
-        <MetricCompare label="실측치 (어제 15:00)" value="-84" unit="dBm" valueColor="text-red-500" />
+        <MetricCompare
+          label="예측치 (시뮬레이션)"
+          value={`${diagnosis.predictedRssiDbm}`}
+          unit="dBm"
+        />
+        <MetricCompare
+          label={`실측치 (${diagnosis.measuredAtLabel})`}
+          value={`${diagnosis.measuredRssiDbm}`}
+          unit="dBm"
+          valueColor={measuredColor}
+        />
       </div>
 
       <div className="mt-4">
         <h4 className="text-xs font-semibold text-foreground/80">상세 품질 지표</h4>
         <div className="mt-2 grid grid-cols-3 gap-2">
-          <Metric value="55ms" label="지연시간" />
-          <Metric value="4.2Mbps" label="다운로드" />
-          <Metric value="2.4GHz" label="대역" />
+          <Metric value={`${diagnosis.latencyMs}ms`} label="지연시간" />
+          <Metric value={`${diagnosis.downloadMbps}Mbps`} label="다운로드" />
+          <Metric value={diagnosis.bandLabel} label="대역" />
         </div>
       </div>
     </section>
   );
 }
 
-function CauseAnalysisCard() {
+function CauseAnalysisCard({
+  diagnosis,
+  onShowFix,
+}: {
+  diagnosis: PointDiagnosis;
+  onShowFix?: () => void;
+}) {
   return (
     <section className="rounded-2xl border bg-background p-5 shadow-sm">
       <header className="mb-3 flex items-center gap-2">
@@ -59,12 +89,12 @@ function CauseAnalysisCard() {
       </header>
 
       <p className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-[13px] leading-relaxed text-foreground/85">
-        예측보다 실측 수치가 훨씬 낮습니다. 창고 가벽의 전파 흡수율이 예상보다
-        높거나, 주변에 전파 간섭을 일으키는 금속성 물체가 있을 수 있습니다.
+        {diagnosis.causeText}
       </p>
 
       <button
         type="button"
+        onClick={onShowFix}
         className="mt-4 inline-flex w-full items-center justify-between rounded-lg border px-3 py-2.5 text-sm font-medium text-foreground/80 hover:bg-accent"
       >
         조치 방법 확인하기

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -1,32 +1,32 @@
 import { Wifi } from 'lucide-react';
+import type {
+  FloorAp,
+  FloorObject,
+  FloorRoom,
+  FloorScene,
+  HeatmapRegion,
+} from '@/types/floor-scene';
+import type { MeasurementPoint, MeasurementSeverity } from './mocks';
 
 export type MeasurementView = 'path' | 'heatmap' | 'combined';
 
 interface Props {
   view: MeasurementView;
+  scene: FloorScene;
+  points: MeasurementPoint[];
+  heatmap?: HeatmapRegion[];
 }
 
-// 측정 포인트 (mock). 실제로는 GET /measurement-sessions/{id}/points 응답으로 받아야 함.
-const POINTS = [
-  { id: 'P-01', x: 420, y: 180, severity: 'good' as const },
-  { id: 'P-02', x: 510, y: 180, severity: 'good' as const },
-  { id: 'P-03', x: 510, y: 280, severity: 'good' as const },
-  { id: 'P-04', x: 320, y: 280, severity: 'good' as const },
-  { id: 'P-05', x: 320, y: 380, severity: 'bad' as const },
-  { id: 'P-06', x: 510, y: 340, severity: 'warning' as const },
-  { id: 'P-07', x: 640, y: 340, severity: 'good' as const },
-  { id: 'P-08', x: 640, y: 440, severity: 'good' as const },
-];
-
-const SEVERITY_COLOR: Record<'good' | 'warning' | 'bad', string> = {
+const SEVERITY_COLOR: Record<MeasurementSeverity, string> = {
   good: 'oklch(0.72 0.18 145)',
   warning: 'oklch(0.78 0.15 85)',
   bad: 'oklch(0.62 0.22 25)',
 };
 
-export function MeasurementCanvas({ view }: Props) {
-  const showHeatmap = view === 'heatmap' || view === 'combined';
+export function MeasurementCanvas({ view, scene, points, heatmap }: Props) {
+  const showHeatmap = (view === 'heatmap' || view === 'combined') && !!heatmap?.length;
   const showPath = view === 'path' || view === 'combined';
+  const { viewBox } = scene;
 
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden rounded-md border bg-[#f8fafc] [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
@@ -36,7 +36,7 @@ export function MeasurementCanvas({ view }: Props) {
 
       <div className="relative min-h-0 flex-1">
         <svg
-          viewBox="0 0 800 520"
+          viewBox={`0 0 ${viewBox.width} ${viewBox.height}`}
           preserveAspectRatio="xMidYMid meet"
           className="h-full w-full p-4"
         >
@@ -59,8 +59,8 @@ export function MeasurementCanvas({ view }: Props) {
           <rect
             x="60"
             y="100"
-            width="680"
-            height="380"
+            width={viewBox.width - 120}
+            height={viewBox.height - 140}
             rx="6"
             fill="white"
             stroke="oklch(0.85 0 0)"
@@ -70,95 +70,43 @@ export function MeasurementCanvas({ view }: Props) {
             x1="290"
             y1="100"
             x2="290"
-            y2="480"
+            y2={viewBox.height - 40}
             stroke="oklch(0.88 0 0)"
             strokeWidth="2"
           />
 
-          {/* 히트맵 레이어 (heatmap, combined 탭에서만) */}
-          {showHeatmap && (
+          {/* 히트맵 레이어 */}
+          {showHeatmap && heatmap && (
             <g>
-              {/* 좋은 영역 (도면 가운데~우측) */}
-              <ellipse cx="480" cy="270" rx="260" ry="190" fill="url(#hot-good)" />
-              {/* 주의 영역 (가운데 약간 우측) */}
-              <ellipse cx="540" cy="340" rx="100" ry="70" fill="url(#hot-warn)" />
-              {/* 불량 영역 (좌하단 창고 앞) */}
-              <ellipse cx="180" cy="400" rx="140" ry="110" fill="url(#hot-bad)" />
+              {heatmap.map((r, i) => (
+                <ellipse
+                  key={`h-${i}`}
+                  cx={r.cx}
+                  cy={r.cy}
+                  rx={r.rx}
+                  ry={r.ry}
+                  fill={`url(#hot-${r.intensity})`}
+                />
+              ))}
             </g>
           )}
 
-          {/* 방/구획 */}
-          <g>
-            <rect x="100" y="140" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
-            <text
-              x="180"
-              y="196"
-              textAnchor="middle"
-              className="fill-foreground/70"
-              style={{ fontSize: '15px', fontWeight: 500 }}
-            >
-              주방 / 카운터
-            </text>
-          </g>
-          <g>
-            <rect x="100" y="280" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
-            <text
-              x="180"
-              y="336"
-              textAnchor="middle"
-              className="fill-foreground/70"
-              style={{ fontSize: '15px', fontWeight: 500 }}
-            >
-              창고
-            </text>
-          </g>
+          {scene.rooms.map((room) => (
+            <RoomShape key={room.id} room={room} />
+          ))}
 
-          {/* 가구 */}
-          <g>
-            <circle cx="600" cy="190" r="42" fill="oklch(0.95 0.04 256)" />
-            <text
-              x="600"
-              y="196"
-              textAnchor="middle"
-              className="fill-primary/80"
-              style={{ fontSize: '13px', fontWeight: 500 }}
-            >
-              테이블
-            </text>
-          </g>
-          <g>
-            <circle cx="380" cy="380" r="38" fill="oklch(0.95 0.04 256)" />
-            <text
-              x="380"
-              y="386"
-              textAnchor="middle"
-              className="fill-primary/80"
-              style={{ fontSize: '13px', fontWeight: 500 }}
-            >
-              테이블
-            </text>
-          </g>
-          <g>
-            <rect x="610" y="370" width="90" height="48" rx="6" fill="oklch(0.95 0.04 256)" />
-            <text
-              x="655"
-              y="400"
-              textAnchor="middle"
-              className="fill-primary/80"
-              style={{ fontSize: '13px', fontWeight: 500 }}
-            >
-              단체석
-            </text>
-          </g>
+          {scene.objects.map((obj) => (
+            <FurnitureShape key={obj.id} obj={obj} />
+          ))}
 
-          {/* 검은 작은 사각형 (선택된 객체 표시 / 측정 마커 anchor) */}
+          {/* 검은 작은 사각형 (선택된 객체 표시 / 측정 마커 anchor) — 시안 일관성 */}
           <rect x="500" y="330" width="14" height="14" fill="oklch(0.2 0 0)" />
 
           {/* 경로 (path, combined 탭에서만) */}
           {showPath && (
             <g>
               <polyline
-                points={POINTS.map((p) => `${p.x},${p.y}`).join(' ')}
+                points={points.map((p) => `${p.x},${p.y}`).join(' ')}
                 fill="none"
                 stroke="oklch(0.55 0.22 264)"
                 strokeWidth="2.5"
@@ -166,7 +114,7 @@ export function MeasurementCanvas({ view }: Props) {
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
-              {POINTS.map((p) => (
+              {points.map((p) => (
                 <circle
                   key={p.id}
                   cx={p.x}
@@ -180,9 +128,9 @@ export function MeasurementCanvas({ view }: Props) {
             </g>
           )}
 
-          {/* AP 마커 */}
-          <ApMarker cx={430} cy={190} label="AP 1" />
-          <ApMarker cx={685} cy={465} label="AP 2" />
+          {scene.aps.map((ap) => (
+            <ApMarker key={ap.id} ap={ap} />
+          ))}
         </svg>
       </div>
     </div>
@@ -191,7 +139,7 @@ export function MeasurementCanvas({ view }: Props) {
 
 function Legend() {
   return (
-    <div className="absolute left-4 top-4 z-10 inline-flex items-center gap-4 rounded-lg border bg-background/90 px-4 py-2 text-xs shadow-sm backdrop-blur">
+    <div className="inline-flex items-center gap-4 rounded-lg border bg-background/90 px-4 py-2 text-xs shadow-sm backdrop-blur">
       <span className="font-semibold text-foreground/80">실측 포인트 범례</span>
       <span className="h-3 w-px bg-border" />
       <LegendDot color="bg-emerald-500" label="양호" />
@@ -210,21 +158,80 @@ function LegendDot({ color, label }: { color: string; label: string }) {
   );
 }
 
-function ApMarker({ cx, cy, label }: { cx: number; cy: number; label: string }) {
+function RoomShape({ room }: { room: FloorRoom }) {
   return (
     <g>
-      <circle cx={cx} cy={cy} r="22" fill="oklch(0.55 0.22 264)" />
-      <foreignObject x={cx - 9} y={cy - 9} width="18" height="18">
+      <rect
+        x={room.x}
+        y={room.y}
+        width={room.width}
+        height={room.height}
+        rx="8"
+        fill="oklch(0.92 0 0)"
+      />
+      <text
+        x={room.x + room.width / 2}
+        y={room.y + room.height / 2 + 6}
+        textAnchor="middle"
+        className="fill-foreground/70"
+        style={{ fontSize: '15px', fontWeight: 500 }}
+      >
+        {room.label}
+      </text>
+    </g>
+  );
+}
+
+function FurnitureShape({ obj }: { obj: FloorObject }) {
+  if (obj.shape === 'circle') {
+    const { cx = 0, cy = 0, r = 30 } = obj;
+    return (
+      <g>
+        <circle cx={cx} cy={cy} r={r} fill="oklch(0.95 0.04 256)" />
+        <text
+          x={cx}
+          y={cy + 6}
+          textAnchor="middle"
+          className="fill-primary/80"
+          style={{ fontSize: '13px', fontWeight: 500 }}
+        >
+          {obj.label}
+        </text>
+      </g>
+    );
+  }
+  const { x = 0, y = 0, width = 0, height = 0 } = obj;
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} rx="6" fill="oklch(0.95 0.04 256)" />
+      <text
+        x={x + width / 2}
+        y={y + height / 2 + 5}
+        textAnchor="middle"
+        className="fill-primary/80"
+        style={{ fontSize: '13px', fontWeight: 500 }}
+      >
+        {obj.label}
+      </text>
+    </g>
+  );
+}
+
+function ApMarker({ ap }: { ap: FloorAp }) {
+  return (
+    <g>
+      <circle cx={ap.cx} cy={ap.cy} r="22" fill="oklch(0.55 0.22 264)" />
+      <foreignObject x={ap.cx - 9} y={ap.cy - 9} width="18" height="18">
         <Wifi className="h-[18px] w-[18px] text-white" />
       </foreignObject>
       <text
-        x={cx}
-        y={cy + 42}
+        x={ap.cx}
+        y={ap.cy + 42}
         textAnchor="middle"
         className="fill-foreground"
         style={{ fontSize: '12px', fontWeight: 600 }}
       >
-        {label}
+        {ap.label}
       </text>
     </g>
   );

--- a/frontend/src/features/measurement/mocks.ts
+++ b/frontend/src/features/measurement/mocks.ts
@@ -1,0 +1,76 @@
+import type { FloorScene, HeatmapRegion } from '@/types/floor-scene';
+
+// 백엔드 §10 측정 도메인이 GET 엔드포인트를 구현하면 이쪽 mock 을 useQuery 로 대체.
+
+export type MeasurementSeverity = 'good' | 'warning' | 'bad';
+
+export interface MeasurementPoint {
+  id: string;
+  x: number;
+  y: number;
+  severity: MeasurementSeverity;
+}
+
+// 선택된 측정 포인트에 대한 진단 (현재 명세에 별도 엔드포인트 없음 — 백엔드와 협의 필요).
+export interface PointDiagnosis {
+  pointLabel: string;
+  pointCode: string;
+  severity: MeasurementSeverity;
+  predictedRssiDbm: number;
+  measuredRssiDbm: number;
+  measuredAtLabel: string;
+  latencyMs: number;
+  downloadMbps: number;
+  bandLabel: string;
+  causeText: string;
+}
+
+export const MOCK_MEASUREMENT_FLOOR_SCENE: FloorScene = {
+  viewBox: { width: 800, height: 520 },
+  rooms: [
+    { id: 'room-kitchen', label: '주방 / 카운터', x: 100, y: 140, width: 160, height: 100 },
+    { id: 'room-storage', label: '창고', x: 100, y: 280, width: 160, height: 100 },
+  ],
+  objects: [
+    { id: 'obj-table-1', label: '테이블', shape: 'circle', cx: 600, cy: 190, r: 42 },
+    { id: 'obj-table-2', label: '테이블', shape: 'circle', cx: 380, cy: 380, r: 38 },
+    { id: 'obj-group', label: '단체석', shape: 'rect', x: 610, y: 370, width: 90, height: 48 },
+  ],
+  aps: [
+    { id: 'ap-1', label: 'AP 1', cx: 430, cy: 190, tone: 'primary' },
+    { id: 'ap-2', label: 'AP 2', cx: 685, cy: 465, tone: 'primary' },
+  ],
+};
+
+// 측정 경로의 포인트 시퀀스. 백엔드: GET /measurement-sessions/{id}/points (§10.4, 미구현).
+export const MOCK_MEASUREMENT_POINTS: MeasurementPoint[] = [
+  { id: 'P-01', x: 420, y: 180, severity: 'good' },
+  { id: 'P-02', x: 510, y: 180, severity: 'good' },
+  { id: 'P-03', x: 510, y: 280, severity: 'good' },
+  { id: 'P-04', x: 320, y: 280, severity: 'good' },
+  { id: 'P-05', x: 320, y: 380, severity: 'bad' },
+  { id: 'P-06', x: 510, y: 340, severity: 'warning' },
+  { id: 'P-07', x: 640, y: 340, severity: 'good' },
+  { id: 'P-08', x: 640, y: 440, severity: 'good' },
+];
+
+// 히트맵 영역 (실측 데이터를 그라데이션으로 변환한 결과).
+export const MOCK_MEASUREMENT_HEATMAP: HeatmapRegion[] = [
+  { cx: 480, cy: 270, rx: 260, ry: 190, intensity: 'good' },
+  { cx: 540, cy: 340, rx: 100, ry: 70, intensity: 'warn' },
+  { cx: 180, cy: 400, rx: 140, ry: 110, intensity: 'bad' },
+];
+
+export const MOCK_POINT_DIAGNOSIS: PointDiagnosis = {
+  pointLabel: '창고 앞 구석',
+  pointCode: 'P-05',
+  severity: 'bad',
+  predictedRssiDbm: -72,
+  measuredRssiDbm: -84,
+  measuredAtLabel: '어제 15:00',
+  latencyMs: 55,
+  downloadMbps: 4.2,
+  bandLabel: '2.4GHz',
+  causeText:
+    '예측보다 실측 수치가 훨씬 낮습니다. 창고 가벽의 전파 흡수율이 예상보다 높거나, 주변에 전파 간섭을 일으키는 금속성 물체가 있을 수 있습니다.',
+};

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -7,17 +7,35 @@ import {
   RotateCw,
   Wifi,
 } from 'lucide-react';
+import type {
+  FloorAp,
+  FloorObject,
+  FloorRoom,
+  FloorScene,
+  HeatmapRegion,
+} from '@/types/floor-scene';
 import { ApPaletteMenu } from './ApPaletteMenu';
 
 export type SimulationState = 'idle' | 'running' | 'complete';
 
 interface Props {
   state: SimulationState;
+  scene: FloorScene;
+  heatmap?: HeatmapRegion[];
   expanded?: boolean;
   onToggleExpand?: () => void;
 }
 
-export function SimulationCanvas({ state, expanded, onToggleExpand }: Props) {
+export function SimulationCanvas({
+  state,
+  scene,
+  heatmap,
+  expanded,
+  onToggleExpand,
+}: Props) {
+  const showHeatmap = state === 'complete' && !!heatmap?.length;
+  const showSelection = state === 'idle';
+
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border bg-[#f8fafc] [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
       <div className="relative z-10 flex items-start justify-between gap-3 p-5">
@@ -62,8 +80,9 @@ export function SimulationCanvas({ state, expanded, onToggleExpand }: Props) {
           }
         >
           <FloorPlanSvg
-            withHeatmap={state === 'complete'}
-            withSelection={state === 'idle'}
+            scene={scene}
+            heatmap={showHeatmap ? heatmap : undefined}
+            withSelection={showSelection}
           />
         </div>
 
@@ -86,7 +105,7 @@ export function SimulationCanvas({ state, expanded, onToggleExpand }: Props) {
 function TopLeftBadge({ state }: { state: SimulationState }) {
   if (state === 'idle') {
     return (
-      <div className="absolute left-5 top-5 z-10 inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm shadow-sm">
+      <div className="inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm shadow-sm">
         <MousePointer2 className="h-4 w-4 text-primary" />
         <span className="font-semibold">도면 배치 모드</span>
         <span className="text-muted-foreground">- AP와 가구를 드래그하여 이동할 수 있습니다.</span>
@@ -95,14 +114,14 @@ function TopLeftBadge({ state }: { state: SimulationState }) {
   }
   if (state === 'running') {
     return (
-      <div className="absolute left-5 top-5 z-10 inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm shadow-sm">
+      <div className="inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm shadow-sm">
         <RotateCw className="h-4 w-4 animate-spin text-primary" />
         <span className="font-semibold">전파 도달 범위 계산 중...</span>
       </div>
     );
   }
   return (
-    <div className="absolute left-5 top-5 z-10 inline-flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3.5 py-2 text-sm shadow-sm">
+    <div className="inline-flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3.5 py-2 text-sm shadow-sm">
       <CheckCircle2 className="h-4 w-4 text-emerald-600" />
       <span className="font-semibold text-emerald-700">시뮬레이션 완료 (새로운 배치)</span>
     </div>
@@ -119,14 +138,16 @@ function LegendDot({ color, label }: { color: string; label: string }) {
 }
 
 interface FloorPlanSvgProps {
-  withHeatmap: boolean;
+  scene: FloorScene;
+  heatmap?: HeatmapRegion[];
   withSelection: boolean;
 }
 
-function FloorPlanSvg({ withHeatmap, withSelection }: FloorPlanSvgProps) {
+function FloorPlanSvg({ scene, heatmap, withSelection }: FloorPlanSvgProps) {
+  const { viewBox } = scene;
   return (
     <svg
-      viewBox="0 0 800 520"
+      viewBox={`0 0 ${viewBox.width} ${viewBox.height}`}
       preserveAspectRatio="xMidYMid meet"
       className="h-full w-full p-4"
     >
@@ -148,8 +169,8 @@ function FloorPlanSvg({ withHeatmap, withSelection }: FloorPlanSvgProps) {
       <rect
         x="60"
         y="100"
-        width="680"
-        height="380"
+        width={viewBox.width - 120}
+        height={viewBox.height - 140}
         rx="6"
         fill="white"
         stroke="oklch(0.85 0 0)"
@@ -159,131 +180,163 @@ function FloorPlanSvg({ withHeatmap, withSelection }: FloorPlanSvgProps) {
         x1="290"
         y1="100"
         x2="290"
-        y2="480"
+        y2={viewBox.height - 40}
         stroke="oklch(0.88 0 0)"
         strokeWidth="2"
       />
 
-      {withHeatmap && (
+      {heatmap && (
         <g>
-          <ellipse cx="500" cy="280" rx="280" ry="200" fill="url(#sim-good)" />
-          <ellipse cx="600" cy="200" rx="160" ry="120" fill="url(#sim-good)" />
-          <ellipse cx="170" cy="400" rx="160" ry="130" fill="url(#sim-bad)" />
-          <ellipse cx="540" cy="380" rx="80" ry="60" fill="url(#sim-warn)" />
+          {heatmap.map((r, i) => (
+            <ellipse
+              key={`h-${i}`}
+              cx={r.cx}
+              cy={r.cy}
+              rx={r.rx}
+              ry={r.ry}
+              fill={`url(#sim-${r.intensity})`}
+            />
+          ))}
         </g>
       )}
 
-      {/* 주방/카운터 */}
-      <g>
-        <rect x="100" y="140" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
-        <text
-          x="180"
-          y="196"
-          textAnchor="middle"
-          className="fill-foreground/70"
-          style={{ fontSize: '15px', fontWeight: 500 }}
-        >
-          주방 / 카운터
-        </text>
-      </g>
-      {/* 창고 */}
-      <g>
-        <rect x="100" y="280" width="160" height="100" rx="8" fill="oklch(0.92 0 0)" />
-        <text
-          x="180"
-          y="336"
-          textAnchor="middle"
-          className="fill-foreground/70"
-          style={{ fontSize: '15px', fontWeight: 500 }}
-        >
-          창고
-        </text>
-      </g>
+      {scene.rooms.map((room) => (
+        <RoomShape key={room.id} room={room} />
+      ))}
 
-      {/* 테이블 우상 */}
-      <g>
-        <circle cx="600" cy="190" r="42" fill="oklch(0.95 0.04 256)" />
-        <text
-          x="600"
-          y="196"
-          textAnchor="middle"
-          className="fill-primary/80"
-          style={{ fontSize: '13px', fontWeight: 500 }}
-        >
-          테이블
-        </text>
-      </g>
-      {/* 테이블 좌하 */}
-      <g>
-        <circle cx="380" cy="380" r="38" fill="oklch(0.95 0.04 256)" />
-        <text
-          x="380"
-          y="386"
-          textAnchor="middle"
-          className="fill-primary/80"
-          style={{ fontSize: '13px', fontWeight: 500 }}
-        >
-          테이블
-        </text>
-      </g>
-      {/* 단체석 */}
-      <g>
-        <rect x="610" y="370" width="90" height="48" rx="6" fill="oklch(0.95 0.04 256)" />
-        <text
-          x="655"
-          y="400"
-          textAnchor="middle"
-          className="fill-primary/80"
-          style={{ fontSize: '13px', fontWeight: 500 }}
-        >
-          단체석
-        </text>
-      </g>
-
-      {/* 선택된 사각형 (idle 일 때만 핸들 표시) */}
-      {withSelection ? (
-        <g>
-          <rect
-            x="440"
-            y="290"
-            width="140"
-            height="80"
-            rx="4"
-            fill="white"
-            stroke="oklch(0.55 0.22 264)"
-            strokeWidth="2"
-          />
-          <Handle cx={440} cy={290} />
-          <Handle cx={580} cy={290} />
-          <Handle cx={440} cy={370} />
-          <Handle cx={580} cy={370} />
-          <rect x="565" y="282" width="14" height="14" fill="oklch(0.2 0 0)" />
-          <line
-            x1="510"
-            y1="290"
-            x2="510"
-            y2="252"
-            stroke="oklch(0.55 0.22 264)"
-            strokeWidth="2"
-          />
-          <circle cx="510" cy="244" r="11" fill="oklch(0.55 0.22 264)" />
-          <text
-            x="510"
-            y="248"
-            textAnchor="middle"
-            fill="white"
-            style={{ fontSize: '11px', fontWeight: 600 }}
-          >
-            ↑
-          </text>
-        </g>
-      ) : (
-        <rect x="500" y="330" width="14" height="14" fill="oklch(0.2 0 0)" />
+      {scene.objects.map((obj) =>
+        obj.id === scene.selectedObjectId ? (
+          withSelection ? (
+            <SelectedObject key={obj.id} obj={obj} />
+          ) : (
+            <BlackAnchor key={obj.id} obj={obj} />
+          )
+        ) : (
+          <FurnitureShape key={obj.id} obj={obj} />
+        ),
       )}
 
-      <ApMarker cx={430} cy={190} label="AP 1" />
-      <ApMarker cx={685} cy={465} label="AP 2" />
+      {scene.aps.map((ap) => (
+        <ApMarker key={ap.id} ap={ap} />
+      ))}
     </svg>
+  );
+}
+
+function RoomShape({ room }: { room: FloorRoom }) {
+  return (
+    <g>
+      <rect
+        x={room.x}
+        y={room.y}
+        width={room.width}
+        height={room.height}
+        rx="8"
+        fill="oklch(0.92 0 0)"
+      />
+      <text
+        x={room.x + room.width / 2}
+        y={room.y + room.height / 2 + 6}
+        textAnchor="middle"
+        className="fill-foreground/70"
+        style={{ fontSize: '15px', fontWeight: 500 }}
+      >
+        {room.label}
+      </text>
+    </g>
+  );
+}
+
+function FurnitureShape({ obj }: { obj: FloorObject }) {
+  if (obj.shape === 'circle') {
+    const { cx = 0, cy = 0, r = 30 } = obj;
+    return (
+      <g>
+        <circle cx={cx} cy={cy} r={r} fill="oklch(0.95 0.04 256)" />
+        <text
+          x={cx}
+          y={cy + 6}
+          textAnchor="middle"
+          className="fill-primary/80"
+          style={{ fontSize: '13px', fontWeight: 500 }}
+        >
+          {obj.label}
+        </text>
+      </g>
+    );
+  }
+  const { x = 0, y = 0, width = 0, height = 0 } = obj;
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} rx="6" fill="oklch(0.95 0.04 256)" />
+      <text
+        x={x + width / 2}
+        y={y + height / 2 + 5}
+        textAnchor="middle"
+        className="fill-primary/80"
+        style={{ fontSize: '13px', fontWeight: 500 }}
+      >
+        {obj.label}
+      </text>
+    </g>
+  );
+}
+
+function SelectedObject({ obj }: { obj: FloorObject }) {
+  if (obj.shape !== 'rect') return <FurnitureShape obj={obj} />;
+  const { x = 0, y = 0, width = 0, height = 0 } = obj;
+  const cxCenter = x + width / 2;
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx="4"
+        fill="white"
+        stroke="oklch(0.55 0.22 264)"
+        strokeWidth="2"
+      />
+      <Handle cx={x} cy={y} />
+      <Handle cx={x + width} cy={y} />
+      <Handle cx={x} cy={y + height} />
+      <Handle cx={x + width} cy={y + height} />
+      <rect x={x + width - 15} y={y - 8} width="14" height="14" fill="oklch(0.2 0 0)" />
+      <line
+        x1={cxCenter}
+        y1={y}
+        x2={cxCenter}
+        y2={y - 38}
+        stroke="oklch(0.55 0.22 264)"
+        strokeWidth="2"
+      />
+      <circle cx={cxCenter} cy={y - 46} r="11" fill="oklch(0.55 0.22 264)" />
+      <text
+        x={cxCenter}
+        y={y - 42}
+        textAnchor="middle"
+        fill="white"
+        style={{ fontSize: '11px', fontWeight: 600 }}
+      >
+        ↑
+      </text>
+    </g>
+  );
+}
+
+function BlackAnchor({ obj }: { obj: FloorObject }) {
+  // running/complete 상태에선 핸들 대신 작은 검은 anchor 만 표시 (시안 일관성).
+  if (obj.shape !== 'rect') return null;
+  const { x = 0, y = 0, width = 0, height = 0 } = obj;
+  return (
+    <rect
+      x={x + width / 2 - 7}
+      y={y + height / 2 - 7}
+      width="14"
+      height="14"
+      fill="oklch(0.2 0 0)"
+    />
   );
 }
 
@@ -300,21 +353,21 @@ function Handle({ cx, cy }: { cx: number; cy: number }) {
   );
 }
 
-function ApMarker({ cx, cy, label }: { cx: number; cy: number; label: string }) {
+function ApMarker({ ap }: { ap: FloorAp }) {
   return (
     <g>
-      <circle cx={cx} cy={cy} r="22" fill="oklch(0.55 0.22 264)" />
-      <foreignObject x={cx - 9} y={cy - 9} width="18" height="18">
+      <circle cx={ap.cx} cy={ap.cy} r="22" fill="oklch(0.55 0.22 264)" />
+      <foreignObject x={ap.cx - 9} y={ap.cy - 9} width="18" height="18">
         <Wifi className="h-[18px] w-[18px] text-white" />
       </foreignObject>
       <text
-        x={cx}
-        y={cy + 42}
+        x={ap.cx}
+        y={ap.cy + 42}
         textAnchor="middle"
         className="fill-foreground"
         style={{ fontSize: '12px', fontWeight: 600 }}
       >
-        {label}
+        {ap.label}
       </text>
     </g>
   );

--- a/frontend/src/features/simulation/mocks.ts
+++ b/frontend/src/features/simulation/mocks.ts
@@ -1,0 +1,51 @@
+import type { FloorScene, HeatmapRegion } from '@/types/floor-scene';
+import type { SimulationHistoryItem } from './SimulationHistory';
+
+// 백엔드: §13 RF Run 응답 + (도면 노출 후) Scene Version → 매핑 예정.
+export const MOCK_SIMULATION_FLOOR_SCENE: FloorScene = {
+  viewBox: { width: 800, height: 520 },
+  rooms: [
+    { id: 'room-kitchen', label: '주방 / 카운터', x: 100, y: 140, width: 160, height: 100 },
+    { id: 'room-storage', label: '창고', x: 100, y: 280, width: 160, height: 100 },
+  ],
+  objects: [
+    { id: 'obj-table-1', label: '테이블', shape: 'circle', cx: 600, cy: 190, r: 42 },
+    { id: 'obj-table-2', label: '테이블', shape: 'circle', cx: 380, cy: 380, r: 38 },
+    { id: 'obj-group', label: '단체석', shape: 'rect', x: 610, y: 370, width: 90, height: 48 },
+    { id: 'obj-selected', label: '', shape: 'rect', x: 440, y: 290, width: 140, height: 80 },
+  ],
+  aps: [
+    { id: 'ap-1', label: 'AP 1', cx: 430, cy: 190, tone: 'primary' },
+    { id: 'ap-2', label: 'AP 2', cx: 685, cy: 465, tone: 'primary' },
+  ],
+  selectedObjectId: 'obj-selected',
+};
+
+// 시뮬레이션 완료 시 보여줄 히트맵.
+// 백엔드: §13.3 GET /rf-runs/{id}/maps 로 받은 RSSI 맵을 region 으로 변환 예정.
+export const MOCK_SIMULATION_HEATMAP: HeatmapRegion[] = [
+  { cx: 500, cy: 280, rx: 280, ry: 200, intensity: 'good' },
+  { cx: 600, cy: 200, rx: 160, ry: 120, intensity: 'good' },
+  { cx: 170, cy: 400, rx: 160, ry: 130, intensity: 'bad' },
+  { cx: 540, cy: 380, rx: 80, ry: 60, intensity: 'warn' },
+];
+
+// 시뮬레이션 기록 — 백엔드: GET /jobs?job_type=rf_run + RF Run metrics 결합 예정.
+export const MOCK_SIMULATION_HISTORY_BASE: SimulationHistoryItem[] = [
+  {
+    id: 'sim-base',
+    label: '초기 배치 (어제)',
+    timeLabel: '14:20',
+    avgRssiDbm: -72,
+    coveragePercent: 65,
+  },
+];
+
+export const MOCK_SIMULATION_NEW_RESULT: SimulationHistoryItem = {
+  id: 'sim-new',
+  label: '새로운 가구 배치 (방금 전)',
+  timeLabel: '오후 02:18',
+  avgRssiDbm: -62,
+  coveragePercent: 85,
+  active: true,
+};

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { authApi } from '@/api/auth';
 import { useAuthStore } from '@/stores/auth-store';
+import { toast } from '@/stores/toast-store';
 import type { LoginRequest, SignupRequest } from '@/types/auth';
 
 export function useLogin() {
@@ -11,6 +12,7 @@ export function useLogin() {
     mutationFn: (body: LoginRequest) => authApi.login(body),
     onSuccess: (data) => {
       setSession(data.access_token, data.expires_in, data.user);
+      toast.success(`${data.user.name}님, 환영합니다`);
       const params = new URLSearchParams(window.location.search);
       const next = params.get('next');
       navigate(next ?? '/', { replace: true });
@@ -21,6 +23,9 @@ export function useLogin() {
 export function useSignup() {
   return useMutation({
     mutationFn: (body: SignupRequest) => authApi.signup(body),
+    onSuccess: () => {
+      toast.success('회원가입 완료', '로그인하여 시작해보세요.');
+    },
   });
 }
 

--- a/frontend/src/hooks/use-scene-draft.ts
+++ b/frontend/src/hooks/use-scene-draft.ts
@@ -5,6 +5,8 @@ import {
   type AnalyzeFromAssetParams,
 } from '@/api/scene-draft';
 import type { UUID } from '@/types/common';
+import { toast } from '@/stores/toast-store';
+import type { HttpError } from '@/api/client';
 
 export function useDraftsForFloor(projectId: UUID | null, floorId: UUID | null) {
   return useQuery({
@@ -28,6 +30,16 @@ export function useSceneDraft(draftId: UUID | null) {
   });
 }
 
+function analyzeErrorMessage(err: unknown): string {
+  const e = err as HttpError | null;
+  if (!e) return '도면 분석에 실패했습니다.';
+  if (e.code === 'INVALID_FILE_EXTENSION') return '지원하지 않는 파일 형식입니다.';
+  if (e.code === 'FILE_SAVE_FAILED') return '파일 저장에 실패했습니다.';
+  if (e.code === 'INVALID_PROJECT_FLOOR_PAIR') return '프로젝트와 층의 매핑이 올바르지 않습니다.';
+  if (e.code === 'SCENE_DRAFT_SAVE_FAILED') return '분석 결과 저장에 실패했습니다.';
+  return e.message ?? '도면 분석에 실패했습니다.';
+}
+
 /** §6.1 — 신규 도면 업로드 + 즉시 분석 */
 export function useAnalyzeFloorplan() {
   const qc = useQueryClient();
@@ -35,6 +47,10 @@ export function useAnalyzeFloorplan() {
     mutationFn: (params: AnalyzeFloorplanParams) => sceneDraftApi.analyzeFloorplan(params),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['scene-drafts'] });
+      toast.success('도면 분석 완료', '결과를 확인하고 확정해주세요.');
+    },
+    onError: (err) => {
+      toast.error('도면 분석 실패', analyzeErrorMessage(err));
     },
   });
 }
@@ -46,6 +62,10 @@ export function useAnalyzeFromAsset() {
     mutationFn: (params: AnalyzeFromAssetParams) => sceneDraftApi.analyzeFromAsset(params),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['scene-drafts'] });
+      toast.success('도면 분석 완료', '결과를 확인하고 확정해주세요.');
+    },
+    onError: (err) => {
+      toast.error('도면 분석 실패', analyzeErrorMessage(err));
     },
   });
 }
@@ -56,6 +76,11 @@ export function useDeleteSceneDraft() {
     mutationFn: (draftId: UUID) => sceneDraftApi.remove(draftId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['scene-drafts'] });
+      toast.info('Draft 가 삭제되었습니다');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('Draft 삭제 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
     },
   });
 }

--- a/frontend/src/hooks/use-scene-version.ts
+++ b/frontend/src/hooks/use-scene-version.ts
@@ -2,6 +2,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { sceneVersionApi } from '@/api/scene-version';
 import type { UUID } from '@/types/common';
 import type { PromoteRequest } from '@/types/scene';
+import { toast } from '@/stores/toast-store';
+import type { HttpError } from '@/api/client';
 
 export function useFloorVersions(floorId: UUID | null, params?: { is_current?: boolean }) {
   return useQuery({
@@ -25,10 +27,21 @@ export function usePromoteDraft() {
   return useMutation({
     mutationFn: ({ draftId, body }: { draftId: UUID; body: PromoteRequest }) =>
       sceneVersionApi.promote(draftId, body),
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
       qc.invalidateQueries({ queryKey: ['scene-drafts'] });
       qc.invalidateQueries({ queryKey: ['scene-versions'] });
       qc.invalidateQueries({ queryKey: ['scene-draft', variables.draftId] });
+      toast.success(`버전 #${data.version_no} 확정 완료`, '이 버전 위에서 이어서 작업할 수 있습니다.');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      const message =
+        e?.code === 'DRAFT_ALREADY_PROMOTED'
+          ? '이미 확정된 Draft 입니다.'
+          : e?.code === 'SCENE_VERSION_CONFLICT'
+          ? '같은 층에 동일한 버전 번호가 이미 존재합니다.'
+          : e?.message ?? '확정에 실패했습니다.';
+      toast.error('확정 실패', message);
     },
   });
 }

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -6,18 +6,16 @@ import {
   Smartphone,
   Activity,
   Settings,
-  Bell,
   Wifi,
   FolderOpen,
   Save,
-  User,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useAuthStore } from '@/stores/auth-store';
-import { useLogout } from '@/hooks/use-auth';
 import { useEditorStore } from '@/stores/editor-store';
 import { ProjectSelector } from '@/features/header/ProjectSelector';
 import { FloorSelector } from '@/features/header/FloorSelector';
+import { ProfileMenu } from '@/features/header/ProfileMenu';
+import { NotificationsMenu } from '@/features/header/NotificationsMenu';
 
 const NAV = [
   { to: '/dashboard', label: '대시보드', icon: LayoutGrid },
@@ -28,8 +26,6 @@ const NAV = [
 ] as const;
 
 export function AppLayout() {
-  const user = useAuthStore((s) => s.user);
-  const logout = useLogout();
   const location = useLocation();
   const editorActions = useEditorStore((s) => s.actions);
   const isEditor = location.pathname.startsWith('/editor');
@@ -86,7 +82,9 @@ export function AppLayout() {
                 <button
                   type="button"
                   onClick={editorActions.onLoadFloorplan}
-                  className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
+                  disabled={!editorActions.onLoadFloorplan}
+                  title={!editorActions.onLoadFloorplan ? '층을 선택하거나 현재 작업을 마친 후 새 도면을 불러올 수 있습니다' : undefined}
+                  className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
                 >
                   <FolderOpen className="h-4 w-4" />
                   도면 불러오기
@@ -110,35 +108,13 @@ export function AppLayout() {
               </div>
             )}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             <button className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent">
               <Smartphone className="h-4 w-4" />
               모바일 앱 연결
             </button>
-            <button className="relative rounded-md p-2 hover:bg-accent" aria-label="알림">
-              <Bell className="h-5 w-5 text-muted-foreground" />
-              <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-destructive" />
-            </button>
-            <div className="flex items-center gap-2">
-              <button
-                aria-label="프로필"
-                className="flex h-9 w-9 items-center justify-center rounded-full bg-muted text-muted-foreground hover:bg-accent"
-              >
-                {user?.name ? (
-                  <span className="text-xs font-medium">
-                    {user.name.slice(0, 1)}
-                  </span>
-                ) : (
-                  <User className="h-4 w-4" />
-                )}
-              </button>
-              <button
-                onClick={logout}
-                className="rounded-md border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                로그아웃
-              </button>
-            </div>
+            <NotificationsMenu />
+            <ProfileMenu />
           </div>
         </header>
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -15,6 +15,10 @@ import { cn } from '@/lib/utils';
 import { useAppStore } from '@/stores/app-store';
 import { FloorPreview } from '@/features/dashboard/FloorPreview';
 import { DiagnosticsList } from '@/features/dashboard/DiagnosticsList';
+import {
+  MOCK_DASHBOARD_FLOOR_SCENE,
+  MOCK_DIAGNOSTICS,
+} from '@/features/dashboard/mocks';
 
 type Tone = 'blue' | 'purple' | 'green';
 
@@ -99,7 +103,11 @@ export default function DashboardPage() {
           <Card title="현재 작업 중인 도면" className="min-h-140">
             <div className={expanded ? 'h-180' : 'h-120'}>
               {hasFloorSelected ? (
-                <FloorPreview expanded={expanded} onToggleExpand={toggleExpand} />
+                <FloorPreview
+                  scene={MOCK_DASHBOARD_FLOOR_SCENE}
+                  expanded={expanded}
+                  onToggleExpand={toggleExpand}
+                />
               ) : (
                 <FloorEmptyState hasProject={!!projectId} />
               )}
@@ -117,7 +125,11 @@ export default function DashboardPage() {
               </Card>
 
               <Card title="현장 앱 최근 진단">
-                {hasFloorSelected ? <DiagnosticsList /> : <DiagnosticsEmptyState />}
+                {hasFloorSelected ? (
+                <DiagnosticsList items={MOCK_DIAGNOSTICS} />
+              ) : (
+                <DiagnosticsEmptyState />
+              )}
               </Card>
             </div>
           )}

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -96,17 +96,21 @@ export default function EditorPage() {
   const openFilePicker = () => fileInputRef.current?.click();
 
   // Wire global header buttons (도면 불러오기 / 도면 저장하기) to this page.
-  // 저장하기는 활성 draft 가 있고 다른 mutation 이 안 돌고 있을 때만 활성화.
+  // 불러오기: 층이 선택돼있고 분석이 안 도는 중이고, 아직 활성 draft 가 없을 때만.
+  //   (이미 draft 가 있는데 또 업로드하면 헷갈리므로 막음 — "다시 업로드" 는 리뷰 카드에서.)
+  // 저장하기: 활성 draft 가 있고 다른 mutation 이 안 돌고 있을 때만.
+  const canLoad =
+    !!floorId && !analyze.isPending && !activeDraftSummary && !justPromoted;
   const canSave =
     !!activeDraftSummary && !analyze.isPending && !promote.isPending && !removeDraft.isPending;
   useEffect(() => {
     registerActions({
-      onLoadFloorplan: openFilePicker,
+      onLoadFloorplan: canLoad ? openFilePicker : undefined,
       onSaveFloorplan: canSave ? handlePromote : undefined,
     });
     return () => clearActions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeDraftSummary?.id, nextVersionNo, canSave]);
+  }, [activeDraftSummary?.id, nextVersionNo, canLoad, canSave]);
 
   const isBusy = analyze.isPending;
   const showOverlay =

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -7,6 +7,12 @@ import {
   type MeasurementView,
 } from '@/features/measurement/MeasurementCanvas';
 import { DiagnosticPanel } from '@/features/measurement/DiagnosticPanel';
+import {
+  MOCK_MEASUREMENT_FLOOR_SCENE,
+  MOCK_MEASUREMENT_HEATMAP,
+  MOCK_MEASUREMENT_POINTS,
+  MOCK_POINT_DIAGNOSIS,
+} from '@/features/measurement/mocks';
 
 const TABS: { id: MeasurementView; label: string }[] = [
   { id: 'path', label: '측정 경로 보기' },
@@ -26,10 +32,15 @@ export default function MeasurementPage() {
 
       <div className="mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">
         <div className="min-h-0 rounded-2xl border bg-background p-4 shadow-sm">
-          <MeasurementCanvas view={view} />
+          <MeasurementCanvas
+            view={view}
+            scene={MOCK_MEASUREMENT_FLOOR_SCENE}
+            points={MOCK_MEASUREMENT_POINTS}
+            heatmap={MOCK_MEASUREMENT_HEATMAP}
+          />
         </div>
         <aside className="flex min-h-0 flex-col overflow-y-auto pr-1">
-          <DiagnosticPanel />
+          <DiagnosticPanel diagnosis={MOCK_POINT_DIAGNOSIS} />
         </aside>
       </div>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,28 +1,113 @@
+import { Code2, LogIn, LogOut, Mail, User2, Info, FileText } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { useAuthStore } from '@/stores/auth-store';
+import { useLogout } from '@/hooks/use-auth';
+
+const APP_VERSION = '0.1.0';
 
 export default function SettingsPage() {
   const user = useAuthStore((s) => s.user);
+  const logout = useLogout();
+  const isAuthed = !!user;
+
   return (
-    <div className="h-full space-y-6 overflow-auto p-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight">설정</h1>
-      </header>
-      <section className="rounded-xl border bg-card p-5 shadow-sm">
-        <h2 className="mb-3 text-sm font-semibold">계정</h2>
-        <dl className="space-y-2 text-sm">
-          <Row label="이름" value={user?.name ?? '-'} />
-          <Row label="이메일" value={user?.email ?? '-'} />
-        </dl>
-      </section>
+    <div className="h-full overflow-auto p-6">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">설정</h1>
+          <p className="text-sm text-muted-foreground">
+            계정 정보와 앱 환경을 관리합니다.
+          </p>
+        </header>
+
+        <Card title="계정">
+          <ul className="space-y-1">
+            <Row
+              icon={<User2 className="h-4 w-4 text-muted-foreground" />}
+              label="이름"
+              value={user?.name ?? '게스트'}
+            />
+            <Row
+              icon={<Mail className="h-4 w-4 text-muted-foreground" />}
+              label="이메일"
+              value={user?.email ?? '로그인되지 않음'}
+            />
+          </ul>
+          <div className="mt-5 flex justify-end">
+            {isAuthed ? (
+              <button
+                type="button"
+                onClick={logout}
+                className="inline-flex items-center gap-1.5 rounded-md border border-destructive/30 bg-background px-3 py-1.5 text-xs font-medium text-destructive shadow-sm hover:bg-destructive/5"
+              >
+                <LogOut className="h-3.5 w-3.5" />
+                로그아웃
+              </button>
+            ) : (
+              <Link
+                to="/auth/login"
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+              >
+                <LogIn className="h-3.5 w-3.5" />
+                로그인
+              </Link>
+            )}
+          </div>
+        </Card>
+
+        <Card title="앱 정보">
+          <ul className="space-y-1">
+            <Row
+              icon={<Info className="h-4 w-4 text-muted-foreground" />}
+              label="버전"
+              value={`v${APP_VERSION}`}
+            />
+            <Row
+              icon={<FileText className="h-4 w-4 text-muted-foreground" />}
+              label="프로젝트"
+              value="Wi-Fi Space (캡스톤 08조)"
+            />
+            <Row
+              icon={<Code2 className="h-4 w-4 text-muted-foreground" />}
+              label="저장소"
+              value="capstone2-08-05"
+            />
+          </ul>
+        </Card>
+
+        <p className="text-center text-[11px] text-muted-foreground">
+          © 2026 Wi-Fi Space — 캡스톤 08조
+        </p>
+      </div>
     </div>
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="flex justify-between border-b py-2 last:border-0">
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className="font-medium">{value}</dd>
-    </div>
+    <section className="rounded-xl border bg-card p-5 shadow-sm">
+      <h2 className="mb-4 text-sm font-semibold">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Row({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <li className="flex items-center justify-between gap-3 border-b py-2.5 last:border-0">
+      <div className="flex items-center gap-2.5">
+        {icon}
+        <span className="text-sm text-muted-foreground">{label}</span>
+      </div>
+      <span className="text-sm font-medium">{value}</span>
+    </li>
   );
 }

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -6,30 +6,13 @@ import {
   type SimulationState,
 } from '@/features/simulation/SimulationCanvas';
 import { SimulationResultCard } from '@/features/simulation/SimulationResultCard';
+import { SimulationHistory } from '@/features/simulation/SimulationHistory';
 import {
-  SimulationHistory,
-  type SimulationHistoryItem,
-} from '@/features/simulation/SimulationHistory';
-
-// 시뮬레이션 기록 mock — 실제는 RF Run + Job 목록에서 가져올 예정 (§13 / §15).
-const HISTORY_BASE: SimulationHistoryItem[] = [
-  {
-    id: 'sim-base',
-    label: '초기 배치 (어제)',
-    timeLabel: '14:20',
-    avgRssiDbm: -72,
-    coveragePercent: 65,
-  },
-];
-
-const NEW_RESULT: SimulationHistoryItem = {
-  id: 'sim-new',
-  label: '새로운 가구 배치 (방금 전)',
-  timeLabel: '오후 02:18',
-  avgRssiDbm: -62,
-  coveragePercent: 85,
-  active: true,
-};
+  MOCK_SIMULATION_FLOOR_SCENE,
+  MOCK_SIMULATION_HEATMAP,
+  MOCK_SIMULATION_HISTORY_BASE,
+  MOCK_SIMULATION_NEW_RESULT,
+} from '@/features/simulation/mocks';
 
 const SIM_DURATION_MS = 2500;
 
@@ -53,7 +36,7 @@ export default function SimulationPage() {
   };
 
   const history =
-    state === 'complete' ? [NEW_RESULT, ...HISTORY_BASE] : HISTORY_BASE;
+    state === 'complete' ? [MOCK_SIMULATION_NEW_RESULT, ...MOCK_SIMULATION_HISTORY_BASE] : MOCK_SIMULATION_HISTORY_BASE;
 
   return (
     <div className="relative flex h-full flex-col p-6">
@@ -73,6 +56,8 @@ export default function SimulationPage() {
         <div className="min-h-0">
           <SimulationCanvas
             state={state}
+            scene={MOCK_SIMULATION_FLOOR_SCENE}
+            heatmap={MOCK_SIMULATION_HEATMAP}
             expanded={expanded}
             onToggleExpand={() => setExpanded((v) => !v)}
           />
@@ -82,8 +67,8 @@ export default function SimulationPage() {
           <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
             {state === 'complete' && (
               <SimulationResultCard
-                avgRssiDbm={NEW_RESULT.avgRssiDbm}
-                coveragePercent={NEW_RESULT.coveragePercent}
+                avgRssiDbm={MOCK_SIMULATION_NEW_RESULT.avgRssiDbm}
+                coveragePercent={MOCK_SIMULATION_NEW_RESULT.coveragePercent}
               />
             )}
             <SimulationHistory

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -31,9 +31,14 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
       <div className="w-full max-w-sm rounded-xl border bg-card p-8 shadow-sm">
-        <div className="mb-6 flex items-center justify-center gap-2">
-          <Wifi className="h-6 w-6 text-primary" />
-          <h1 className="text-xl font-semibold">Wi-Fang!</h1>
+        <div className="mb-6 flex flex-col items-center gap-2 text-center">
+          <div className="flex items-center gap-2">
+            <Wifi className="h-6 w-6 text-primary" />
+            <h1 className="text-xl font-semibold tracking-tight">Wi-Fi Space</h1>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            매장의 와이파이를 더 똑똑하게
+          </p>
         </div>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">

--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -33,9 +33,14 @@ export default function SignupPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
       <div className="w-full max-w-sm rounded-xl border bg-card p-8 shadow-sm">
-        <div className="mb-6 flex items-center justify-center gap-2">
-          <Wifi className="h-6 w-6 text-primary" />
-          <h1 className="text-xl font-semibold">회원가입</h1>
+        <div className="mb-6 flex flex-col items-center gap-2 text-center">
+          <div className="flex items-center gap-2">
+            <Wifi className="h-6 w-6 text-primary" />
+            <h1 className="text-xl font-semibold tracking-tight">Wi-Fi Space</h1>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            계정을 만들고 매장 도면 분석을 시작하세요.
+          </p>
         </div>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <Field label="이름" error={errors.name?.message}>

--- a/frontend/src/stores/toast-store.ts
+++ b/frontend/src/stores/toast-store.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+
+export type ToastKind = 'success' | 'error' | 'info';
+
+export interface Toast {
+  id: string;
+  kind: ToastKind;
+  title: string;
+  description?: string;
+  /** ms. 기본 4000. 0이면 수동 닫기만. */
+  durationMs?: number;
+}
+
+interface ToastStore {
+  toasts: Toast[];
+  show: (toast: Omit<Toast, 'id'>) => string;
+  dismiss: (id: string) => void;
+  clearAll: () => void;
+}
+
+let counter = 0;
+const nextId = () => {
+  counter += 1;
+  return `t-${Date.now()}-${counter}`;
+};
+
+export const useToastStore = create<ToastStore>((set, get) => ({
+  toasts: [],
+  show: (toast) => {
+    const id = nextId();
+    set((state) => ({ toasts: [...state.toasts, { id, ...toast }] }));
+
+    const duration = toast.durationMs ?? 4000;
+    if (duration > 0) {
+      window.setTimeout(() => get().dismiss(id), duration);
+    }
+    return id;
+  },
+  dismiss: (id) =>
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+  clearAll: () => set({ toasts: [] }),
+}));
+
+// 편의 함수
+export const toast = {
+  success: (title: string, description?: string) =>
+    useToastStore.getState().show({ kind: 'success', title, description }),
+  error: (title: string, description?: string) =>
+    useToastStore.getState().show({ kind: 'error', title, description }),
+  info: (title: string, description?: string) =>
+    useToastStore.getState().show({ kind: 'info', title, description }),
+};

--- a/frontend/src/types/floor-scene.ts
+++ b/frontend/src/types/floor-scene.ts
@@ -1,0 +1,61 @@
+// 캔버스 시각화용 클라이언트 타입.
+// 백엔드 GET /scene-versions/{id} 등의 응답이 도형 컬럼을 노출하기 시작하면,
+// 그쪽 GeoJSON → 이 모양으로 매핑하는 adapter 만 추가하면 됨.
+
+export interface FloorRoom {
+  id: string;
+  label: string;
+  /** 좌상단 기준 사각형. 추후 polygon 지원 시 별도 필드 추가 가능. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type FloorObjectShape = 'circle' | 'rect';
+
+export interface FloorObject {
+  id: string;
+  label: string;
+  shape: FloorObjectShape;
+  /** shape === 'circle' 일 때 사용 */
+  cx?: number;
+  cy?: number;
+  r?: number;
+  /** shape === 'rect' 일 때 사용 */
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+}
+
+export type ApTone = 'primary' | 'indigo';
+
+export interface FloorAp {
+  id: string;
+  label: string;
+  cx: number;
+  cy: number;
+  /** 일반 AP (primary) / 고성능 AP (indigo) */
+  tone?: ApTone;
+}
+
+export interface FloorScene {
+  viewBox: { width: number; height: number };
+  rooms: FloorRoom[];
+  objects: FloorObject[];
+  aps: FloorAp[];
+  /** 캔버스에서 현재 선택된 객체 id (없으면 null) */
+  selectedObjectId?: string | null;
+}
+
+// 히트맵 영역 (시뮬레이션/실측 공용)
+export type HeatmapIntensity = 'good' | 'warn' | 'bad';
+
+export interface HeatmapRegion {
+  cx: number;
+  cy: number;
+  rx: number;
+  ry: number;
+  intensity: HeatmapIntensity;
+}


### PR DESCRIPTION
- 토스트 시스템 + mutation 훅(analyze/promote/login 등) wire-up
- 헤더 ProfileMenu/NotificationsMenu 팝오버 (인증 분기)
- FloorScene 공용 타입 + feature 별 mocks 분리, 캔버스 5개 props 리팩터
- 에디터 real_width_m UI 복귀, "도면 불러오기" disabled 처리
- 로그인/회원가입/설정 페이지 인증 분기 및 브랜드 통일
- analyze 타임아웃 900s 로 (콜드 스타트 대응, 임시)