### PR TITLE
feat: §8/§9/§12/§15 백엔드 도메인 wire-up

### DIFF
--- a/frontend/src/api/job.ts
+++ b/frontend/src/api/job.ts
@@ -1,0 +1,16 @@
+import { api } from './client';
+import type { Paginated, UUID } from '@/types/common';
+import type { Job, JobStatus } from '@/types/job';
+
+export const jobApi = {
+  // §15.2 GET /jobs — paginated, filters: job_type / status
+  list: (params?: {
+    job_type?: string;
+    status?: JobStatus;
+    page?: number;
+    page_size?: number;
+  }) => api.get<Paginated<Job>>('/jobs', { params }).then((r) => r.data),
+
+  // §15.1 GET /jobs/{job_id}
+  get: (id: UUID) => api.get<Job>(`/jobs/${id}`).then((r) => r.data),
+};

--- a/frontend/src/api/material-hypothesis.ts
+++ b/frontend/src/api/material-hypothesis.ts
@@ -1,0 +1,17 @@
+import { api } from './client';
+import type { UUID } from '@/types/common';
+import type { MaterialHypothesis } from '@/types/material-hypothesis';
+
+export const materialHypothesisApi = {
+  // §12.3 GET /walls/{wall_id}/material-hypotheses — 벽의 재질 후보 목록
+  listForWall: (wallId: UUID) =>
+    api
+      .get<MaterialHypothesis[]>(`/walls/${wallId}/material-hypotheses`)
+      .then((r) => r.data),
+
+  // §12.3 POST /material-hypotheses/{id}/select — 후보 확정
+  select: (hypothesisId: UUID) =>
+    api
+      .post<MaterialHypothesis>(`/material-hypotheses/${hypothesisId}/select`)
+      .then((r) => r.data),
+};

--- a/frontend/src/api/material.ts
+++ b/frontend/src/api/material.ts
@@ -1,0 +1,17 @@
+import { api } from './client';
+import type { UUID } from '@/types/common';
+import type { Material, MaterialRfProfile } from '@/types/material';
+
+export const materialApi = {
+  // §12.1 GET /materials  (?is_active=true)
+  list: (params?: { is_active?: boolean }) =>
+    api.get<Material[]>('/materials', { params }).then((r) => r.data),
+
+  // §12.2 GET /materials/{id}/rf-profile
+  getRfProfile: (id: UUID, freqGhz?: number) =>
+    api
+      .get<MaterialRfProfile>(`/materials/${id}/rf-profile`, {
+        params: freqGhz != null ? { freq_ghz: freqGhz } : undefined,
+      })
+      .then((r) => r.data),
+};

--- a/frontend/src/api/patch-log.ts
+++ b/frontend/src/api/patch-log.ts
@@ -1,0 +1,18 @@
+import { api } from './client';
+import type { Paginated, UUID } from '@/types/common';
+import type { PatchLog } from '@/types/patch-log';
+
+export const patchLogApi = {
+  // §9.1 GET /scene-versions/{version_id}/patch-logs
+  listByVersion: (
+    versionId: UUID,
+    params?: {
+      target_type?: 'room' | 'wall' | 'opening' | 'object';
+      page?: number;
+      page_size?: number;
+    },
+  ) =>
+    api
+      .get<Paginated<PatchLog>>(`/scene-versions/${versionId}/patch-logs`, { params })
+      .then((r) => r.data),
+};

