### PR TITLE
feat: 드래프트 편집 및 RF Run 흐름 연동

### DIFF
--- a/frontend/src/api/floorplan-job.ts
+++ b/frontend/src/api/floorplan-job.ts
@@ -1,0 +1,9 @@
+import { api } from './client';
+import type { UUID } from '@/types/common';
+import type { Job } from '@/types/job';
+
+export const floorplanJobApi = {
+  /** §6.1 / §6.1.1 분석 호출 후 받은 job_id 로 진행 상태 폴링. */
+  get: (jobId: UUID) =>
+    api.get<Job>(`/floorplan-jobs/${jobId}`).then((r) => r.data),
+};

--- a/frontend/src/api/rf-run.ts
+++ b/frontend/src/api/rf-run.ts
@@ -1,0 +1,16 @@
+import { api } from './client';
+import type { UUID } from '@/types/common';
+import type { RfMap, RfRun, RfRunCreate, RfRunCreated } from '@/types/rf';
+
+export const rfRunApi = {
+  // §13.1 POST /rf-runs — 비동기 시뮬레이션 큐 등록 (HTTP 202)
+  create: (body: RfRunCreate) =>
+    api.post<RfRunCreated>('/rf-runs', body).then((r) => r.data),
+
+  // §13.2 GET /rf-runs/{rf_run_id} — 상태/메트릭 폴링
+  get: (id: UUID) => api.get<RfRun>(`/rf-runs/${id}`).then((r) => r.data),
+
+  // §13.3 GET /rf-runs/{rf_run_id}/maps — 완료 후 RF 맵 목록
+  listMaps: (id: UUID) =>
+    api.get<RfMap[]>(`/rf-runs/${id}/maps`).then((r) => r.data),
+};

--- a/frontend/src/api/scene-draft.ts
+++ b/frontend/src/api/scene-draft.ts
@@ -12,12 +12,9 @@ import type {
   SceneDraftSummary,
 } from '@/types/scene';
 