--- a/frontend/src/api/scene-version-entities.ts
+++ b/frontend/src/api/scene-version-entities.ts
@@ -1,0 +1,44 @@
+import { api } from './client';
+import type { UUID } from '@/types/common';
+import type {
+  SceneVersionObject,
+  SceneVersionOpening,
+  SceneVersionRoom,
+  SceneVersionWall,
+} from '@/types/scene-version-entities';
+
+// 백엔드 §8 확정본 자식 리소스 CRUD.
+// SceneVersion 의 rooms/walls/openings/objects 단건/수정/삭제.
+// 변경 시 patch_log 자동 기록됨 (§9).
+
+export const sceneVersionEntitiesApi = {
+  // Walls
+  getWall: (id: UUID) =>
+    api.get<SceneVersionWall>(`/walls/${id}`).then((r) => r.data),
+  patchWall: (id: UUID, body: Partial<SceneVersionWall>) =>
+    api.patch<SceneVersionWall>(`/walls/${id}`, body).then((r) => r.data),
+  deleteWall: (id: UUID) => api.delete<void>(`/walls/${id}`).then((r) => r.data),
+
+  // Rooms
+  getRoom: (id: UUID) =>
+    api.get<SceneVersionRoom>(`/rooms/${id}`).then((r) => r.data),
+  patchRoom: (id: UUID, body: Partial<SceneVersionRoom>) =>
+    api.patch<SceneVersionRoom>(`/rooms/${id}`, body).then((r) => r.data),
+  deleteRoom: (id: UUID) => api.delete<void>(`/rooms/${id}`).then((r) => r.data),
+
+  // Openings
+  getOpening: (id: UUID) =>
+    api.get<SceneVersionOpening>(`/openings/${id}`).then((r) => r.data),
+  patchOpening: (id: UUID, body: Partial<SceneVersionOpening>) =>
+    api.patch<SceneVersionOpening>(`/openings/${id}`, body).then((r) => r.data),
+  deleteOpening: (id: UUID) =>
+    api.delete<void>(`/openings/${id}`).then((r) => r.data),
+
+  // Objects
+  getObject: (id: UUID) =>
+    api.get<SceneVersionObject>(`/objects/${id}`).then((r) => r.data),
+  patchObject: (id: UUID, body: Partial<SceneVersionObject>) =>
+    api.patch<SceneVersionObject>(`/objects/${id}`, body).then((r) => r.data),
+  deleteObject: (id: UUID) =>
+    api.delete<void>(`/objects/${id}`).then((r) => r.data),
+};

--- a/frontend/src/features/editor/PromotedCard.tsx
+++ b/frontend/src/features/editor/PromotedCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
-import { CheckCircle2 } from 'lucide-react';
+import { CheckCircle2, History } from 'lucide-react';
 import type { SceneVersion } from '@/types/scene';
+import { useVersionPatchLogs } from '@/hooks/use-patch-logs';
 
 interface PromotedCardProps {
   version: SceneVersion;
@@ -8,6 +9,10 @@ interface PromotedCardProps {
 }
 
 export function PromotedCard({ version, onReupload }: PromotedCardProps) {
+  // 확정본 변경 이력 (§9.1) — Draft 단계 변경은 안 쌓이고, 확정 후 PATCH 시 기록됨.
+  const patchLogsQuery = useVersionPatchLogs(version.id, { page: 1, page_size: 1 });
+  const totalPatchLogs = patchLogsQuery.data?.total ?? 0;
+
   return (
     <div className="rounded-xl border bg-card p-6 shadow-sm">
       <div className="flex items-start gap-3">
@@ -29,6 +34,11 @@ export function PromotedCard({ version, onReupload }: PromotedCardProps) {
         <Row label="floor_id" value={version.floor_id} mono />
         <Row label="source_draft_id" value={version.source_draft_id} mono />
       </dl>
+
+      <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+        <History className="h-3.5 w-3.5" />
+        변경 이력 {totalPatchLogs} 건 (확정 후 수정 시 기록됩니다)
+      </div>
 
       <div className="mt-5 flex justify-end gap-2">
         <button

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, RotateCcw, ScanLine, Trash2 } from 'lucide-react';
+import { Check, ChevronDown, RotateCcw, ScanLine, Sparkles, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type {
   DraftObject,
@@ -7,6 +7,13 @@ import type {
   DraftWall,
   SelectedEntityResolved,
 } from '@/types/scene';
+import type { Material } from '@/types/material';
+import type { MaterialHypothesis } from '@/types/material-hypothesis';
+import { useMaterials } from '@/hooks/use-materials';
+import {
+  useSelectMaterialHypothesis,
+  useWallMaterialHypotheses,
+} from '@/hooks/use-material-hypotheses';
 
 interface PropertiesPanelProps {
   selected: SelectedEntityResolved | null;
@@ -28,12 +35,13 @@ const KIND_LABELS: Record<SelectedEntityResolved['kind'], string> = {
   object: '객체',
 };
 
-const MATERIAL_OPTIONS = [
-  '목재 테이블 (신호 감쇠 보통)',
-  '금속 캐비닛 (신호 감쇠 높음)',
-  '유리 (신호 감쇠 낮음)',
-  '플라스틱 (신호 감쇠 매우 낮음)',
-  '콘크리트 벽 (신호 감쇠 매우 높음)',
+/** 백엔드 Materials API 가 비어있을 때 fallback 으로 쓸 mock 목록. */
+const FALLBACK_MATERIAL_NAMES = [
+  '목재',
+  '금속',
+  '유리',
+  '플라스틱',
+  '콘크리트',
 ];
 
 export function PropertiesPanel({
@@ -98,7 +106,7 @@ function SelectedBody({
 
       {selected.kind === 'wall' && (
         <Section label="장애물 재질 설정">
-          <MaterialSelect
+          <MaterialSelectWired
             value={getMaterial(selected)}
             onChange={onUpdateMaterial}
             disabled={isSaving}
@@ -108,6 +116,10 @@ function SelectedBody({
             {isSaving && ' 저장 중…'}
           </p>
         </Section>
+      )}
+
+      {selected.kind === 'wall' && (
+        <WallHypothesesSection wallId={selected.data.id} />
       )}
 
       <div className="flex gap-2">
@@ -211,7 +223,11 @@ function ObjectFields({ object }: { object: DraftObject }) {
   );
 }
 
-function MaterialSelect({
+/**
+ * 백엔드 §12.1 GET /materials 결과를 옵션으로 사용.
+ * 로딩 중이거나 비어있으면 fallback 옵션으로 동작.
+ */
+function MaterialSelectWired({
   value,
   onChange,
   disabled,
@@ -219,6 +235,43 @@ function MaterialSelect({
   value: string;
   onChange?: (next: string) => void;
   disabled?: boolean;
+}) {
+  const { data: materials, isLoading } = useMaterials();
+  const options = materialNamesFrom(materials);
+  return (
+    <MaterialSelect
+      value={value}
+      onChange={onChange}
+      disabled={disabled || isLoading || !onChange}
+      options={options}
+      sourceLabel={
+        materials && materials.length > 0
+          ? '백엔드 재질 DB'
+          : isLoading
+          ? '재질 목록 불러오는 중...'
+          : '기본 재질 목록 사용 (백엔드 비어있음)'
+      }
+    />
+  );
+}
+
+function materialNamesFrom(materials: Material[] | undefined): string[] {
+  if (!materials || materials.length === 0) return FALLBACK_MATERIAL_NAMES;
+  return materials.map((m) => m.material_name);
+}
+
+function MaterialSelect({
+  value,
+  onChange,
+  disabled,
+  options,
+  sourceLabel,
+}: {
+  value: string;
+  onChange?: (next: string) => void;
+  disabled?: boolean;
+  options: string[];
+  sourceLabel?: string;
 }) {
   return (
     <div className="relative">
@@ -228,10 +281,10 @@ function MaterialSelect({
         disabled={disabled || !onChange}
         className="w-full appearance-none rounded-md border bg-background px-3 py-2.5 pr-9 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-70"
       >
-        {!MATERIAL_OPTIONS.includes(value) && value && (
+        {!options.includes(value) && value && (
           <option value={value}>{value}</option>
         )}
-        {MATERIAL_OPTIONS.map((m) => (
+        {options.map((m) => (
           <option key={m} value={m}>
             {m}
           </option>
@@ -239,8 +292,88 @@ function MaterialSelect({
         {!value && <option value="">재질 미지정</option>}
       </select>
       <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      {sourceLabel && (
+        <p className="mt-1 text-[10px] text-muted-foreground/80">{sourceLabel}</p>
+      )}
     </div>
   );
+}
+
+/**
+ * §12.3 — 벽의 자동 추출된 재질 후보 목록.
+ * 백엔드는 *확정본 Wall* 기준이라 Draft 단계에선 빈 응답 가능.
+ * 비어있거나 에러면 섹션 자체를 안 보임 (조용히 graceful 처리).
+ */
+function WallHypothesesSection({ wallId }: { wallId: string }) {
+  const { data, isError } = useWallMaterialHypotheses(wallId);
+  const select = useSelectMaterialHypothesis();
+
+  if (isError || !data || data.length === 0) return null;
+
+  return (
+    <Section label="추출된 재질 후보">
+      <ul className="space-y-1.5">
+        {data.map((h) => (
+          <HypothesisRow
+            key={h.id}
+            hypothesis={h}
+            onSelect={() => select.mutate(h.id)}
+            disabled={select.isPending}
+          />
+        ))}
+      </ul>
+      <p className="mt-2 text-[10px] text-muted-foreground/80">
+        AI 가 추출한 후보. 클릭하면 해당 후보로 확정됩니다.
+      </p>
+    </Section>
+  );
+}
+
+function HypothesisRow({
+  hypothesis,
+  onSelect,
+  disabled,
+}: {
+  hypothesis: MaterialHypothesis;
+  onSelect: () => void;
+  disabled: boolean;
+}) {
+  const confidence = parseConfidencePercent(hypothesis.confidence);
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        disabled={disabled || hypothesis.is_selected}
+        className={cn(
+          'flex w-full items-center justify-between gap-2 rounded-md border bg-background px-3 py-2 text-left text-sm shadow-sm transition-colors hover:bg-accent disabled:cursor-not-allowed',
+          hypothesis.is_selected && 'border-primary/40 bg-primary/5 disabled:opacity-100',
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{hypothesis.material_name}</p>
+          {confidence != null && (
+            <p className="text-[11px] text-muted-foreground">신뢰도 {confidence}%</p>
+          )}
+        </div>
+        {hypothesis.is_selected ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+            <Check className="h-3 w-3" />
+            적용됨
+          </span>
+        ) : (
+          <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+    </li>
+  );
+}
+
+function parseConfidencePercent(value: string | null): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Math.round(n * 100);
 }
 
 function EmptyBody() {

--- a/frontend/src/hooks/use-jobs.ts
+++ b/frontend/src/hooks/use-jobs.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { jobApi } from '@/api/job';
+import type { UUID } from '@/types/common';
+import type { JobStatus } from '@/types/job';
+
+/** §15.2 — Job 목록 (job_type/status 필터, 페이지네이션). */
+export function useJobs(params?: {
+  job_type?: string;
+  status?: JobStatus;
+  page?: number;
+  page_size?: number;
+}) {
+  return useQuery({
+    queryKey: ['jobs', params ?? {}] as const,
+    queryFn: () => jobApi.list(params),
+    staleTime: 10_000,
+  });
+}
+
+/** §15.1 — Job 단건. (분석 Job 폴링은 useFloorplanJob 사용) */
+export function useJob(jobId: UUID | null) {
+  return useQuery({
+    queryKey: ['job', jobId] as const,
+    queryFn: () => jobApi.get(jobId as UUID),
+    enabled: !!jobId,
+  });
+}

--- a/frontend/src/hooks/use-material-hypotheses.ts
+++ b/frontend/src/hooks/use-material-hypotheses.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { materialHypothesisApi } from '@/api/material-hypothesis';
+import type { HttpError } from '@/api/client';
+import type { UUID } from '@/types/common';
+import { toast } from '@/stores/toast-store';
+
+/**
+ * §12.3 — 벽의 재질 후보 목록.
+ *
+ * 백엔드 라우터가 /walls/{wall_id} 기준이라 *확정본 Wall* (§8) 의 id 가 필요할 수 있음.
+ * Draft 단계에서 호출하면 빈 배열 또는 404 일 가능성 — 컴포넌트에서 graceful 처리.
+ */
+export function useWallMaterialHypotheses(wallId: UUID | null) {
+  return useQuery({
+    queryKey: ['material-hypotheses', 'wall', wallId] as const,
+    queryFn: () => materialHypothesisApi.listForWall(wallId as UUID),
+    enabled: !!wallId,
+    // 404 / 빈 응답은 정상으로 취급
+    retry: false,
+    staleTime: 30_000,
+  });
+}
+
+/** §12.3 — 재질 후보 확정. */
+export function useSelectMaterialHypothesis() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (hypothesisId: UUID) => materialHypothesisApi.select(hypothesisId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['material-hypotheses'] });
+      qc.invalidateQueries({ queryKey: ['scene-draft'] });
+      qc.invalidateQueries({ queryKey: ['scene-version'] });
+      toast.success('재질 후보가 적용되었습니다');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('재질 후보 적용 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
+    },
+  });
+}

--- a/frontend/src/hooks/use-materials.ts
+++ b/frontend/src/hooks/use-materials.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { materialApi } from '@/api/material';
+import type { UUID } from '@/types/common';
+
+/** §12.1 — 활성 재질 목록. 백엔드 Materials DB 와 연동. */
+export function useMaterials() {
+  return useQuery({
+    queryKey: ['materials', { is_active: true }] as const,
+    queryFn: () => materialApi.list({ is_active: true }),
+    staleTime: 10 * 60 * 1000, // 10분
+  });
+}
+
+/** §12.2 — 특정 재질의 RF 프로파일 (Sionna 입력용 메타). */
+export function useMaterialRfProfile(materialId: UUID | null) {
+  return useQuery({
+    queryKey: ['material-rf-profile', materialId] as const,
+    queryFn: () => materialApi.getRfProfile(materialId as UUID),
+    enabled: !!materialId,
+    staleTime: 10 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/use-patch-logs.ts
+++ b/frontend/src/hooks/use-patch-logs.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { patchLogApi } from '@/api/patch-log';
+import type { UUID } from '@/types/common';
+
+/**
+ * §9.1 — Scene Version 의 수정 이력.
+ * Draft 단계 변경은 안 쌓이고, 확정본 Room/Wall/Opening/Object PATCH 시 자동 기록됨.
+ */
+export function useVersionPatchLogs(
+  versionId: UUID | null,
+  params?: {
+    target_type?: 'room' | 'wall' | 'opening' | 'object';
+    page?: number;
+    page_size?: number;
+  },
+) {
+  return useQuery({
+    queryKey: ['patch-logs', versionId, params ?? {}] as const,
+    queryFn: () => patchLogApi.listByVersion(versionId as UUID, params),
+    enabled: !!versionId,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/hooks/use-scene-version-entities.ts
+++ b/frontend/src/hooks/use-scene-version-entities.ts
@@ -1,0 +1,167 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { sceneVersionEntitiesApi } from '@/api/scene-version-entities';
+import type { HttpError } from '@/api/client';
+import { toast } from '@/stores/toast-store';
+import type { UUID } from '@/types/common';
+import type {
+  SceneVersionObject,
+  SceneVersionOpening,
+  SceneVersionRoom,
+  SceneVersionWall,
+} from '@/types/scene-version-entities';
+
+// §8 확정본 자식 CRUD 훅 모음.
+// 현재 시연 시나리오에선 promote 후 편집을 안 하므로 미사용 — 후속 화면 구현 시 사용.
+
+const ENTITY_LABEL = { wall: '벽', room: '방', opening: '개구부', object: '객체' } as const;
+
+function invalidateVersion(qc: ReturnType<typeof useQueryClient>) {
+  qc.invalidateQueries({ queryKey: ['scene-version'] });
+  qc.invalidateQueries({ queryKey: ['patch-logs'] });
+}
+
+// ── GET 단건 ────────────────────────────────────────────
+
+export function useSceneVersionWall(id: UUID | null) {
+  return useQuery({
+    queryKey: ['scene-version-wall', id] as const,
+    queryFn: () => sceneVersionEntitiesApi.getWall(id as UUID),
+    enabled: !!id,
+  });
+}
+
+export function useSceneVersionRoom(id: UUID | null) {
+  return useQuery({
+    queryKey: ['scene-version-room', id] as const,
+    queryFn: () => sceneVersionEntitiesApi.getRoom(id as UUID),
+    enabled: !!id,
+  });
+}
+
+export function useSceneVersionOpening(id: UUID | null) {
+  return useQuery({
+    queryKey: ['scene-version-opening', id] as const,
+    queryFn: () => sceneVersionEntitiesApi.getOpening(id as UUID),
+    enabled: !!id,
+  });
+}
+
+export function useSceneVersionObject(id: UUID | null) {
+  return useQuery({
+    queryKey: ['scene-version-object', id] as const,
+    queryFn: () => sceneVersionEntitiesApi.getObject(id as UUID),
+    enabled: !!id,
+  });
+}
+
+// ── PATCH ──────────────────────────────────────────────
+
+export function usePatchSceneVersionWall() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: UUID; body: Partial<SceneVersionWall> }) =>
+      sceneVersionEntitiesApi.patchWall(id, body),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.success(`${ENTITY_LABEL.wall} 수정 완료`);
+    },
+    onError: (err) => emitErrorToast('wall', err),
+  });
+}
+
+export function usePatchSceneVersionRoom() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: UUID; body: Partial<SceneVersionRoom> }) =>
+      sceneVersionEntitiesApi.patchRoom(id, body),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.success(`${ENTITY_LABEL.room} 수정 완료`);
+    },
+    onError: (err) => emitErrorToast('room', err),
+  });
+}
+
+export function usePatchSceneVersionOpening() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: UUID; body: Partial<SceneVersionOpening> }) =>
+      sceneVersionEntitiesApi.patchOpening(id, body),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.success(`${ENTITY_LABEL.opening} 수정 완료`);
+    },
+    onError: (err) => emitErrorToast('opening', err),
+  });
+}
+
+export function usePatchSceneVersionObject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: UUID; body: Partial<SceneVersionObject> }) =>
+      sceneVersionEntitiesApi.patchObject(id, body),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.success(`${ENTITY_LABEL.object} 수정 완료`);
+    },
+    onError: (err) => emitErrorToast('object', err),
+  });
+}
+
+// ── DELETE ─────────────────────────────────────────────
+
+export function useDeleteSceneVersionWall() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: UUID) => sceneVersionEntitiesApi.deleteWall(id),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.info(`${ENTITY_LABEL.wall} 삭제됨`);
+    },
+    onError: (err) => emitErrorToast('wall', err),
+  });
+}
+
+export function useDeleteSceneVersionRoom() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: UUID) => sceneVersionEntitiesApi.deleteRoom(id),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.info(`${ENTITY_LABEL.room} 삭제됨`);
+    },
+    onError: (err) => emitErrorToast('room', err),
+  });
+}
+
+export function useDeleteSceneVersionOpening() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: UUID) => sceneVersionEntitiesApi.deleteOpening(id),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.info(`${ENTITY_LABEL.opening} 삭제됨`);
+    },
+    onError: (err) => emitErrorToast('opening', err),
+  });
+}
+
+export function useDeleteSceneVersionObject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: UUID) => sceneVersionEntitiesApi.deleteObject(id),
+    onSuccess: () => {
+      invalidateVersion(qc);
+      toast.info(`${ENTITY_LABEL.object} 삭제됨`);
+    },
+    onError: (err) => emitErrorToast('object', err),
+  });
+}
+
+function emitErrorToast(kind: keyof typeof ENTITY_LABEL, err: unknown) {
+  const e = err as HttpError | null;
+  toast.error(
+    `${ENTITY_LABEL[kind]} 변경 실패`,
+    e?.message ?? '잠시 후 다시 시도해주세요.',
+  );
+}