-// AI 분석:
-//  - 콜드 스타트 (SageMaker 컨테이너 새로 띄울 때) 약 10분
-//  - 웜 상태에서는 추론 ~3초
-// 글로벌 30s 로는 콜드 스타트는 물론, 일반 분석도 부족함.
-// 백엔드 비동기 전환 (Job 큐 + 폴링) 끝나면 이 override 가 사라질 예정.
-const ANALYZE_TIMEOUT_MS = 900_000; // 15분
+// 분석 호출은 이제 비동기 Job 으로 전환됨 (HTTP 202 즉시 반환).
+// 추론 대기는 GET /floorplan-jobs/{job_id} 폴링으로 처리하므로
+// 글로벌 30s 타임아웃으로 충분.
 
 export interface AnalyzeFloorplanParams {
   file: File;
@@ -41,7 +38,7 @@ export interface SceneDraftListParams {
 }
 
 export const sceneDraftApi = {
-  // §6.1 POST /upload/floorplan/analyze
+  // §6.1 POST /upload/floorplan/analyze — Job 큐 등록, HTTP 202 + job_id 반환
   analyzeFloorplan: ({ file, ...rest }: AnalyzeFloorplanParams) => {
     const fd = new FormData();
     fd.append('file', file);
@@ -52,19 +49,14 @@ export const sceneDraftApi = {
     return api
       .post<AnalyzeFloorplanResponse>('/upload/floorplan/analyze', fd, {
         headers: { 'Content-Type': 'multipart/form-data' },
-        timeout: ANALYZE_TIMEOUT_MS,
       })
       .then((r) => r.data);
   },
 
-  // §6.1.1 POST /assets/{asset_id}/analyze
+  // §6.1.1 POST /assets/{asset_id}/analyze — Job 큐 등록
   analyzeFromAsset: ({ asset_id, real_width_m }: AnalyzeFromAssetParams) =>
     api
-      .post<AnalyzeFromAssetResponse>(
-        `/assets/${asset_id}/analyze`,
-        { real_width_m },
-        { timeout: ANALYZE_TIMEOUT_MS },
-      )
+      .post<AnalyzeFromAssetResponse>(`/assets/${asset_id}/analyze`, { real_width_m })
       .then((r) => r.data),
 
   // §6.3 GET /scene-drafts  — 자식 배열 없는 summary 응답

--- a/frontend/src/features/editor/CanvasToolbar.tsx
+++ b/frontend/src/features/editor/CanvasToolbar.tsx
@@ -4,6 +4,8 @@ import {
   Square,
   Circle,
   Type,
+  Hexagon,
+  DoorOpen,
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -29,6 +31,8 @@ const TOP_TOOLS: ToolDef[] = [
 
 const SHAPE_TOOLS: ToolDef[] = [
   { id: 'rect', icon: Square, label: '벽/구조물', onClick: 'change' },
+  { id: 'polygon', icon: Hexagon, label: '방 만들기', onClick: 'change' },
+  { id: 'opening', icon: DoorOpen, label: '문/창 추가', onClick: 'change' },
   { id: 'circle', icon: Circle, label: '가구 배치', onClick: 'change' },
   { id: 'text', icon: Type, label: '구역 라벨', onClick: 'change' },
 ];

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -1,0 +1,688 @@
+import { useEffect, useRef, useState } from 'react';
+import type {
+  DraftEntityKind,
+  DraftObject,
+  DraftOpening,
+  DraftRoom,
+  DraftWall,
+  SceneDraft,
+  SelectedEntityRef,
+} from '@/types/scene';
+import {
+  moveLineStringVertex,
+  movePolygonVertex,
+  parseGeometry,
+  translateGeometry,
+  type Coord,
+  type GeoJsonGeometry,
+} from './geometry-utils';
+import type { EditorTool } from '@/stores/editor-store';
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function emptyBounds(): Bounds {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+}
+
+function extendBounds(b: Bounds, x: number, y: number) {
+  if (x < b.minX) b.minX = x;
+  if (y < b.minY) b.minY = y;
+  if (x > b.maxX) b.maxX = x;
+  if (y > b.maxY) b.maxY = y;
+}
+
+function computeViewBox(draft: SceneDraft): { x: number; y: number; w: number; h: number } {
+  const b = emptyBounds();
+  for (const room of draft.rooms) {
+    const g = parseGeometry(room.polygon_geom);
+    if (g?.type === 'Polygon') {
+      for (const ring of g.coordinates) for (const [x, y] of ring) extendBounds(b, x, y);
+    }
+  }
+  for (const wall of draft.walls) {
+    const g = parseGeometry(wall.centerline_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  for (const op of draft.openings) {
+    const g = parseGeometry(op.line_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  for (const obj of draft.objects) {
+    const g = parseGeometry(obj.point_geom);
+    if (g?.type === 'Point') {
+      const [x, y] = g.coordinates;
+      extendBounds(b, x, y);
+    }
+  }
+  if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
+  const w = b.maxX - b.minX || 1;
+  const h = b.maxY - b.minY || 1;
+  const padding = Math.max(w, h) * 0.05;
+  return { x: b.minX - padding, y: b.minY - padding, w: w + 2 * padding, h: h + 2 * padding };
+}
+
+const DRAG_THRESHOLD_M = 0.05;
+
+type DragState =
+  | {
+      mode: 'shape';
+      ref: SelectedEntityRef;
+      startSvg: Coord;
+      delta: Coord;
+    }
+  | {
+      mode: 'vertex';
+      ref: SelectedEntityRef;
+      vertexIndex: number;
+      startSvg: Coord;
+      delta: Coord;
+    };
+
+/** 생성 진행 중 임시 상태 (예: 벽 그릴 때 첫 클릭 후 두 번째 대기). */
+type CreatingState = { kind: 'wall'; firstPoint: Coord } | null;
+
+interface Props {
+  draft: SceneDraft;
+  selectedRef?: SelectedEntityRef | null;
+  onSelect?: (ref: SelectedEntityRef | null) => void;
+  /** 드래그 종료 시 새 geometry. 호출 측이 적절한 *_geom 필드로 PATCH 한다. */
+  onDragEnd?: (ref: SelectedEntityRef, geometry: GeoJsonGeometry) => void;
+  /** 현재 도구 (좌측 도구바). 'select' 이외 모드면 그리기 흐름으로 전환. */
+  tool?: EditorTool;
+  /** 새 도형 생성. body 는 *_geom + 필수 메타 포함. */
+  onCreate?: (kind: DraftEntityKind, body: Record<string, unknown>) => void;
+}
+
+export function DraftSceneCanvas({
+  draft,
+  selectedRef,
+  onSelect,
+  onDragEnd,
+  tool = 'select',
+  onCreate,
+}: Props) {
+  const vb = computeViewBox(draft);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const [creating, setCreating] = useState<CreatingState>(null);
+  const [cursorPos, setCursorPos] = useState<Coord | null>(null);
+
+  // 도구 변화에 따른 임시 생성 상태 리셋 (props 변화 시 state 조정 패턴).
+  // useEffect 대신 render 중에 비교 → setState 하면 cascading render 없이 즉시 리셋.
+  const [prevTool, setPrevTool] = useState(tool);
+  if (prevTool !== tool) {
+    setPrevTool(tool);
+    setCreating(null);
+    setCursorPos(null);
+  }
+
+  const isCreationMode = tool === 'rect' || tool === 'circle' || tool === 'text';
+
+  // Escape 키로 진행 중 생성 취소
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setCreating(null);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
+  const getSvgPoint = (e: React.PointerEvent): Coord | null => {
+    const svg = svgRef.current;
+    if (!svg) return null;
+    const pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return null;
+    const t = pt.matrixTransform(ctm.inverse());
+    return [t.x, t.y];
+  };
+
+  const startShapeDrag = (e: React.PointerEvent, ref: SelectedEntityRef) => {
+    // 생성 모드에선 도형 클릭이 드래그/선택을 일으키지 않음. 이벤트가 SVG 로 버블링되어
+    // 빈 캔버스 클릭과 동일하게 처리되도록 stopPropagation 안 함.
+    if (tool !== 'select') return;
+    e.stopPropagation();
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    svgRef.current?.setPointerCapture(e.pointerId);
+    setDrag({ mode: 'shape', ref, startSvg: pt, delta: [0, 0] });
+    onSelect?.(ref);
+  };
+
+  const startVertexDrag = (
+    e: React.PointerEvent,
+    ref: SelectedEntityRef,
+    vertexIndex: number,
+  ) => {
+    if (tool !== 'select') return;
+    e.stopPropagation();
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    svgRef.current?.setPointerCapture(e.pointerId);
+    setDrag({ mode: 'vertex', ref, vertexIndex, startSvg: pt, delta: [0, 0] });
+    onSelect?.(ref);
+  };
+
+  const handleSvgPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    // 생성 모드 / 벽 그리기 preview 용으로 항상 cursor 추적
+    if (isCreationMode) setCursorPos(pt);
+    if (!drag) return;
+    setDrag((prev) =>
+      prev ? { ...prev, delta: [pt[0] - prev.startSvg[0], pt[1] - prev.startSvg[1]] } : null,
+    );
+  };
+
+  const handleSvgPointerUp = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!drag) return;
+    try {
+      svgRef.current?.releasePointerCapture(e.pointerId);
+    } catch {
+      /* already released */
+    }
+    const captured = drag;
+    setDrag(null);
+
+    const [dx, dy] = captured.delta;
+    if (Math.abs(dx) < DRAG_THRESHOLD_M && Math.abs(dy) < DRAG_THRESHOLD_M) return;
+
+    const newGeom = buildDraggedGeometry(captured, draft);
+    if (newGeom) onDragEnd?.(captured.ref, newGeom);
+  };
+
+  const handleSvgPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    // 생성 모드 처리
+    if (tool === 'rect') {
+      const pt = getSvgPoint(e);
+      if (!pt) return;
+      if (!creating) {
+        // 첫 클릭: 시작점 저장
+        setCreating({ kind: 'wall', firstPoint: pt });
+      } else {
+        // 두 번째 클릭: 벽 생성
+        const start = creating.firstPoint;
+        const dx = pt[0] - start[0];
+        const dy = pt[1] - start[1];
+        if (Math.abs(dx) > DRAG_THRESHOLD_M || Math.abs(dy) > DRAG_THRESHOLD_M) {
+          onCreate?.('wall', {
+            wall_role: 'inner',
+            source_method: 'user_drawn',
+            centerline_geom: {
+              type: 'LineString',
+              coordinates: [start, pt],
+            },
+          });
+        }
+        setCreating(null);
+      }
+      return;
+    }
+    if (tool === 'circle') {
+      const pt = getSvgPoint(e);
+      if (!pt) return;
+      onCreate?.('object', {
+        object_type: 'furniture',
+        source_method: 'user_drawn',
+        point_geom: { type: 'Point', coordinates: pt },
+      });
+      return;
+    }
+    // select 모드: 빈 영역 클릭 → 선택 해제
+    if (e.target === e.currentTarget) onSelect?.(null);
+  };
+
+  const isSelected = (kind: SelectedEntityRef['kind'], id: string) =>
+    selectedRef?.kind === kind && selectedRef.id === id;
+
+  return (
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[#f8fafc] p-6 [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
+      <svg
+        ref={svgRef}
+        viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
+        preserveAspectRatio="xMidYMid meet"
+        className={
+          isCreationMode
+            ? 'h-full w-full cursor-crosshair select-none'
+            : 'h-full w-full select-none'
+        }
+        onPointerDown={handleSvgPointerDown}
+        onPointerMove={handleSvgPointerMove}
+        onPointerUp={handleSvgPointerUp}
+        onPointerCancel={handleSvgPointerUp}
+      >
+        {draft.rooms.map((room) => (
+          <RoomShape
+            key={room.id}
+            room={room}
+            selected={isSelected('room', room.id)}
+            drag={matchDrag(drag, 'room', room.id)}
+            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'room', id: room.id })}
+            onVertexPointerDown={(e, idx) =>
+              startVertexDrag(e, { kind: 'room', id: room.id }, idx)
+            }
+          />
+        ))}
+
+        {draft.walls.map((wall) => (
+          <WallShape
+            key={wall.id}
+            wall={wall}
+            selected={isSelected('wall', wall.id)}
+            drag={matchDrag(drag, 'wall', wall.id)}
+            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'wall', id: wall.id })}
+            onVertexPointerDown={(e, idx) =>
+              startVertexDrag(e, { kind: 'wall', id: wall.id }, idx)
+            }
+          />
+        ))}
+
+        {draft.openings.map((op) => (
+          <OpeningShape
+            key={op.id}
+            opening={op}
+            selected={isSelected('opening', op.id)}
+            drag={matchDrag(drag, 'opening', op.id)}
+            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'opening', id: op.id })}
+            onVertexPointerDown={(e, idx) =>
+              startVertexDrag(e, { kind: 'opening', id: op.id }, idx)
+            }
+          />
+        ))}
+
+        {draft.objects.map((obj) => (
+          <ObjectShape
+            key={obj.id}
+            object={obj}
+            selected={isSelected('object', obj.id)}
+            drag={matchDrag(drag, 'object', obj.id)}
+            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'object', id: obj.id })}
+          />
+        ))}
+
+        {/* 벽 생성 preview — 첫 점 찍은 후 cursor 까지 점선 */}
+        {creating?.kind === 'wall' && cursorPos && (
+          <g pointerEvents="none">
+            <line
+              x1={creating.firstPoint[0]}
+              y1={creating.firstPoint[1]}
+              x2={cursorPos[0]}
+              y2={cursorPos[1]}
+              stroke="oklch(0.55 0.22 264)"
+              strokeWidth="4"
+              strokeDasharray="6 4"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+            <circle
+              cx={creating.firstPoint[0]}
+              cy={creating.firstPoint[1]}
+              r="0.15"
+              fill="oklch(0.55 0.22 264)"
+            />
+          </g>
+        )}
+
+        {/* 가구 placement hover hint */}
+        {tool === 'circle' && cursorPos && (
+          <circle
+            cx={cursorPos[0]}
+            cy={cursorPos[1]}
+            r="0.18"
+            fill="oklch(0.9 0.04 256)"
+            stroke="oklch(0.55 0.22 264)"
+            strokeWidth="2"
+            strokeDasharray="3 2"
+            vectorEffect="non-scaling-stroke"
+            opacity="0.7"
+            pointerEvents="none"
+          />
+        )}
+      </svg>
+
+      <ScaleHint draft={draft} bounds={vb} dragging={!!drag} />
+      {isCreationMode && <CreationHint tool={tool} creating={creating} />}
+    </div>
+  );
+}
+
+function CreationHint({
+  tool,
+  creating,
+}: {
+  tool: EditorTool;
+  creating: CreatingState;
+}) {
+  let text = '';
+  if (tool === 'rect') {
+    text = creating
+      ? '두 번째 점을 클릭해 벽을 완성하세요. (Esc 취소)'
+      : '첫 번째 점을 클릭해 벽 그리기를 시작하세요.';
+  } else if (tool === 'circle') {
+    text = '캔버스를 클릭해 가구를 배치하세요.';
+  } else if (tool === 'text') {
+    text = '구역 라벨 추가는 현재 미지원입니다.';
+  }
+  if (!text) return null;
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-4 -translate-x-1/2 rounded-md bg-slate-900/90 px-3 py-1.5 text-xs font-medium text-white shadow-md">
+      {text}
+    </div>
+  );
+}
+
+function matchDrag(
+  drag: DragState | null,
+  kind: SelectedEntityRef['kind'],
+  id: string,
+): DragState | null {
+  if (drag && drag.ref.kind === kind && drag.ref.id === id) return drag;
+  return null;
+}
+
+/** drag 진행 중인 도형의 effective coords 계산 (rendering 용). */
+function effectiveLineCoords(coords: Coord[], drag: DragState | null): Coord[] {
+  if (!drag) return coords;
+  const [dx, dy] = drag.delta;
+  if (drag.mode === 'shape') {
+    return coords.map(([x, y]) => [x + dx, y + dy] as Coord);
+  }
+  return moveLineStringVertex(coords, drag.vertexIndex, dx, dy);
+}
+
+function effectivePolygonRings(rings: Coord[][], drag: DragState | null): Coord[][] {
+  if (!drag) return rings;
+  const [dx, dy] = drag.delta;
+  if (drag.mode === 'shape') {
+    return rings.map((r) => r.map(([x, y]) => [x + dx, y + dy] as Coord));
+  }
+  return movePolygonVertex(rings, drag.vertexIndex, dx, dy);
+}
+
+function effectivePoint(p: Coord, drag: DragState | null): Coord {
+  if (!drag) return p;
+  if (drag.mode !== 'shape') return p;
+  const [dx, dy] = drag.delta;
+  return [p[0] + dx, p[1] + dy];
+}
+
+/** drag 종료 시 적용할 새 GeoJSON 생성. */
+function buildDraggedGeometry(drag: DragState, draft: SceneDraft): GeoJsonGeometry | null {
+  const { ref } = drag;
+  if (ref.kind === 'wall') {
+    const w = draft.walls.find((x) => x.id === ref.id);
+    const g = parseGeometry(w?.centerline_geom);
+    if (g?.type !== 'LineString') return null;
+    if (drag.mode === 'shape') return translateGeometry(g, drag.delta[0], drag.delta[1]);
+    return {
+      type: 'LineString',
+      coordinates: moveLineStringVertex(g.coordinates, drag.vertexIndex, drag.delta[0], drag.delta[1]),
+    };
+  }
+  if (ref.kind === 'opening') {
+    const o = draft.openings.find((x) => x.id === ref.id);
+    const g = parseGeometry(o?.line_geom);
+    if (g?.type !== 'LineString') return null;
+    if (drag.mode === 'shape') return translateGeometry(g, drag.delta[0], drag.delta[1]);
+    return {
+      type: 'LineString',
+      coordinates: moveLineStringVertex(g.coordinates, drag.vertexIndex, drag.delta[0], drag.delta[1]),
+    };
+  }
+  if (ref.kind === 'room') {
+    const r = draft.rooms.find((x) => x.id === ref.id);
+    const g = parseGeometry(r?.polygon_geom);
+    if (g?.type !== 'Polygon') return null;
+    if (drag.mode === 'shape') return translateGeometry(g, drag.delta[0], drag.delta[1]);
+    return {
+      type: 'Polygon',
+      coordinates: movePolygonVertex(g.coordinates, drag.vertexIndex, drag.delta[0], drag.delta[1]),
+    };
+  }
+  // object — Point, vertex 모드는 무의미. shape drag 만.
+  const o = draft.objects.find((x) => x.id === ref.id);
+  const g = parseGeometry(o?.point_geom);
+  if (g?.type !== 'Point') return null;
+  if (drag.mode !== 'shape') return null;
+  return translateGeometry(g, drag.delta[0], drag.delta[1]);
+}
+
+// ============================================
+// 도형 컴포넌트
+// ============================================
+
+interface ShapeBaseProps {
+  selected: boolean;
+  drag: DragState | null;
+  onShapePointerDown: (e: React.PointerEvent) => void;
+}
+interface VertexAwareProps extends ShapeBaseProps {
+  onVertexPointerDown: (e: React.PointerEvent, vertexIndex: number) => void;
+}
+
+function RoomShape({
+  room,
+  selected,
+  drag,
+  onShapePointerDown,
+  onVertexPointerDown,
+}: { room: DraftRoom } & VertexAwareProps) {
+  const g = parseGeometry(room.polygon_geom);
+  if (g?.type !== 'Polygon') return null;
+  const rings = effectivePolygonRings(g.coordinates, drag);
+  const ring = rings[0];
+  if (!ring) return null;
+  const isClosed =
+    ring.length > 0 &&
+    ring[0][0] === ring[ring.length - 1][0] &&
+    ring[0][1] === ring[ring.length - 1][1];
+  const handlePts = isClosed ? ring.slice(0, -1) : ring;
+  const points = ring.map(([x, y]) => `${x},${y}`).join(' ');
+  return (
+    <g>
+      <polygon
+        points={points}
+        fill={selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.01 256)'}
+        stroke={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.86 0 0)'}
+        strokeWidth={selected ? 3 : 1.5}
+        vectorEffect="non-scaling-stroke"
+        className="cursor-pointer"
+        onPointerDown={onShapePointerDown}
+      />
+      {selected &&
+        handlePts.map((pt, i) => (
+          <VertexHandle
+            key={i}
+            x={pt[0]}
+            y={pt[1]}
+            onPointerDown={(e) => onVertexPointerDown(e, i)}
+          />
+        ))}
+    </g>
+  );
+}
+
+function WallShape({
+  wall,
+  selected,
+  drag,
+  onShapePointerDown,
+  onVertexPointerDown,
+}: { wall: DraftWall } & VertexAwareProps) {
+  const g = parseGeometry(wall.centerline_geom);
+  if (g?.type !== 'LineString') return null;
+  const coords = effectiveLineCoords(g.coordinates, drag);
+  const [start, end] = coords;
+  if (!start || !end) return null;
+  return (
+    <g>
+      <line
+        x1={start[0]}
+        y1={start[1]}
+        x2={end[0]}
+        y2={end[1]}
+        stroke="transparent"
+        strokeWidth="14"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        className="cursor-pointer"
+        onPointerDown={onShapePointerDown}
+      />
+      <line
+        x1={start[0]}
+        y1={start[1]}
+        x2={end[0]}
+        y2={end[1]}
+        stroke={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.25 0 0)'}
+        strokeWidth={selected ? 6 : 4}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        pointerEvents="none"
+      />
+      {selected && (
+        <>
+          <VertexHandle x={start[0]} y={start[1]} onPointerDown={(e) => onVertexPointerDown(e, 0)} />
+          <VertexHandle x={end[0]} y={end[1]} onPointerDown={(e) => onVertexPointerDown(e, 1)} />
+        </>
+      )}
+    </g>
+  );
+}
+
+function OpeningShape({
+  opening,
+  selected,
+  drag,
+  onShapePointerDown,
+  onVertexPointerDown,
+}: { opening: DraftOpening } & VertexAwareProps) {
+  const g = parseGeometry(opening.line_geom);
+  if (g?.type !== 'LineString') return null;
+  const coords = effectiveLineCoords(g.coordinates, drag);
+  const [start, end] = coords;
+  if (!start || !end) return null;
+  const isDoor = opening.opening_type === 'door';
+  const baseColor = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  return (
+    <g>
+      <line
+        x1={start[0]}
+        y1={start[1]}
+        x2={end[0]}
+        y2={end[1]}
+        stroke="transparent"
+        strokeWidth="14"
+        vectorEffect="non-scaling-stroke"
+        className="cursor-pointer"
+        onPointerDown={onShapePointerDown}
+      />
+      <line
+        x1={start[0]}
+        y1={start[1]}
+        x2={end[0]}
+        y2={end[1]}
+        stroke={baseColor}
+        strokeWidth={selected ? 8 : 5}
+        strokeLinecap="butt"
+        vectorEffect="non-scaling-stroke"
+        pointerEvents="none"
+      />
+      {selected && (
+        <>
+          <VertexHandle x={start[0]} y={start[1]} onPointerDown={(e) => onVertexPointerDown(e, 0)} />
+          <VertexHandle x={end[0]} y={end[1]} onPointerDown={(e) => onVertexPointerDown(e, 1)} />
+        </>
+      )}
+    </g>
+  );
+}
+
+function ObjectShape({
+  object,
+  selected,
+  drag,
+  onShapePointerDown,
+}: { object: DraftObject } & ShapeBaseProps) {
+  const g = parseGeometry(object.point_geom);
+  if (g?.type !== 'Point') return null;
+  const [x, y] = effectivePoint(g.coordinates, drag);
+  return (
+    <g onPointerDown={onShapePointerDown} className="cursor-pointer">
+      <circle cx={x} cy={y} r="0.4" fill="transparent" />
+      <circle
+        cx={x}
+        cy={y}
+        r="0.18"
+        fill={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.9 0.04 256)'}
+        stroke={selected ? 'oklch(0.45 0.22 264)' : 'oklch(0.55 0.22 264)'}
+        strokeWidth={selected ? 3 : 1.5}
+        vectorEffect="non-scaling-stroke"
+      />
+    </g>
+  );
+}
+
+function VertexHandle({
+  x,
+  y,
+  onPointerDown,
+}: {
+  x: number;
+  y: number;
+  onPointerDown: (e: React.PointerEvent) => void;
+}) {
+  return (
+    <g onPointerDown={onPointerDown} className="cursor-grab">
+      {/* 클릭 영역 확장 */}
+      <circle cx={x} cy={y} r="0.35" fill="transparent" />
+      <circle
+        cx={x}
+        cy={y}
+        r="0.16"
+        fill="white"
+        stroke="oklch(0.55 0.22 264)"
+        strokeWidth="3"
+        vectorEffect="non-scaling-stroke"
+      />
+    </g>
+  );
+}
+
+function ScaleHint({
+  draft,
+  bounds,
+  dragging,
+}: {
+  draft: SceneDraft;
+  bounds: { w: number; h: number };
+  dragging?: boolean;
+}) {
+  const summary = (draft.summary_json ?? {}) as { storage?: { real_width_m?: number } };
+  const realWidth = summary.storage?.real_width_m;
+  return (
+    <div className="pointer-events-none absolute bottom-3 left-3 inline-flex items-center gap-2 rounded-md border bg-background/90 px-2.5 py-1 text-[11px] text-muted-foreground shadow-sm backdrop-blur">
+      <span className="font-mono">
+        {bounds.w.toFixed(1)} × {bounds.h.toFixed(1)} m
+      </span>
+      {realWidth != null && (
+        <>
+          <span className="h-3 w-px bg-border" />
+          <span>입력 너비 {realWidth} m</span>
+        </>
+      )}
+      {dragging && (
+        <>
+          <span className="h-3 w-px bg-border" />
+          <span className="text-primary">드래그 중…</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -83,8 +83,27 @@ type DragState =
       delta: Coord;
     };
 
-/** 생성 진행 중 임시 상태 (예: 벽 그릴 때 첫 클릭 후 두 번째 대기). */
-type CreatingState = { kind: 'wall'; firstPoint: Coord } | null;
+/** 생성 진행 중 임시 상태. */
+type CreatingState =
+  | { kind: 'wall'; firstPoint: Coord }
+  | { kind: 'opening'; firstPoint: Coord }
+  | { kind: 'polygon'; points: Coord[] }
+  | null;
+
+/** 폴리곤 닫기 임계값 (미터). 시작점 근처 클릭으로 인식. */
+const POLYGON_CLOSE_THRESHOLD_M = 0.4;
+
+function distance(a: Coord, b: Coord): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1]);
+}
+
+function polygonCentroid(points: Coord[]): Coord {
+  if (points.length === 0) return [0, 0];
+  const n = points.length;
+  const sx = points.reduce((s, p) => s + p[0], 0);
+  const sy = points.reduce((s, p) => s + p[1], 0);
+  return [sx / n, sy / n];
+}
 
 interface Props {
   draft: SceneDraft;
@@ -121,7 +140,12 @@ export function DraftSceneCanvas({
     setCursorPos(null);
   }
 
-  const isCreationMode = tool === 'rect' || tool === 'circle' || tool === 'text';
+  const isCreationMode =
+    tool === 'rect' ||
+    tool === 'circle' ||
+    tool === 'text' ||
+    tool === 'polygon' ||
+    tool === 'opening';
 
   // Escape 키로 진행 중 생성 취소
   useEffect(() => {
@@ -199,32 +223,50 @@ export function DraftSceneCanvas({
   };
 
   const handleSvgPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
-    // 생성 모드 처리
+    // ─ 벽 (2 클릭 LineString) ─
     if (tool === 'rect') {
       const pt = getSvgPoint(e);
       if (!pt) return;
-      if (!creating) {
-        // 첫 클릭: 시작점 저장
+      if (!creating || creating.kind !== 'wall') {
         setCreating({ kind: 'wall', firstPoint: pt });
       } else {
-        // 두 번째 클릭: 벽 생성
         const start = creating.firstPoint;
-        const dx = pt[0] - start[0];
-        const dy = pt[1] - start[1];
-        if (Math.abs(dx) > DRAG_THRESHOLD_M || Math.abs(dy) > DRAG_THRESHOLD_M) {
+        if (Math.abs(pt[0] - start[0]) > DRAG_THRESHOLD_M || Math.abs(pt[1] - start[1]) > DRAG_THRESHOLD_M) {
           onCreate?.('wall', {
             wall_role: 'inner',
             source_method: 'user_drawn',
-            centerline_geom: {
-              type: 'LineString',
-              coordinates: [start, pt],
-            },
+            centerline_geom: { type: 'LineString', coordinates: [start, pt] },
           });
         }
         setCreating(null);
       }
       return;
     }
+
+    // ─ 문/창 (2 클릭 LineString, opening_type=door 기본) ─
+    if (tool === 'opening') {
+      const pt = getSvgPoint(e);
+      if (!pt) return;
+      if (!creating || creating.kind !== 'opening') {
+        setCreating({ kind: 'opening', firstPoint: pt });
+      } else {
+        const start = creating.firstPoint;
+        const width = distance(start, pt);
+        if (width > DRAG_THRESHOLD_M) {
+          onCreate?.('opening', {
+            opening_type: 'door',
+            width_m: Number(width.toFixed(2)),
+            height_m: 2.1,
+            source_method: 'user_drawn',
+            line_geom: { type: 'LineString', coordinates: [start, pt] },
+          });
+        }
+        setCreating(null);
+      }
+      return;
+    }
+
+    // ─ 가구 (1 클릭 Point) ─
     if (tool === 'circle') {
       const pt = getSvgPoint(e);
       if (!pt) return;
@@ -235,6 +277,34 @@ export function DraftSceneCanvas({
       });
       return;
     }
+
+    // ─ 방 (다중 클릭 Polygon, 시작점 클릭 또는 Enter 로 닫기) ─
+    if (tool === 'polygon') {
+      const pt = getSvgPoint(e);
+      if (!pt) return;
+      if (!creating || creating.kind !== 'polygon') {
+        setCreating({ kind: 'polygon', points: [pt] });
+        return;
+      }
+      const pts = creating.points;
+      // 3 점 이상일 때 시작점 근처 클릭 → 닫기
+      if (pts.length >= 3 && distance(pt, pts[0]) < POLYGON_CLOSE_THRESHOLD_M) {
+        const ring = [...pts, pts[0]];
+        const centroid = polygonCentroid(pts);
+        onCreate?.('room', {
+          room_type: 'general',
+          source_method: 'user_drawn',
+          polygon_geom: { type: 'Polygon', coordinates: [ring] },
+          centroid_geom: { type: 'Point', coordinates: centroid },
+        });
+        setCreating(null);
+        return;
+      }
+      // 그 외 → 점 추가
+      setCreating({ kind: 'polygon', points: [...pts, pt] });
+      return;
+    }
+
     // select 모드: 빈 영역 클릭 → 선택 해제
     if (e.target === e.currentTarget) onSelect?.(null);
   };
@@ -307,7 +377,7 @@ export function DraftSceneCanvas({
           />
         ))}
 
-        {/* 벽 생성 preview — 첫 점 찍은 후 cursor 까지 점선 */}
+        {/* 벽 생성 preview */}
         {creating?.kind === 'wall' && cursorPos && (
           <g pointerEvents="none">
             <line
@@ -329,6 +399,96 @@ export function DraftSceneCanvas({
             />
           </g>
         )}
+
+        {/* 개구부(문/창) 생성 preview */}
+        {creating?.kind === 'opening' && cursorPos && (
+          <g pointerEvents="none">
+            <line
+              x1={creating.firstPoint[0]}
+              y1={creating.firstPoint[1]}
+              x2={cursorPos[0]}
+              y2={cursorPos[1]}
+              stroke="oklch(0.55 0.22 264)"
+              strokeWidth="5"
+              strokeDasharray="4 3"
+              vectorEffect="non-scaling-stroke"
+            />
+            <circle
+              cx={creating.firstPoint[0]}
+              cy={creating.firstPoint[1]}
+              r="0.15"
+              fill="oklch(0.55 0.22 264)"
+            />
+          </g>
+        )}
+
+        {/* 방(다각형) 생성 preview */}
+        {creating?.kind === 'polygon' && (() => {
+          const pts = creating.points;
+          const canClose =
+            pts.length >= 3 && cursorPos && distance(cursorPos, pts[0]) < POLYGON_CLOSE_THRESHOLD_M;
+          const polyPoints = pts.map(([x, y]) => `${x},${y}`).join(' ');
+          return (
+            <g pointerEvents="none">
+              {/* 닫혀 보이도록 hover 상태에선 채우기 */}
+              {canClose && pts.length >= 3 && (
+                <polygon
+                  points={polyPoints}
+                  fill="oklch(0.92 0.05 264 / 0.3)"
+                  stroke="oklch(0.55 0.22 264)"
+                  strokeWidth="3"
+                  strokeDasharray="6 4"
+                  vectorEffect="non-scaling-stroke"
+                />
+              )}
+              {/* 이어진 변들 */}
+              {!canClose && pts.length >= 2 && (
+                <polyline
+                  points={polyPoints}
+                  fill="none"
+                  stroke="oklch(0.55 0.22 264)"
+                  strokeWidth="3"
+                  strokeDasharray="6 4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  vectorEffect="non-scaling-stroke"
+                />
+              )}
+              {/* 마지막 점 → cursor preview 변 */}
+              {!canClose && cursorPos && pts.length > 0 && (
+                <line
+                  x1={pts[pts.length - 1][0]}
+                  y1={pts[pts.length - 1][1]}
+                  x2={cursorPos[0]}
+                  y2={cursorPos[1]}
+                  stroke="oklch(0.55 0.22 264)"
+                  strokeWidth="2"
+                  strokeDasharray="3 3"
+                  strokeLinecap="round"
+                  opacity="0.6"
+                  vectorEffect="non-scaling-stroke"
+                />
+              )}
+              {/* 꼭짓점들 — 첫 점은 크게(닫기 가능 표시) */}
+              {pts.map((p, i) => {
+                const isFirst = i === 0;
+                const isFirstHighlighted = isFirst && canClose;
+                return (
+                  <circle
+                    key={i}
+                    cx={p[0]}
+                    cy={p[1]}
+                    r={isFirstHighlighted ? 0.28 : isFirst ? 0.2 : 0.13}
+                    fill={isFirstHighlighted ? 'oklch(0.55 0.22 264)' : 'white'}
+                    stroke="oklch(0.55 0.22 264)"
+                    strokeWidth={isFirstHighlighted ? 2 : 3}
+                    vectorEffect="non-scaling-stroke"
+                  />
+                );
+              })}
+            </g>
+          );
+        })()}
 
         {/* 가구 placement hover hint */}
         {tool === 'circle' && cursorPos && (
@@ -362,9 +522,23 @@ function CreationHint({
 }) {
   let text = '';
   if (tool === 'rect') {
-    text = creating
-      ? '두 번째 점을 클릭해 벽을 완성하세요. (Esc 취소)'
-      : '첫 번째 점을 클릭해 벽 그리기를 시작하세요.';
+    text =
+      creating?.kind === 'wall'
+        ? '두 번째 점을 클릭해 벽을 완성하세요. (Esc 취소)'
+        : '첫 번째 점을 클릭해 벽 그리기를 시작하세요.';
+  } else if (tool === 'opening') {
+    text =
+      creating?.kind === 'opening'
+        ? '두 번째 점을 클릭해 문/창을 완성하세요. (Esc 취소)'
+        : '첫 번째 점을 클릭해 문/창 그리기를 시작하세요.';
+  } else if (tool === 'polygon') {
+    if (!creating || creating.kind !== 'polygon') {
+      text = '첫 번째 점을 클릭해 방 만들기를 시작하세요.';
+    } else if (creating.points.length < 3) {
+      text = `점을 클릭해 방 외곽을 만드세요 (${creating.points.length}/3+). Esc 로 취소.`;
+    } else {
+      text = `시작점을 다시 클릭하면 방이 완성됩니다. (현재 ${creating.points.length}개 점)`;
+    }
   } else if (tool === 'circle') {
     text = '캔버스를 클릭해 가구를 배치하세요.';
   } else if (tool === 'text') {

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -1,36 +1,48 @@
 import { ChevronDown, RotateCcw, ScanLine, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-export interface SelectedObject {
-  typeLabel: string;
-  scanned?: boolean;
-  width: number;
-  height: number;
-  x: number;
-  y: number;
-  material: string;
-  materialHint?: string;
-}
+import type {
+  DraftObject,
+  DraftOpening,
+  DraftRoom,
+  DraftWall,
+  SelectedEntityResolved,
+} from '@/types/scene';
 
 interface PropertiesPanelProps {
-  selected: SelectedObject | null;
-  onChange?: (next: SelectedObject) => void;
-  onRotate?: () => void;
+  selected: SelectedEntityResolved | null;
+  /** 선택된 엔티티 삭제 (백엔드 DELETE 호출). */
   onDelete?: () => void;
+  /** 선택된 엔티티 90° 시계방향 회전. 객체(Point) 는 회전 무의미. */
+  onRotate?: () => void;
+  /** 벽의 material_label 변경. 백엔드 PATCH /draft-walls/{id}. */
+  onUpdateMaterial?: (next: string) => void;
+  /** 작업 진행 중 표시 */
+  isSaving?: boolean;
+  isDeleting?: boolean;
 }
+
+const KIND_LABELS: Record<SelectedEntityResolved['kind'], string> = {
+  wall: '벽',
+  room: '방',
+  opening: '개구부',
+  object: '객체',
+};
 
 const MATERIAL_OPTIONS = [
   '목재 테이블 (신호 감쇠 보통)',
   '금속 캐비닛 (신호 감쇠 높음)',
   '유리 (신호 감쇠 낮음)',
   '플라스틱 (신호 감쇠 매우 낮음)',
+  '콘크리트 벽 (신호 감쇠 매우 높음)',
 ];
 
 export function PropertiesPanel({
   selected,
-  onChange,
-  onRotate,
   onDelete,
+  onRotate,
+  onUpdateMaterial,
+  isSaving,
+  isDeleting,
 }: PropertiesPanelProps) {
   return (
     <aside className="flex w-80 shrink-0 flex-col gap-5 overflow-y-auto border-l bg-background p-5">
@@ -41,9 +53,11 @@ export function PropertiesPanel({
       {selected ? (
         <SelectedBody
           selected={selected}
-          onChange={onChange}
-          onRotate={onRotate}
           onDelete={onDelete}
+          onRotate={onRotate}
+          onUpdateMaterial={onUpdateMaterial}
+          isSaving={!!isSaving}
+          isDeleting={!!isDeleting}
         />
       ) : (
         <EmptyBody />
@@ -56,112 +70,176 @@ export function PropertiesPanel({
 
 function SelectedBody({
   selected,
-  onChange,
-  onRotate,
   onDelete,
+  onRotate,
+  onUpdateMaterial,
+  isSaving,
+  isDeleting,
 }: {
-  selected: SelectedObject;
-  onChange?: (next: SelectedObject) => void;
-  onRotate?: () => void;
+  selected: SelectedEntityResolved;
   onDelete?: () => void;
+  onRotate?: () => void;
+  onUpdateMaterial?: (next: string) => void;
+  isSaving: boolean;
+  isDeleting: boolean;
 }) {
-  const update = <K extends keyof SelectedObject>(key: K, value: SelectedObject[K]) => {
-    onChange?.({ ...selected, [key]: value });
-  };
-
   return (
     <>
       <Section label="객체 유형">
-        <div className="flex items-center gap-3 rounded-lg border bg-background p-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10">
-            <span className="block h-3 w-3 rounded-full bg-primary/80" />
-          </div>
-          <div className="flex-1 space-y-0.5">
-            <div className="flex items-center gap-1.5">
-              <span className="text-sm font-medium text-foreground">
-                {selected.typeLabel}
-              </span>
-              {selected.scanned && (
-                <span className="rounded-md bg-purple-100 px-1.5 py-0.5 text-[10px] font-medium text-purple-700">
-                  스캔됨
-                </span>
-              )}
-            </div>
-            <p className="text-[11px] text-muted-foreground">
-              마우스로 끌어서 위치/크기 수정
-            </p>
-          </div>
-        </div>
+        <TypeHeader selected={selected} />
       </Section>
 
-      <Section label="크기 및 위치">
-        <div className="grid grid-cols-2 gap-2.5">
-          <PxField
-            label="가로 (W)"
-            value={selected.width}
-            onChange={(v) => update('width', v)}
-          />
-          <PxField
-            label="세로 (H)"
-            value={selected.height}
-            onChange={(v) => update('height', v)}
-          />
-          <PxField
-            label="X 좌표"
-            value={selected.x}
-            onChange={(v) => update('x', v)}
-          />
-          <PxField
-            label="Y 좌표"
-            value={selected.y}
-            onChange={(v) => update('y', v)}
-          />
-        </div>
+      <Section label="속성">
+        {selected.kind === 'wall' && <WallFields wall={selected.data} />}
+        {selected.kind === 'room' && <RoomFields room={selected.data} />}
+        {selected.kind === 'opening' && <OpeningFields opening={selected.data} />}
+        {selected.kind === 'object' && <ObjectFields object={selected.data} />}
       </Section>
 
-      <Section label="장애물 재질 설정">
-        <div className="relative">
-          <select
-            value={selected.material}
-            onChange={(e) => update('material', e.target.value)}
-            className="w-full appearance-none rounded-md border bg-background px-3 py-2.5 pr-9 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            {MATERIAL_OPTIONS.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-            {/* 현재 값이 옵션 목록에 없을 경우 fallback */}
-            {!MATERIAL_OPTIONS.includes(selected.material) && (
-              <option value={selected.material}>{selected.material}</option>
-            )}
-          </select>
-          <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        </div>
-        <p className="mt-2 rounded-md bg-primary/5 px-3 py-2 text-[11px] leading-relaxed text-primary/90">
-          {selected.materialHint ?? '가구의 재질에 따라 와이파이 품질에 미치는 영향이 달라집니다.'}
-        </p>
-      </Section>
+      {selected.kind === 'wall' && (
+        <Section label="장애물 재질 설정">
+          <MaterialSelect
+            value={getMaterial(selected)}
+            onChange={onUpdateMaterial}
+            disabled={isSaving}
+          />
+          <p className="mt-2 rounded-md bg-primary/5 px-3 py-2 text-[11px] leading-relaxed text-primary/90">
+            재질에 따라 와이파이 품질에 미치는 영향이 달라집니다.
+            {isSaving && ' 저장 중…'}
+          </p>
+        </Section>
+      )}
 
       <div className="flex gap-2">
         <button
           type="button"
           onClick={onRotate}
-          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border bg-background px-3 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent"
+          disabled={isSaving || !onRotate || selected.kind === 'object'}
+          title={
+            selected.kind === 'object'
+              ? '점 객체는 회전이 적용되지 않습니다'
+              : '90° 시계방향 회전'
+          }
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border bg-background px-3 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
         >
           <RotateCcw className="h-4 w-4" />
-          회전
+          {isSaving ? '회전 중…' : '회전 90°'}
         </button>
         <button
           type="button"
           onClick={onDelete}
-          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-destructive/30 bg-background px-3 py-2 text-sm font-medium text-destructive shadow-sm hover:bg-destructive/5"
+          disabled={isDeleting || !onDelete}
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-destructive/30 bg-background px-3 py-2 text-sm font-medium text-destructive shadow-sm hover:bg-destructive/5 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Trash2 className="h-4 w-4" />
-          삭제
+          {isDeleting ? '삭제 중…' : '삭제'}
         </button>
       </div>
+
+      <div className="rounded-md bg-muted/40 p-3">
+        <p className="text-[10px] uppercase tracking-wide text-muted-foreground">ID</p>
+        <p className="mt-0.5 break-all font-mono text-[11px]">{getEntityId(selected)}</p>
+      </div>
     </>
+  );
+}
+
+function TypeHeader({ selected }: { selected: SelectedEntityResolved }) {
+  const label = KIND_LABELS[selected.kind];
+  const subLabel = getEntitySubLabel(selected);
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-background p-3">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10">
+        <span className="block h-3 w-3 rounded-full bg-primary/80" />
+      </div>
+      <div className="flex-1 space-y-0.5">
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-medium text-foreground">{label}</span>
+          {subLabel && (
+            <span className="rounded-md bg-purple-100 px-1.5 py-0.5 text-[10px] font-medium text-purple-700">
+              {subLabel}
+            </span>
+          )}
+        </div>
+        <p className="text-[11px] text-muted-foreground">캔버스에서 클릭으로 선택됨</p>
+      </div>
+    </div>
+  );
+}
+
+function WallFields({ wall }: { wall: DraftWall }) {
+  return (
+    <Grid>
+      <Row label="역할" value={wall.wall_role} />
+      <Row label="두께" value={fmtDecimal(wall.thickness_m, 'm')} />
+      <Row label="높이" value={fmtDecimal(wall.height_m, 'm')} />
+      <Row label="재질" value={wall.material_label ?? '-'} />
+      <Row label="신뢰도" value={fmtConfidence(wall.confidence)} />
+    </Grid>
+  );
+}
+
+function RoomFields({ room }: { room: DraftRoom }) {
+  return (
+    <Grid>
+      <Row label="이름" value={room.room_name ?? '-'} />
+      <Row label="용도" value={room.room_type ?? '-'} />
+      <Row label="신뢰도" value={fmtConfidence(room.confidence)} />
+    </Grid>
+  );
+}
+
+function OpeningFields({ opening }: { opening: DraftOpening }) {
+  return (
+    <Grid>
+      <Row label="종류" value={opening.opening_type} />
+      <Row label="너비" value={fmtDecimal(opening.width_m, 'm')} />
+      <Row label="높이" value={fmtDecimal(opening.height_m, 'm')} />
+      <Row label="턱 높이" value={fmtDecimal(opening.sill_height_m, 'm')} />
+      <Row label="신뢰도" value={fmtConfidence(opening.confidence)} />
+    </Grid>
+  );
+}
+
+function ObjectFields({ object }: { object: DraftObject }) {
+  return (
+    <Grid>
+      <Row label="종류" value={object.object_type} />
+      <Row label="높이" value={fmtDecimal(object.z_m, 'm')} />
+      <Row label="신뢰도" value={fmtConfidence(object.confidence)} />
+    </Grid>
+  );
+}
+
+function MaterialSelect({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange?: (next: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+        disabled={disabled || !onChange}
+        className="w-full appearance-none rounded-md border bg-background px-3 py-2.5 pr-9 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-70"
+      >
+        {!MATERIAL_OPTIONS.includes(value) && value && (
+          <option value={value}>{value}</option>
+        )}
+        {MATERIAL_OPTIONS.map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+        {!value && <option value="">재질 미지정</option>}
+      </select>
+      <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+    </div>
   );
 }
 
@@ -172,7 +250,7 @@ function EmptyBody() {
         선택된 객체가 없습니다
       </p>
       <p className="mt-1 text-[11px] text-muted-foreground/80">
-        캔버스의 객체를 클릭하면 속성이 표시됩니다.
+        캔버스의 도형을 클릭하면 속성이 표시됩니다.
       </p>
     </div>
   );
@@ -211,31 +289,61 @@ function Section({
   );
 }
 
-function PxField({
-  label,
-  value,
-  onChange,
-  className,
-}: {
-  label: string;
-  value: number;
-  onChange: (next: number) => void;
-  className?: string;
-}) {
+function Grid({ children }: { children: React.ReactNode }) {
+  return <dl className="space-y-1 rounded-md border bg-background/60 p-3">{children}</dl>;
+}
+
+function Row({ label, value }: { label: string; value: string }) {
   return (
-    <label className={cn('flex flex-col gap-1.5', className)}>
-      <span className="text-[11px] text-muted-foreground">{label}</span>
-      <div className="relative">
-        <input
-          type="number"
-          value={value}
-          onChange={(e) => onChange(Number(e.target.value))}
-          className="w-full rounded-md border bg-background px-2.5 py-1.5 pr-8 text-sm font-medium tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
-        />
-        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] text-muted-foreground">
-          px
-        </span>
-      </div>
-    </label>
+    <div className="flex items-center justify-between gap-3 border-b py-1.5 last:border-0">
+      <dt className="text-[11px] text-muted-foreground">{label}</dt>
+      <dd className={cn('text-sm font-medium tabular-nums', value === '-' && 'text-muted-foreground')}>
+        {value}
+      </dd>
+    </div>
   );
+}
+
+// ============================================
+// helpers
+// ============================================
+
+function fmtDecimal(value: string | null | undefined, unit = ''): string {
+  if (value == null || value === '') return '-';
+  const n = Number(value);
+  if (!Number.isFinite(n)) return value;
+  return `${n.toFixed(2)}${unit ? ' ' + unit : ''}`;
+}
+
+function fmtConfidence(value: string | null | undefined): string {
+  if (value == null) return '-';
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '-';
+  return `${Math.round(n * 100)}%`;
+}
+
+function getMaterial(selected: SelectedEntityResolved): string {
+  if (selected.kind === 'wall') return selected.data.material_label ?? '';
+  if (selected.kind === 'object') {
+    const raw = selected.data.metadata_json as { raw?: { material?: string } };
+    return raw?.raw?.material ?? '';
+  }
+  return '';
+}
+
+function getEntityId(selected: SelectedEntityResolved): string {
+  return selected.data.id;
+}
+
+function getEntitySubLabel(selected: SelectedEntityResolved): string | null {
+  switch (selected.kind) {
+    case 'wall':
+      return selected.data.wall_role || null;
+    case 'room':
+      return selected.data.room_type || null;
+    case 'opening':
+      return selected.data.opening_type;
+    case 'object':
+      return selected.data.object_type;
+  }
 }

--- a/frontend/src/features/editor/geometry-utils.ts
+++ b/frontend/src/features/editor/geometry-utils.ts
@@ -1,0 +1,151 @@
+// GeoJSON 파싱 + 도형 평행이동 헬퍼.
+// 좌표 단위: 미터 (백엔드 PostGIS 저장 기준).
+
+export type Coord = [number, number];
+
+export type GeoJsonGeometry =
+  | { type: 'LineString'; coordinates: Coord[] }
+  | { type: 'Polygon'; coordinates: Coord[][] }
+  | { type: 'Point'; coordinates: Coord };
+
+export function parseGeometry(
+  geom: Record<string, unknown> | null | undefined,
+): GeoJsonGeometry | null {
+  if (!geom || typeof geom !== 'object') return null;
+  const type = (geom as { type?: unknown }).type;
+  const coordinates = (geom as { coordinates?: unknown }).coordinates;
+  if (typeof type !== 'string' || !coordinates) return null;
+
+  if (type === 'LineString' && Array.isArray(coordinates)) {
+    const coords = (coordinates as unknown[]).filter(isCoord);
+    if (coords.length < 2) return null;
+    return { type: 'LineString', coordinates: coords };
+  }
+  if (type === 'Polygon' && Array.isArray(coordinates)) {
+    const rings = (coordinates as unknown[])
+      .map((ring) => (Array.isArray(ring) ? ring.filter(isCoord) : []))
+      .filter((r) => r.length >= 3);
+    if (rings.length === 0) return null;
+    return { type: 'Polygon', coordinates: rings };
+  }
+  if (
+    type === 'Point' &&
+    Array.isArray(coordinates) &&
+    coordinates.length >= 2 &&
+    typeof coordinates[0] === 'number' &&
+    typeof coordinates[1] === 'number'
+  ) {
+    return { type: 'Point', coordinates: [coordinates[0], coordinates[1]] };
+  }
+  return null;
+}
+
+function isCoord(p: unknown): p is Coord {
+  return (
+    Array.isArray(p) &&
+    p.length >= 2 &&
+    typeof p[0] === 'number' &&
+    typeof p[1] === 'number'
+  );
+}
+
+/** 도형을 (dx, dy) 만큼 평행이동. 동일 type 의 새 GeoJSON 반환. */
+export function translateGeometry(
+  g: GeoJsonGeometry,
+  dx: number,
+  dy: number,
+): GeoJsonGeometry {
+  if (g.type === 'LineString') {
+    return {
+      type: 'LineString',
+      coordinates: g.coordinates.map(([x, y]) => [x + dx, y + dy] as Coord),
+    };
+  }
+  if (g.type === 'Polygon') {
+    return {
+      type: 'Polygon',
+      coordinates: g.coordinates.map((ring) =>
+        ring.map(([x, y]) => [x + dx, y + dy] as Coord),
+      ),
+    };
+  }
+  return {
+    type: 'Point',
+    coordinates: [g.coordinates[0] + dx, g.coordinates[1] + dy],
+  };
+}
+
+/** LineString 의 index 번째 꼭짓점을 (dx, dy) 만큼 이동. */
+export function moveLineStringVertex(
+  coords: Coord[],
+  index: number,
+  dx: number,
+  dy: number,
+): Coord[] {
+  return coords.map((c, i) =>
+    i === index ? ([c[0] + dx, c[1] + dy] as Coord) : c,
+  );
+}
+
+/** Polygon 첫 ring 의 index 번째 꼭짓점을 (dx, dy) 만큼 이동. ring 닫힘 유지. */
+export function movePolygonVertex(
+  rings: Coord[][],
+  index: number,
+  dx: number,
+  dy: number,
+): Coord[][] {
+  if (rings.length === 0) return rings;
+  const ring = rings[0];
+  const isClosed =
+    ring.length > 0 &&
+    ring[0][0] === ring[ring.length - 1][0] &&
+    ring[0][1] === ring[ring.length - 1][1];
+  const updated = ring.map((c, i) =>
+    i === index ? ([c[0] + dx, c[1] + dy] as Coord) : c,
+  );
+  // 닫힌 ring 의 첫 꼭짓점을 옮긴 경우 마지막 꼭짓점도 같이 이동시켜 닫힘 유지
+  if (isClosed && index === 0) {
+    updated[updated.length - 1] = updated[0];
+  }
+  return [updated, ...rings.slice(1)];
+}
+
+/** 도형 회전 중심점. LineString=중점, Polygon=꼭짓점 평균, Point=자기 자신. */
+export function geometryCenter(g: GeoJsonGeometry): Coord {
+  if (g.type === 'Point') return [g.coordinates[0], g.coordinates[1]];
+  if (g.type === 'LineString') {
+    const a = g.coordinates[0];
+    const b = g.coordinates[g.coordinates.length - 1];
+    return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+  }
+  const ring = g.coordinates[0] ?? [];
+  if (ring.length === 0) return [0, 0];
+  const isClosed =
+    ring[0][0] === ring[ring.length - 1][0] &&
+    ring[0][1] === ring[ring.length - 1][1];
+  const pts = isClosed ? ring.slice(0, -1) : ring;
+  const n = pts.length || 1;
+  const sx = pts.reduce((s, p) => s + p[0], 0);
+  const sy = pts.reduce((s, p) => s + p[1], 0);
+  return [sx / n, sy / n];
+}
+
+/** (cx, cy) 주위로 90° 시계방향 회전: (x, y) → (cx + (y - cy), cy - (x - cx)). */
+export function rotateGeometry90Cw(
+  g: GeoJsonGeometry,
+  center?: Coord,
+): GeoJsonGeometry {
+  const [cx, cy] = center ?? geometryCenter(g);
+  const rot = ([x, y]: Coord): Coord => [cx + (y - cy), cy - (x - cx)];
+  if (g.type === 'LineString') {
+    return { type: 'LineString', coordinates: g.coordinates.map(rot) };
+  }
+  if (g.type === 'Polygon') {
+    return {
+      type: 'Polygon',
+      coordinates: g.coordinates.map((ring) => ring.map(rot)),
+    };
+  }
+  // Point 는 자기 중심 회전 = 변화 없음
+  return g;
+}

--- a/frontend/src/hooks/use-draft-mutations.ts
+++ b/frontend/src/hooks/use-draft-mutations.ts
@@ -1,0 +1,239 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { sceneDraftApi } from '@/api/scene-draft';
+import type { HttpError } from '@/api/client';
+import { toast } from '@/stores/toast-store';
+import type { UUID } from '@/types/common';
+import type {
+  DraftEntityKind,
+  DraftObject,
+  DraftOpening,
+  DraftRoom,
+  DraftWall,
+  SceneDraft,
+} from '@/types/scene';
+
+const ENTITY_LABEL: Record<DraftEntityKind, string> = {
+  wall: '벽',
+  room: '방',
+  opening: '개구부',
+  object: '객체',
+};
+
+/** SceneDraft 의 어느 배열에 속하는지. */
+const ENTITY_ARRAY: Record<
+  DraftEntityKind,
+  'walls' | 'rooms' | 'openings' | 'objects'
+> = {
+  wall: 'walls',
+  room: 'rooms',
+  opening: 'openings',
+  object: 'objects',
+};
+
+type AnyDraftEntity = DraftWall | DraftRoom | DraftOpening | DraftObject;
+type AnyDraftEntityPatch =
+  | Partial<DraftWall>
+  | Partial<DraftRoom>
+  | Partial<DraftOpening>
+  | Partial<DraftObject>;
+
+interface PatchVars {
+  kind: DraftEntityKind;
+  id: UUID;
+  body: AnyDraftEntityPatch;
+  /** 토스트 옵션 — 자동 저장(드래그/입력)에선 토스트 노이즈 줄이려고 false */
+  silent?: boolean;
+}
+
+interface DeleteVars {
+  kind: DraftEntityKind;
+  id: UUID;
+}
+
+interface CreateVars {
+  draftId: UUID;
+  kind: DraftEntityKind;
+  body: AnyDraftEntityPatch;
+}
+
+type AnyPatchResult = DraftWall | DraftRoom | DraftOpening | DraftObject;
+
+async function patchByKind(vars: PatchVars): Promise<AnyPatchResult> {
+  switch (vars.kind) {
+    case 'wall':
+      return sceneDraftApi.patchWall(vars.id, vars.body as Partial<DraftWall>);
+    case 'room':
+      return sceneDraftApi.patchRoom(vars.id, vars.body as Partial<DraftRoom>);
+    case 'opening':
+      return sceneDraftApi.patchOpening(vars.id, vars.body as Partial<DraftOpening>);
+    case 'object':
+      return sceneDraftApi.patchObject(vars.id, vars.body as Partial<DraftObject>);
+  }
+}
+
+async function deleteByKind(vars: DeleteVars): Promise<void> {
+  switch (vars.kind) {
+    case 'wall':
+      return sceneDraftApi.deleteWall(vars.id);
+    case 'room':
+      return sceneDraftApi.deleteRoom(vars.id);
+    case 'opening':
+      return sceneDraftApi.deleteOpening(vars.id);
+    case 'object':
+      return sceneDraftApi.deleteObject(vars.id);
+  }
+}
+
+async function addByKind(vars: CreateVars): Promise<AnyPatchResult> {
+  switch (vars.kind) {
+    case 'wall':
+      return sceneDraftApi.addWall(vars.draftId, vars.body as Partial<DraftWall>);
+    case 'room':
+      return sceneDraftApi.addRoom(vars.draftId, vars.body as Partial<DraftRoom>);
+    case 'opening':
+      return sceneDraftApi.addOpening(vars.draftId, vars.body as Partial<DraftOpening>);
+    case 'object':
+      return sceneDraftApi.addObject(vars.draftId, vars.body as Partial<DraftObject>);
+  }
+}
+
+// ============================================
+// 캐시 조작 헬퍼 (optimistic update)
+// ============================================
+
+type SceneDraftSnapshot = ReturnType<
+  ReturnType<typeof useQueryClient>['getQueriesData']
+>;
+
+function snapshotDrafts(qc: ReturnType<typeof useQueryClient>): SceneDraftSnapshot {
+  return qc.getQueriesData({ queryKey: ['scene-draft'] });
+}
+
+function restoreDrafts(
+  qc: ReturnType<typeof useQueryClient>,
+  snap: SceneDraftSnapshot,
+) {
+  for (const [key, data] of snap) {
+    qc.setQueryData(key, data);
+  }
+}
+
+function patchDraftInCache(draft: SceneDraft | undefined, vars: PatchVars): SceneDraft | undefined {
+  if (!draft) return draft;
+  const arrKey = ENTITY_ARRAY[vars.kind];
+  const arr = draft[arrKey] as AnyDraftEntity[] | undefined;
+  if (!Array.isArray(arr)) return draft;
+  return {
+    ...draft,
+    [arrKey]: arr.map((e) =>
+      e.id === vars.id ? ({ ...e, ...vars.body } as AnyDraftEntity) : e,
+    ),
+  };
+}
+
+function deleteFromDraftCache(
+  draft: SceneDraft | undefined,
+  vars: DeleteVars,
+): SceneDraft | undefined {
+  if (!draft) return draft;
+  const arrKey = ENTITY_ARRAY[vars.kind];
+  const arr = draft[arrKey] as AnyDraftEntity[] | undefined;
+  if (!Array.isArray(arr)) return draft;
+  return { ...draft, [arrKey]: arr.filter((e) => e.id !== vars.id) };
+}
+
+// ============================================
+// 훅
+// ============================================
+
+/**
+ * Draft 자식 엔티티 PATCH (모든 kind 공통).
+ * onMutate 로 캐시에 즉시 반영(optimistic) → 서버 응답 후 invalidate 로 정합화.
+ */
+export function usePatchDraftEntity() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: PatchVars) => patchByKind(vars),
+    onMutate: async (vars) => {
+      await qc.cancelQueries({ queryKey: ['scene-draft'] });
+      const snapshot = snapshotDrafts(qc);
+      qc.setQueriesData<SceneDraft | undefined>(
+        { queryKey: ['scene-draft'] },
+        (old) => patchDraftInCache(old, vars),
+      );
+      return { snapshot };
+    },
+    onError: (err, vars, context) => {
+      if (context?.snapshot) restoreDrafts(qc, context.snapshot);
+      const e = err as HttpError | null;
+      toast.error(
+        `${ENTITY_LABEL[vars.kind]} 수정 실패`,
+        e?.message ?? '잠시 후 다시 시도해주세요.',
+      );
+    },
+    onSuccess: (_data, vars) => {
+      if (!vars.silent) {
+        toast.success(`${ENTITY_LABEL[vars.kind]} 수정 완료`);
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['scene-draft'] });
+    },
+  });
+}
+
+/**
+ * Draft 자식 엔티티 DELETE.
+ * onMutate 로 캐시에서 즉시 제거(optimistic).
+ */
+export function useDeleteDraftEntity() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: DeleteVars) => deleteByKind(vars),
+    onMutate: async (vars) => {
+      await qc.cancelQueries({ queryKey: ['scene-draft'] });
+      const snapshot = snapshotDrafts(qc);
+      qc.setQueriesData<SceneDraft | undefined>(
+        { queryKey: ['scene-draft'] },
+        (old) => deleteFromDraftCache(old, vars),
+      );
+      return { snapshot };
+    },
+    onError: (err, vars, context) => {
+      if (context?.snapshot) restoreDrafts(qc, context.snapshot);
+      const e = err as HttpError | null;
+      toast.error(
+        `${ENTITY_LABEL[vars.kind]} 삭제 실패`,
+        e?.message ?? '잠시 후 다시 시도해주세요.',
+      );
+    },
+    onSuccess: (_data, vars) => {
+      toast.info(`${ENTITY_LABEL[vars.kind]} 삭제됨`);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['scene-draft'] });
+    },
+  });
+}
+
+/**
+ * Draft 자식 엔티티 CREATE.
+ * 서버가 새 id 를 발급하므로 optimistic 은 생략 — refetch 로 최신 상태 받음.
+ */
+export function useCreateDraftEntity() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: CreateVars) => addByKind(vars),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ['scene-draft'] });
+      toast.success(`${ENTITY_LABEL[vars.kind]} 추가 완료`);
+    },
+    onError: (err, vars) => {
+      const e = err as HttpError | null;
+      toast.error(
+        `${ENTITY_LABEL[vars.kind]} 추가 실패`,
+        e?.message ?? '잠시 후 다시 시도해주세요.',
+      );
+    },
+  });
+}

--- a/frontend/src/hooks/use-floorplan-job.ts
+++ b/frontend/src/hooks/use-floorplan-job.ts
@@ -1,0 +1,72 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { floorplanJobApi } from '@/api/floorplan-job';
+import type { UUID } from '@/types/common';
+import type { Job } from '@/types/job';
+import { toast } from '@/stores/toast-store';
+
+const POLL_INTERVAL_MS = 3_000;
+
+/**
+ * 비동기 분석 Job 진행 상태 폴링.
+ *
+ * - jobId 가 truthy 인 동안 3초 간격으로 GET /floorplan-jobs/{id}.
+ * - status 가 succeeded / failed 면 자동 폴링 중지.
+ * - succeeded 시 scene-drafts 캐시 무효화 + 토스트.
+ * - failed 시 에러 토스트.
+ */
+export function useFloorplanJob(jobId: UUID | null) {
+  const qc = useQueryClient();
+  // 같은 jobId 에 대해 success/error 토스트가 중복 발화되지 않도록 가드.
+  const settledRef = useRef<string | null>(null);
+
+  const query = useQuery({
+    queryKey: ['floorplan-job', jobId] as const,
+    queryFn: () => floorplanJobApi.get(jobId as UUID),
+    enabled: !!jobId,
+    refetchInterval: (q) => {
+      const status = q.state.data?.status;
+      if (status === 'succeeded' || status === 'failed') return false;
+      return POLL_INTERVAL_MS;
+    },
+    refetchIntervalInBackground: false,
+  });
+
+  // 상태 변화 부수효과 (토스트, 캐시 무효화)
+  useEffect(() => {
+    const data = query.data;
+    if (!data || !jobId) return;
+    if (settledRef.current === jobId) return;
+
+    if (data.status === 'succeeded') {
+      settledRef.current = jobId;
+      qc.invalidateQueries({ queryKey: ['scene-drafts'] });
+      toast.success('도면 분석 완료', '결과를 확인하고 확정해주세요.');
+    } else if (data.status === 'failed') {
+      settledRef.current = jobId;
+      toast.error('도면 분석 실패', data.error_message ?? '잠시 후 다시 시도해주세요.');
+    }
+  }, [query.data, jobId, qc]);
+
+  // jobId 가 바뀌면 가드 초기화
+  useEffect(() => {
+    settledRef.current = null;
+  }, [jobId]);
+
+  const job: Job | null = query.data ?? null;
+  const isPolling = !!jobId && job?.status !== 'succeeded' && job?.status !== 'failed';
+  const sceneDraftId =
+    job?.status === 'succeeded'
+      ? (job.result_json?.scene_draft_id as string | undefined) ?? null
+      : null;
+
+  return {
+    job,
+    isPolling,
+    isLoading: query.isLoading,
+    isSucceeded: job?.status === 'succeeded',
+    isFailed: job?.status === 'failed',
+    sceneDraftId,
+    errorMessage: job?.status === 'failed' ? job.error_message : null,
+  };
+}

--- a/frontend/src/hooks/use-rf-run.ts
+++ b/frontend/src/hooks/use-rf-run.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { rfRunApi } from '@/api/rf-run';
+import type { HttpError } from '@/api/client';
+import { toast } from '@/stores/toast-store';
+import type { UUID } from '@/types/common';
+import type { RfRun, RfRunCreate } from '@/types/rf';
+
+const POLL_INTERVAL_MS = 3_000;
+
+/** POST /rf-runs — 시뮬레이션 큐 등록. */
+export function useCreateRfRun() {
+  return useMutation({
+    mutationFn: (body: RfRunCreate) => rfRunApi.create(body),
+    onSuccess: () => {
+      toast.info('RF 시뮬레이션 시작', '분석이 완료되면 결과를 알려드릴게요.');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error(
+        'RF 시뮬레이션 요청 실패',
+        e?.message ?? '잠시 후 다시 시도해주세요.',
+      );
+    },
+  });
+}
+
+/**
+ * RF Run 진행 상태 폴링.
+ * succeeded/failed 시 자동 중지 + 토스트 (중복 발화 방지).
+ */
+export function useRfRun(rfRunId: UUID | null) {
+  const settledRef = useRef<string | null>(null);
+
+  const query = useQuery({
+    queryKey: ['rf-run', rfRunId] as const,
+    queryFn: () => rfRunApi.get(rfRunId as UUID),
+    enabled: !!rfRunId,
+    refetchInterval: (q) => {
+      const s = q.state.data?.status;
+      if (s === 'succeeded' || s === 'failed') return false;
+      return POLL_INTERVAL_MS;
+    },
+    refetchIntervalInBackground: false,
+  });
+
+  useEffect(() => {
+    const data = query.data;
+    if (!data || !rfRunId) return;
+    if (settledRef.current === rfRunId) return;
+    if (data.status === 'succeeded') {
+      settledRef.current = rfRunId;
+      toast.success('RF 시뮬레이션 완료', '결과를 확인해주세요.');
+    } else if (data.status === 'failed') {
+      settledRef.current = rfRunId;
+      const err = (data.metrics_json?.['error_message'] as string | undefined) ?? undefined;
+      toast.error('RF 시뮬레이션 실패', err ?? '잠시 후 다시 시도해주세요.');
+    }
+  }, [query.data, rfRunId]);
+
+  useEffect(() => {
+    settledRef.current = null;
+  }, [rfRunId]);
+
+  const rfRun: RfRun | null = query.data ?? null;
+  const status = rfRun?.status;
+  return {
+    rfRun,
+    isPolling: !!rfRunId && status !== 'succeeded' && status !== 'failed',
+    isSucceeded: status === 'succeeded',
+    isFailed: status === 'failed',
+  };
+}
+
+/** GET /rf-runs/{id}/maps — RF Run 이 succeeded 된 후에만 활성화 */
+export function useRfMaps(rfRunId: UUID | null, enabled: boolean) {
+  return useQuery({
+    queryKey: ['rf-maps', rfRunId] as const,
+    queryFn: () => rfRunApi.listMaps(rfRunId as UUID),
+    enabled: !!rfRunId && enabled,
+  });
+}

--- a/frontend/src/hooks/use-scene-draft.ts
+++ b/frontend/src/hooks/use-scene-draft.ts
@@ -40,32 +40,34 @@ function analyzeErrorMessage(err: unknown): string {
   return e.message ?? '도면 분석에 실패했습니다.';
 }
 
-/** §6.1 — 신규 도면 업로드 + 즉시 분석 */
+/**
+ * §6.1 — 신규 도면 업로드 + 분석 Job 등록.
+ *
+ * 백엔드가 비동기로 전환되어 mutation 은 즉시 job_id 만 반환함.
+ * 실제 완료 여부는 useFloorplanJob(jobId) 폴링으로 확인하고,
+ * 완료/실패 토스트도 그 훅에서 발화함.
+ */
 export function useAnalyzeFloorplan() {
-  const qc = useQueryClient();
   return useMutation({
     mutationFn: (params: AnalyzeFloorplanParams) => sceneDraftApi.analyzeFloorplan(params),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['scene-drafts'] });
-      toast.success('도면 분석 완료', '결과를 확인하고 확정해주세요.');
+      toast.info('도면 분석 시작', '분석이 완료되면 결과를 알려드릴게요.');
     },
     onError: (err) => {
-      toast.error('도면 분석 실패', analyzeErrorMessage(err));
+      toast.error('도면 분석 요청 실패', analyzeErrorMessage(err));
     },
   });
 }
 