--- a/frontend/src/types/material-hypothesis.ts
+++ b/frontend/src/types/material-hypothesis.ts
@@ -1,0 +1,17 @@
+import type { ISODateString, UUID } from './common';
+
+// 백엔드 §12.3 Material Hypothesis — 자동 추출된 재질 후보.
+// scene_version_id 기반이므로 Draft 단계에선 비어있을 수 있음.
+
+export interface MaterialHypothesis {
+  id: UUID;
+  scene_version_id: UUID;
+  target_type: 'wall' | 'room' | 'opening' | 'object' | string;
+  target_id: UUID;
+  material_name: string;
+  confidence: string | null;
+  source_method: string | null;
+  is_selected: boolean;
+  evidence_json: Record<string, unknown>;
+  created_at: ISODateString;
+}

--- a/frontend/src/types/material.ts
+++ b/frontend/src/types/material.ts
@@ -1,0 +1,24 @@
+import type { ISODateString, UUID } from './common';
+
+// 백엔드 §12 Material DTO 매핑 (app/schemas/material.py)
+
+export interface Material {
+  id: UUID;
+  material_code: string;
+  material_name: string;
+  category: string | null;
+  is_active: boolean;
+  created_at: ISODateString;
+}
+
+export interface MaterialRfProfile {
+  id: UUID;
+  material_id: UUID;
+  freq_ghz: string;
+  permittivity: string;
+  conductivity: string;
+  penetration_loss_db: string;
+  reference_thickness_m: string;
+  profile_version: number;
+  is_default: boolean;
+}