-/** §6.1.1 — 이미 등록된 Asset 도면을 재분석. 권장 흐름. */
+/** §6.1.1 — 이미 등록된 Asset 도면을 재분석. 권장 흐름. (동일하게 비동기 Job) */
 export function useAnalyzeFromAsset() {
-  const qc = useQueryClient();
   return useMutation({
     mutationFn: (params: AnalyzeFromAssetParams) => sceneDraftApi.analyzeFromAsset(params),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['scene-drafts'] });
-      toast.success('도면 분석 완료', '결과를 확인하고 확정해주세요.');
+      toast.info('도면 분석 시작', '분석이 완료되면 결과를 알려드릴게요.');
     },
     onError: (err) => {
-      toast.error('도면 분석 실패', analyzeErrorMessage(err));
+      toast.error('도면 분석 요청 실패', analyzeErrorMessage(err));
     },
   });
 }

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronRight, Loader2, Map as MapIcon } from 'lucide-react';
 import { useAppStore } from '@/stores/app-store';
@@ -9,28 +9,32 @@ import {
   useDraftsForFloor,
   useSceneDraft,
 } from '@/hooks/use-scene-draft';
+import { useFloorplanJob } from '@/hooks/use-floorplan-job';
 import { useFloorVersions, usePromoteDraft } from '@/hooks/use-scene-version';
+import {
+  useCreateDraftEntity,
+  useDeleteDraftEntity,
+  usePatchDraftEntity,
+} from '@/hooks/use-draft-mutations';
 import { CanvasToolbar } from '@/features/editor/CanvasToolbar';
 import { CanvasArea } from '@/features/editor/CanvasArea';
-import {
-  PropertiesPanel,
-  type SelectedObject,
-} from '@/features/editor/PropertiesPanel';
+import { DraftSceneCanvas } from '@/features/editor/DraftSceneCanvas';
+import { PropertiesPanel } from '@/features/editor/PropertiesPanel';
 import { ReviewCard } from '@/features/editor/ReviewCard';
 import { PromotedCard } from '@/features/editor/PromotedCard';
+import {
+  parseGeometry,
+  rotateGeometry90Cw,
+  type GeoJsonGeometry,
+} from '@/features/editor/geometry-utils';
+import type { DraftEntityKind } from '@/types/scene';
 import type { HttpError } from '@/api/client';
-import type { SceneVersion } from '@/types/scene';
-
-// Figma 디자인의 우측 패널 mock 데이터. 실제 캔버스 선택과 연동되기 전까지 사용.
-const DEMO_SELECTED: SelectedObject = {
-  typeLabel: '가구 (테이블)',
-  scanned: true,
-  width: 120,
-  height: 40,
-  x: 350,
-  y: 200,
-  material: '목재 테이블 (신호 감쇠 보통)',
-};
+import type {
+  SceneDraft,
+  SceneVersion,
+  SelectedEntityRef,
+  SelectedEntityResolved,
+} from '@/types/scene';
 
 export default function EditorPage() {
   const projectId = useAppStore((s) => s.selectedProjectId);
@@ -49,10 +53,18 @@ export default function EditorPage() {
   const analyze = useAnalyzeFloorplan();
   const promote = usePromoteDraft();
   const removeDraft = useDeleteSceneDraft();
+  const patchEntity = usePatchDraftEntity();
+  const deleteEntity = useDeleteDraftEntity();
+  const createEntity = useCreateDraftEntity();
 
   const [justPromoted, setJustPromoted] = useState<SceneVersion | null>(null);
   const [pendingFileName, setPendingFileName] = useState<string | null>(null);
-  const [selected, setSelected] = useState<SelectedObject | null>(DEMO_SELECTED);
+  const [selectedRef, setSelectedRef] = useState<SelectedEntityRef | null>(null);
+
+  // 분석 Job 추적 — POST /upload/floorplan/analyze 가 즉시 202 + job_id 만 반환.
+  // 실제 완료 여부는 useFloorplanJob 폴링으로 확인.
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const jobPoll = useFloorplanJob(activeJobId);
 
   // list 응답은 summary (자식 배열 없음). 상세는 별도 GET 으로 가져와야 함.
   const activeDraftSummary =
@@ -60,19 +72,114 @@ export default function EditorPage() {
   const activeDraftQuery = useSceneDraft(activeDraftSummary?.id ?? null);
   const activeDraft = activeDraftQuery.data ?? null;
 
+  // selectedRef → activeDraft 의 실제 엔티티로 해소
+  const resolvedSelected = useMemo<SelectedEntityResolved | null>(() => {
+    if (!activeDraft || !selectedRef) return null;
+    switch (selectedRef.kind) {
+      case 'wall': {
+        const data = activeDraft.walls.find((w) => w.id === selectedRef.id);
+        return data ? { kind: 'wall', data } : null;
+      }
+      case 'room': {
+        const data = activeDraft.rooms.find((r) => r.id === selectedRef.id);
+        return data ? { kind: 'room', data } : null;
+      }
+      case 'opening': {
+        const data = activeDraft.openings.find((o) => o.id === selectedRef.id);
+        return data ? { kind: 'opening', data } : null;
+      }
+      case 'object': {
+        const data = activeDraft.objects.find((o) => o.id === selectedRef.id);
+        return data ? { kind: 'object', data } : null;
+      }
+    }
+  }, [activeDraft, selectedRef]);
+
+  // draft 가 바뀌면 (재분석 / 삭제 / promote) 선택 해제.
+  // props 변화에 따른 state 조정 — render 중 비교 → setState 로 cascading render 회피.
+  const [prevDraftId, setPrevDraftId] = useState<string | null>(activeDraft?.id ?? null);
+  const currentDraftId = activeDraft?.id ?? null;
+  if (prevDraftId !== currentDraftId) {
+    setPrevDraftId(currentDraftId);
+    setSelectedRef(null);
+  }
+
+  // 드래그 (shape 평행이동 / vertex 개별 이동) 종료 시 새 geometry 로 PATCH.
+  // canvas 가 이미 새 GeoJSON 까지 만들어 넘겨주므로, 여기선 적절한 *_geom 필드로 매핑만.
+  const handleDragEnd = (
+    ref: SelectedEntityRef,
+    geometry: GeoJsonGeometry,
+  ) => {
+    const body = geomFieldFor(ref.kind, geometry);
+    if (!body) return;
+    patchEntity.mutate({ kind: ref.kind, id: ref.id, body, silent: true });
+  };
+
+  // 선택된 엔티티 삭제
+  const handleDeleteSelected = () => {
+    if (!selectedRef) return;
+    deleteEntity.mutate(
+      { kind: selectedRef.kind, id: selectedRef.id },
+      { onSuccess: () => setSelectedRef(null) },
+    );
+  };
+
+  // 벽 재질 변경
+  const handleUpdateMaterial = (material: string) => {
+    if (!selectedRef || selectedRef.kind !== 'wall') return;
+    patchEntity.mutate({
+      kind: 'wall',
+      id: selectedRef.id,
+      body: { material_label: material },
+    });
+  };
+
+  // 90° 시계방향 회전 (벽 / 개구부 / 방). 객체는 의미 없음.
+  const handleRotateSelected = () => {
+    if (!activeDraft || !selectedRef || selectedRef.kind === 'object') return;
+    const g = readGeometryOf(selectedRef, activeDraft);
+    if (!g) return;
+    const rotated = rotateGeometry90Cw(g);
+    const body = geomFieldFor(selectedRef.kind, rotated);
+    if (!body) return;
+    patchEntity.mutate({ kind: selectedRef.kind, id: selectedRef.id, body });
+  };
+
+  // 좌측 도구바로 새 도형 추가
+  const handleCreate = (kind: DraftEntityKind, body: Record<string, unknown>) => {
+    if (!activeDraft) return;
+    createEntity.mutate({ draftId: activeDraft.id, kind, body });
+  };
+
   const versions = versionsQuery.data ?? [];
   const nextVersionNo =
     versions.length > 0 ? Math.max(...versions.map((v) => v.version_no)) + 1 : 1;
 
+  // Job 이 성공/실패로 정착되면 추적 종료
+  useEffect(() => {
+    if (jobPoll.isSucceeded || jobPoll.isFailed) {
+      // 약간의 지연 후 클리어 (refetch invalidate + draft fetch 가 끝나도록)
+      const t = window.setTimeout(() => setActiveJobId(null), 1000);
+      return () => window.clearTimeout(t);
+    }
+  }, [jobPoll.isSucceeded, jobPoll.isFailed]);
+
   const handleFile = (file: File, realWidthM: number) => {
     setPendingFileName(file.name);
     if (!floorId) return;
-    analyze.mutate({
-      file,
-      real_width_m: realWidthM,
-      project_id: projectId ?? undefined,
-      floor_id: floorId,
-    });
+    analyze.mutate(
+      {
+        file,
+        real_width_m: realWidthM,
+        project_id: projectId ?? undefined,
+        floor_id: floorId,
+      },
+      {
+        onSuccess: (data) => {
+          setActiveJobId(data.job_id);
+        },
+      },
+    );
   };
 
   const handlePromote = () => {
@@ -99,10 +206,11 @@ export default function EditorPage() {
   // 불러오기: 층이 선택돼있고 분석이 안 도는 중이고, 아직 활성 draft 가 없을 때만.
   //   (이미 draft 가 있는데 또 업로드하면 헷갈리므로 막음 — "다시 업로드" 는 리뷰 카드에서.)
   // 저장하기: 활성 draft 가 있고 다른 mutation 이 안 돌고 있을 때만.
+  const isAnalyzing = analyze.isPending || jobPoll.isPolling;
   const canLoad =
-    !!floorId && !analyze.isPending && !activeDraftSummary && !justPromoted;
+    !!floorId && !isAnalyzing && !activeDraftSummary && !justPromoted;
   const canSave =
-    !!activeDraftSummary && !analyze.isPending && !promote.isPending && !removeDraft.isPending;
+    !!activeDraftSummary && !isAnalyzing && !promote.isPending && !removeDraft.isPending;
   useEffect(() => {
     registerActions({
       onLoadFloorplan: canLoad ? openFilePicker : undefined,
@@ -112,9 +220,8 @@ export default function EditorPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeDraftSummary?.id, nextVersionNo, canLoad, canSave]);
 
-  const isBusy = analyze.isPending;
   const showOverlay =
-    !floorId || !!justPromoted || isBusy || !!activeDraftSummary;
+    !floorId || !!justPromoted || isAnalyzing || !!activeDraftSummary;
 
   return (
     <div className="flex h-full">
@@ -127,13 +234,24 @@ export default function EditorPage() {
       <div className="relative flex flex-1 overflow-hidden">
         {floorId ? (
           <>
-            <CanvasArea
-              fileInputRef={fileInputRef}
-              isPending={isBusy}
-              errorMessage={readError(analyze.error) ?? undefined}
-              selectedFileName={pendingFileName}
-              onFile={handleFile}
-            />
+            {activeDraft ? (
+              <DraftSceneCanvas
+                draft={activeDraft}
+                selectedRef={selectedRef}
+                onSelect={setSelectedRef}
+                onDragEnd={handleDragEnd}
+                tool={tool}
+                onCreate={handleCreate}
+              />
+            ) : (
+              <CanvasArea
+                fileInputRef={fileInputRef}
+                isPending={isAnalyzing}
+                errorMessage={readError(analyze.error) ?? undefined}
+                selectedFileName={pendingFileName}
+                onFile={handleFile}
+              />
+            )}
 
             {showOverlay && (
               <OverlayLayer>
@@ -145,10 +263,10 @@ export default function EditorPage() {
                       setPendingFileName(null);
                     }}
                   />
-                ) : analyze.isPending ? (
+                ) : isAnalyzing ? (
                   <BusyOverlay
-                    title="도면 분석 중..."
-                    subtitle="이미지 분석은 수십 초 정도 걸릴 수 있습니다."
+                    title={analyzingTitle(jobPoll.job?.status)}
+                    subtitle={analyzingSubtitle(jobPoll.job?.status)}
                   />
                 ) : activeDraft ? (
                   <ReviewCard
@@ -174,9 +292,12 @@ export default function EditorPage() {
       </div>
 
       <PropertiesPanel
-        selected={selected}
-        onChange={setSelected}
-        onDelete={() => setSelected(null)}
+        selected={resolvedSelected}
+        onDelete={handleDeleteSelected}
+        onRotate={handleRotateSelected}
+        onUpdateMaterial={handleUpdateMaterial}
+        isSaving={patchEntity.isPending}
+        isDeleting={deleteEntity.isPending}
       />
     </div>
   );
@@ -225,6 +346,52 @@ function NoFloorScreen({ hasProject }: { hasProject: boolean }) {
       </div>
     </div>
   );
+}
+
+/** 엔티티 kind 에 따라 PATCH body 의 적절한 *_geom 필드명을 채워 반환. */
+function geomFieldFor(
+  kind: DraftEntityKind,
+  geometry: GeoJsonGeometry,
+): Record<string, unknown> | null {
+  if (kind === 'wall' && geometry.type === 'LineString')
+    return { centerline_geom: geometry };
+  if (kind === 'opening' && geometry.type === 'LineString')
+    return { line_geom: geometry };
+  if (kind === 'room' && geometry.type === 'Polygon')
+    return { polygon_geom: geometry };
+  if (kind === 'object' && geometry.type === 'Point')
+    return { point_geom: geometry };
+  return null;
+}
+
+/** 선택된 엔티티의 현재 geometry 를 읽어옴. */
+function readGeometryOf(
+  ref: SelectedEntityRef,
+  draft: SceneDraft,
+): GeoJsonGeometry | null {
+  switch (ref.kind) {
+    case 'wall':
+      return parseGeometry(draft.walls.find((w) => w.id === ref.id)?.centerline_geom);
+    case 'opening':
+      return parseGeometry(draft.openings.find((o) => o.id === ref.id)?.line_geom);
+    case 'room':
+      return parseGeometry(draft.rooms.find((r) => r.id === ref.id)?.polygon_geom);
+    case 'object':
+      return parseGeometry(draft.objects.find((o) => o.id === ref.id)?.point_geom);
+  }
+}
+
+function analyzingTitle(status: string | undefined): string {
+  if (!status || status === 'pending') return '분석 Job 등록 중...';
+  if (status === 'running') return '도면 분석 중...';
+  return '도면 분석 중...';
+}
+
+function analyzingSubtitle(status: string | undefined): string {
+  if (!status || status === 'pending') return '큐에 등록되어 곧 분석이 시작됩니다.';
+  if (status === 'running')
+    return '콜드 스타트는 최대 10분, 웜 상태에서는 수 초가 걸립니다.';
+  return '잠시만 기다려주세요.';
 }
 
 function readError(err: unknown): string | null {

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -1,83 +1,143 @@
-import { useEffect, useRef, useState } from 'react';
-import { Play, RotateCcw, Save } from 'lucide-react';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronRight, Map as MapIcon, Play, RotateCcw, Save } from 'lucide-react';
+import { useAppStore } from '@/stores/app-store';
+import { useFloorVersions } from '@/hooks/use-scene-version';
+import { useCreateRfRun, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
 import { HelpFab } from '@/components/HelpFab';
 import {
   SimulationCanvas,
   type SimulationState,
 } from '@/features/simulation/SimulationCanvas';
 import { SimulationResultCard } from '@/features/simulation/SimulationResultCard';
-import { SimulationHistory } from '@/features/simulation/SimulationHistory';
+import {
+  SimulationHistory,
+  type SimulationHistoryItem,
+} from '@/features/simulation/SimulationHistory';
 import {
   MOCK_SIMULATION_FLOOR_SCENE,
   MOCK_SIMULATION_HEATMAP,
-  MOCK_SIMULATION_HISTORY_BASE,
-  MOCK_SIMULATION_NEW_RESULT,
 } from '@/features/simulation/mocks';
 
-const SIM_DURATION_MS = 2500;
-
 export default function SimulationPage() {
-  const [state, setState] = useState<SimulationState>('idle');
+  const floorId = useAppStore((s) => s.selectedFloorId);
+  const versionsQuery = useFloorVersions(floorId);
+  // 현재 활성 버전 (없으면 가장 최근 버전)
+  const currentVersion =
+    versionsQuery.data?.find((v) => v.is_current) ?? versionsQuery.data?.[0] ?? null;
+
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
-  const timerRef = useRef<number | null>(null);
 
-  useEffect(() => () => {
-    if (timerRef.current) window.clearTimeout(timerRef.current);
-  }, []);
+  const createRfRun = useCreateRfRun();
+  const rfRunPoll = useRfRun(activeRunId);
+  const rfMapsQuery = useRfMaps(activeRunId, rfRunPoll.isSucceeded);
 
-  const startSimulation = () => {
-    setState('running');
-    timerRef.current = window.setTimeout(() => setState('complete'), SIM_DURATION_MS);
+  // 백엔드 상태 → UI 상태 매핑
+  const state: SimulationState = (() => {
+    if (!activeRunId) return 'idle';
+    if (rfRunPoll.isSucceeded) return 'complete';
+    if (rfRunPoll.isFailed) return 'idle'; // 토스트로 알림 + 다시 시작 가능
+    return 'running';
+  })();
+
+  const handleStart = () => {
+    if (!currentVersion) return;
+    createRfRun.mutate(
+      {
+        scene_version_id: currentVersion.id,
+        run_type: 'forward',
+      },
+      { onSuccess: (data) => setActiveRunId(data.id) },
+    );
   };
 
-  const resetSimulation = () => {
-    if (timerRef.current) window.clearTimeout(timerRef.current);
-    setState('idle');
+  const handleReset = () => {
+    setActiveRunId(null);
   };
 
-  const history =
-    state === 'complete' ? [MOCK_SIMULATION_NEW_RESULT, ...MOCK_SIMULATION_HISTORY_BASE] : MOCK_SIMULATION_HISTORY_BASE;
+  // 메트릭 추출 (백엔드가 metrics_json 안에 다양한 키로 넣을 수 있어 유연하게)
+  const metrics = parseMetrics(
+    rfRunPoll.rfRun?.metrics_json,
+    rfMapsQuery.data?.[0]?.metrics_json,
+  );
+
+  // 시뮬레이션 기록 — 현재 실행 + (TODO: 과거 RF runs 목록)
+  const history: SimulationHistoryItem[] = currentVersion
+    ? [
+        ...(rfRunPoll.isSucceeded
+          ? [
+              {
+                id: `run-${activeRunId}`,
+                label: `시뮬레이션 결과 #${rfRunPoll.rfRun?.id?.slice(0, 6) ?? ''}`,
+                timeLabel: '방금 전',
+                avgRssiDbm: metrics.avgRssiDbm ?? 0,
+                coveragePercent: metrics.coveragePercent ?? 0,
+                active: true,
+              },
+            ]
+          : []),
+      ]
+    : [];
 
   return (
     <div className="relative flex h-full flex-col p-6">
       <PageHeader
         state={state}
-        onStart={startSimulation}
-        onReset={resetSimulation}
+        hasVersion={!!currentVersion}
+        isStarting={createRfRun.isPending}
+        onStart={handleStart}
+        onReset={handleReset}
       />
 
-      <div
-        className={
-          expanded
-            ? 'mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6'
-            : 'mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]'
-        }
-      >
-        <div className="min-h-0">
-          <SimulationCanvas
-            state={state}
-            scene={MOCK_SIMULATION_FLOOR_SCENE}
-            heatmap={MOCK_SIMULATION_HEATMAP}
-            expanded={expanded}
-            onToggleExpand={() => setExpanded((v) => !v)}
-          />
-        </div>
-
-        {!expanded && (
-          <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
-            {state === 'complete' && (
-              <SimulationResultCard
-                avgRssiDbm={MOCK_SIMULATION_NEW_RESULT.avgRssiDbm}
-                coveragePercent={MOCK_SIMULATION_NEW_RESULT.coveragePercent}
-              />
-            )}
-            <SimulationHistory
-              items={history}
-              showCompareButton={state !== 'idle' && history.length >= 2}
+      {!floorId ? (
+        <EmptyState
+          title="층을 선택해주세요"
+          subtitle="대시보드에서 층을 선택하면 시뮬레이션을 시작할 수 있습니다."
+        />
+      ) : versionsQuery.isLoading ? (
+        <EmptyState title="버전 정보를 불러오는 중..." />
+      ) : !currentVersion ? (
+        <EmptyState
+          title="확정된 도면 버전이 없습니다"
+          subtitle="공간 편집에서 도면을 분석·확정한 후 시뮬레이션을 실행할 수 있습니다."
+          ctaLabel="공간 편집으로 이동"
+          ctaTo="/editor"
+        />
+      ) : (
+        <div
+          className={
+            expanded
+              ? 'mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6'
+              : 'mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]'
+          }
+        >
+          <div className="min-h-0">
+            <SimulationCanvas
+              state={state}
+              scene={MOCK_SIMULATION_FLOOR_SCENE}
+              heatmap={MOCK_SIMULATION_HEATMAP}
+              expanded={expanded}
+              onToggleExpand={() => setExpanded((v) => !v)}
             />
-          </aside>
-        )}
-      </div>
+          </div>
+
+          {!expanded && (
+            <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
+              {state === 'complete' && (
+                <SimulationResultCard
+                  avgRssiDbm={metrics.avgRssiDbm ?? -65}
+                  coveragePercent={metrics.coveragePercent ?? 0}
+                />
+              )}
+              <SimulationHistory
+                items={history}
+                showCompareButton={false}
+              />
+            </aside>
+          )}
+        </div>
+      )}
 
       <HelpFab />
     </div>
@@ -86,10 +146,14 @@ export default function SimulationPage() {
 
 function PageHeader({
   state,
+  hasVersion,
+  isStarting,
   onStart,
   onReset,
 }: {
   state: SimulationState;
+  hasVersion: boolean;
+  isStarting: boolean;
   onStart: () => void;
   onReset: () => void;
 }) {
@@ -107,10 +171,11 @@ function PageHeader({
           <button
             type="button"
             onClick={onStart}
-            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+            disabled={!hasVersion || isStarting}
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Play className="h-4 w-4 fill-current" />
-            시뮬레이션 실행
+            {isStarting ? '요청 중...' : '시뮬레이션 실행'}
           </button>
         ) : (
           <>
@@ -137,3 +202,64 @@ function PageHeader({
   );
 }
 
+function EmptyState({
+  title,
+  subtitle,
+  ctaLabel,
+  ctaTo,
+}: {
+  title: string;
+  subtitle?: string;
+  ctaLabel?: string;
+  ctaTo?: string;
+}) {
+  return (
+    <div className="mt-5 flex flex-1 items-center justify-center">
+      <div className="flex max-w-md flex-col items-center gap-3 rounded-xl border border-dashed bg-background p-10 text-center shadow-sm">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
+          <MapIcon className="h-6 w-6 text-primary" strokeWidth={1.8} />
+        </div>
+        <p className="text-base font-semibold">{title}</p>
+        {subtitle && (
+          <p className="text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+        )}
+        {ctaLabel && ctaTo && (
+          <Link
+            to={ctaTo}
+            className="mt-2 inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            {ctaLabel}
+            <ChevronRight className="h-3.5 w-3.5" />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 백엔드 metrics_json 에서 표시용 값 추출.
+ * AI 서버가 다양한 키로 넣을 수 있어 흔히 쓰이는 키들을 fallback 순으로 확인.
+ */
+function parseMetrics(
+  ...sources: Array<Record<string, unknown> | undefined>
+): { avgRssiDbm: number | null; coveragePercent: number | null } {
+  const merged: Record<string, unknown> = {};
+  for (const s of sources) {
+    if (s) Object.assign(merged, s);
+  }
+  const pickNumber = (...keys: string[]): number | null => {
+    for (const k of keys) {
+      const v = merged[k];
+      if (typeof v === 'number' && Number.isFinite(v)) return v;
+      if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) {
+        return Number(v);
+      }
+    }
+    return null;
+  };
+  return {
+    avgRssiDbm: pickNumber('avg_rssi_dbm', 'avg_dbm', 'rssi_avg', 'avg_rssi'),
+    coveragePercent: pickNumber('coverage_percent', 'coverage', 'coverage_pct'),
+  };
+}

--- a/frontend/src/stores/editor-store.ts
+++ b/frontend/src/stores/editor-store.ts
@@ -1,6 +1,13 @@
 import { create } from 'zustand';
 
-export type EditorTool = 'select' | 'upload' | 'rect' | 'circle' | 'text';
+export type EditorTool =
+  | 'select'
+  | 'upload'
+  | 'rect'      // 벽/구조물 (LineString — 2 클릭)
+  | 'circle'    // 가구 (Point — 1 클릭)
+  | 'text'      // 구역 라벨 (백엔드 미지원, placeholder)
+  | 'polygon'   // 방 (Polygon — 다중 클릭 + 시작점 클릭으로 닫기)
+  | 'opening';  // 문/창 (LineString — 2 클릭)
 
 interface EditorActions {
   onLoadFloorplan?: () => void;

--- a/frontend/src/types/job.ts
+++ b/frontend/src/types/job.ts
@@ -1,0 +1,30 @@
+import type { ISODateString, UUID } from './common';
+
+// 백엔드 §15 Job DTO (app/schemas/job.py 의 JobResponse 와 매칭)
+// 도면 분석은 비동기로 큐잉되어 이 모델로 상태 추적됨.
+
+export type JobStatus =
+  | 'pending'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | string;
+
+export interface Job {
+  id: UUID;
+  project_id: UUID;
+  floor_id: UUID | null;
+  job_type: string;
+  status: JobStatus;
+  input_json: Record<string, unknown>;
+  result_json: Record<string, unknown>;
+  error_message: string | null;
+  started_at: ISODateString | null;
+  finished_at: ISODateString | null;
+  created_at: ISODateString;
+}
+
+/** 도면 분석 완료(succeeded) 후 result_json 에서 추출되는 값들. */
+export interface FloorplanJobResult {
+  scene_draft_id?: UUID;
+}

--- a/frontend/src/types/rf.ts
+++ b/frontend/src/types/rf.ts
@@ -1,0 +1,44 @@
+import type { ISODateString, UUID } from './common';
+
+// 백엔드 §13 RF Run / RF Map DTO 와 매칭 (app/schemas/rf_run.py, rf_map.py).
+
+export type RfRunStatus =
+  | 'pending'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | string;
+
+export interface RfRunCreate {
+  scene_version_id: UUID;
+  run_type?: string;
+  request_json?: Record<string, unknown>;
+}
+
+export interface RfRun {
+  id: UUID;
+  project_id: UUID;
+  floor_id: UUID;
+  scene_version_id: UUID;
+  run_type: string;
+  status: RfRunStatus;
+  request_json: Record<string, unknown>;
+  metrics_json: Record<string, unknown>;
+  created_at: ISODateString;
+}
+
+/** POST /rf-runs 응답 — RfRun + job_id. */
+export interface RfRunCreated extends RfRun {
+  job_id: UUID;
+}
+
+export interface RfMap {
+  id: UUID;
+  rf_run_id: UUID;
+  map_type: string;
+  resolution_cm: number;
+  storage_url: string;
+  bounds_json: Record<string, unknown>;
+  metrics_json: Record<string, unknown>;
+  created_at: ISODateString;
+}

--- a/frontend/src/types/scene.ts
+++ b/frontend/src/types/scene.ts
@@ -149,21 +149,33 @@ export interface AnalyzedScene {
   sourceType?: string;
 }
 
-// §6.1
-export interface AnalyzeFloorplanResponse {
-  status: 'ok' | string;
-  scene_draft_id: UUID;
-  fileId: UUID;
-  savedPath: string;
-  scene: AnalyzedScene;
+// ============================================
+// 분석 호출 응답 (비동기 Job)
+// 백엔드가 동기 → 비동기 Job 으로 전환됨. POST 즉시 202 + job_id 반환.
+// 결과는 GET /floorplan-jobs/{job_id} 로 폴링.
+// ============================================
+
+import type { JobStatus } from './job';
+
+export interface SubmitFloorplanJobResponse {
+  status: 'submitted' | string;
+  job_id: UUID;
+  project_id: UUID | null;
+  floor_id: UUID | null;
+  job_status: JobStatus;
+  sagemaker_inference_id: string | null;
+  poll_url: string;
 }
 
-// §6.1.1
-export interface AnalyzeFromAssetResponse {
-  status: 'ok' | string;
-  scene_draft_id: UUID;
+// §6.1 POST /upload/floorplan/analyze
+export interface AnalyzeFloorplanResponse extends SubmitFloorplanJobResponse {
+  fileId: string;
+  savedPath: string;
+}
+
+// §6.1.1 POST /assets/{asset_id}/analyze
+export interface AnalyzeFromAssetResponse extends SubmitFloorplanJobResponse {
   asset_id: UUID;
-  scene: AnalyzedScene;
 }
 
 // ============================================
@@ -199,3 +211,20 @@ export interface PromoteRequest {
   version_no: number;
   is_current: boolean;
 }
+
+// ============================================
+// 캔버스 선택 상태 (UI 전용)
+// ============================================
+
+export type DraftEntityKind = 'wall' | 'room' | 'opening' | 'object';
+
+export interface SelectedEntityRef {
+  kind: DraftEntityKind;
+  id: UUID;
+}
+
+export type SelectedEntityResolved =
+  | { kind: 'wall'; data: DraftWall }
+  | { kind: 'room'; data: DraftRoom }
+  | { kind: 'opening'; data: DraftOpening }
+  | { kind: 'object'; data: DraftObject };


### PR DESCRIPTION
- 비동기 analyze Job 흐름 추가
  - 즉시 job_id 반환 후 폴링
  - succeeded 시 draft 표시
  - DraftSceneCanvas에서 GeoJSON geometry를 SVG로 렌더링

- 공간 편집 기능 확장
  - 도형 클릭 선택 및 타입별 PropertiesPanel 표시
  - 벽/방/개구부/객체 속성 편집 지원
  - 본체/끝점/꼭짓점 드래그, 90도 회전, 재질 변경, 삭제 연결
  - PATCH/DELETE optimistic update 적용으로 깜빡임 제거
  - 좌측 도구바에서 벽 2-클릭, 가구 1-클릭 추가 지원

- room/opening 작성 도구 추가
  - EditorTool에 polygon/opening 추가
  - opening: 2-클릭 LineString 생성 후 draft-openings POST
  - polygon: 다중 클릭으로 꼭짓점 누적 후 3점 이상에서 닫기 처리
  - draft-rooms POST 시 polygon_geom 및 centroid_geom 전송
  - 단계별 안내 텍스트, 점선 preview, 시작점 강조 추가

- RF Run 실제 API 흐름 연동
  - §13 RF Run API client/hook 추가
  - mutation, polling, maps 처리
  - SimulationPage mock setTimeout 제거
  - 활성 scene version 자동 인식
  - 상태 폴링 및 메트릭 표시
  - 층 미선택/확정 버전 없음 빈 상태 및 공간 편집 CTA 추가