--- a/frontend/src/types/patch-log.ts
+++ b/frontend/src/types/patch-log.ts
@@ -1,0 +1,12 @@
+import type { ISODateString, UUID } from './common';
+
+export interface PatchLog {
+  id: UUID;
+  scene_version_id: UUID;
+  created_by: UUID | null;
+  patch_type: string;
+  target_type: 'room' | 'wall' | 'opening' | 'object' | string;
+  target_id: UUID;
+  patch_json: Record<string, unknown>;
+  created_at: ISODateString;
+}

--- a/frontend/src/types/scene-version-entities.ts
+++ b/frontend/src/types/scene-version-entities.ts
@@ -1,0 +1,61 @@
+import type { ISODateString, UUID } from './common';
+
+// 백엔드 §8 확정본 (rooms/walls/openings/objects) 도메인.
+// Draft 구조와 거의 동일하지만 scene_draft_id 대신 scene_version_id 를 가진다.
+// 변경 시 자동으로 patch_log 기록됨 (§9).
+
+export interface SceneVersionWall {
+  id: UUID;
+  scene_version_id: UUID;
+  wall_role: string;
+  thickness_m: string;
+  height_m: string | null;
+  material_label: string | null;
+  confidence: string | null;
+  source_method: string | null;
+  centerline_geom?: Record<string, unknown> | null;
+  polygon_geom?: Record<string, unknown> | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
+}
+
+export interface SceneVersionRoom {
+  id: UUID;
+  scene_version_id: UUID;
+  room_name: string | null;
+  room_type: string | null;
+  confidence: string | null;
+  source_method: string | null;
+  polygon_geom?: Record<string, unknown> | null;
+  centroid_geom?: Record<string, unknown> | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
+}
+
+export interface SceneVersionOpening {
+  id: UUID;
+  scene_version_id: UUID;
+  wall_id: UUID | null;
+  opening_type: string;
+  width_m: string;
+  height_m: string;
+  sill_height_m: string | null;
+  confidence: string | null;
+  source_method: string | null;
+  line_geom?: Record<string, unknown> | null;
+  polygon_geom?: Record<string, unknown> | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
+}
+
+export interface SceneVersionObject {
+  id: UUID;
+  scene_version_id: UUID;
+  object_type: string;
+  confidence: string | null;
+  source_method: string | null;
+  point_geom?: Record<string, unknown> | null;
+  z_m: string | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
+}


### PR DESCRIPTION
- §12 Materials: PropertiesPanel 재질 select 가 GET /materials 결과 사용
  (비어있으면 fallback, 출처 라벨 표시)
- §12.3 Material Hypotheses: 벽 선택 시 자동 추출 재질 후보 섹션 + 클릭으로 확정
- §9 Patch Logs: PromotedCard 에 변경 이력 카운트 표시
- §8 확정본 자식 CRUD (rooms/walls/openings/objects) — scaffolding 만, 후속 화면 대비
- §15 Jobs 목록 — scaffolding 만, 추후 알림/내 작업 화면 대비