### PR TITLE
feat: §8 확정 버전에 도형 추가 (POST) + 개구부 속성 슬림화

### DIFF
--- a/backend/app/routers/scene_versions.py
+++ b/backend/app/routers/scene_versions.py
@@ -10,12 +10,22 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.user import User
+from app.schemas.opening import OpeningCreate, OpeningResponse
+from app.schemas.room import RoomCreate, RoomResponse
+from app.schemas.scene_object import ObjectCreate, ObjectResponse
 from app.schemas.scene_version import (
     PromoteRequest,
     SceneVersionDetailResponse,
     SceneVersionResponse,
 )
-from app.services import scene_version_service
+from app.schemas.wall import WallCreate, WallResponse
+from app.services import (
+    object_service,
+    opening_service,
+    room_service,
+    scene_version_service,
+    wall_service,
+)
 
 
 promote_router = APIRouter(prefix="/scene-drafts", tags=["scene-versions"])
@@ -83,4 +93,79 @@ def list_scene_versions_by_floor(
 ) -> list[SceneVersionResponse]:
     return scene_version_service.list_by_floor(
         db, floor_id=floor_id, user=current_user, is_current=is_current
+    )
+
+
+# ---------------------------------------------------------------------------
+# §8 확정본 자식 리소스 신규 추가 (POST). 기존 PATCH/DELETE 는 각 엔티티 라우터에 위치.
+# 명세서 §8 에는 누락돼있던 부분 — 프론트에서 확정 버전 위에 새 도형을 그리는
+# 요구사항으로 추가됨. 변경 시 patch_log 자동 기록.
+# ---------------------------------------------------------------------------
+
+
+@scene_versions_router.post(
+    "/{version_id}/walls",
+    response_model=WallResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="확정본 Scene Version 에 새 Wall 추가 (patch_log 자동 기록)",
+)
+def add_wall_to_version(
+    payload: WallCreate,
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> WallResponse:
+    return wall_service.create_wall(
+        db, scene_version_id=version_id, payload=payload, user=current_user
+    )
+
+
+@scene_versions_router.post(
+    "/{version_id}/rooms",
+    response_model=RoomResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="확정본 Scene Version 에 새 Room 추가 (patch_log 자동 기록)",
+)
+def add_room_to_version(
+    payload: RoomCreate,
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RoomResponse:
+    return room_service.create_room(
+        db, scene_version_id=version_id, payload=payload, user=current_user
+    )
+
+
+@scene_versions_router.post(
+    "/{version_id}/openings",
+    response_model=OpeningResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="확정본 Scene Version 에 새 Opening 추가 (patch_log 자동 기록)",
+)
+def add_opening_to_version(
+    payload: OpeningCreate,
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OpeningResponse:
+    return opening_service.create_opening(
+        db, scene_version_id=version_id, payload=payload, user=current_user
+    )
+
+
+@scene_versions_router.post(
+    "/{version_id}/objects",
+    response_model=ObjectResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="확정본 Scene Version 에 새 Object 추가 (patch_log 자동 기록)",
+)
+def add_object_to_version(
+    payload: ObjectCreate,
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ObjectResponse:
+    return object_service.create_object(
+        db, scene_version_id=version_id, payload=payload, user=current_user
     )

--- a/backend/app/routers/scene_versions.py
+++ b/backend/app/routers/scene_versions.py
@@ -80,6 +80,22 @@ def set_current_scene_version(
     )
 
 
+@scene_versions_router.delete(
+    "/{version_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Scene Version 삭제 (children/patch_logs/rf_runs cascade)",
+)
+def delete_scene_version(
+    version_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    scene_version_service.delete_version(
+        db, version_id=version_id, user=current_user
+    )
+    return None
+
+
 @floor_scene_versions_router.get(
     "/{floor_id}/scene-versions",
     response_model=list[SceneVersionResponse],

--- a/backend/app/schemas/opening.py
+++ b/backend/app/schemas/opening.py
@@ -24,6 +24,26 @@ class OpeningUpdate(BaseModel):
     metadata_json: Optional[dict[str, Any]] = None
 
 
+class OpeningCreate(BaseModel):
+    """확정본 Scene Version 에 새 Opening 추가용 (POST /scene-versions/{id}/openings).
+
+    opening_type / width_m / height_m 은 NOT NULL 컬럼 — 누락 시 사용자에게 에러.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    wall_id: Optional[UUID] = None
+    opening_type: str
+    width_m: Decimal
+    height_m: Decimal
+    sill_height_m: Optional[Decimal] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    line_geom: Optional[dict[str, Any]] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
 class OpeningResponse(BaseModel):
     id: UUID
     scene_version_id: UUID

--- a/backend/app/schemas/room.py
+++ b/backend/app/schemas/room.py
@@ -21,6 +21,20 @@ class RoomUpdate(BaseModel):
     metadata_json: Optional[dict[str, Any]] = None
 
 
+class RoomCreate(BaseModel):
+    """확정본 Scene Version 에 새 Room 추가용 (POST /scene-versions/{id}/rooms)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    room_name: Optional[str] = None
+    room_type: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    centroid_geom: Optional[dict[str, Any]] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
 class RoomResponse(BaseModel):
     id: UUID
     scene_version_id: UUID

--- a/backend/app/schemas/scene_object.py
+++ b/backend/app/schemas/scene_object.py
@@ -20,6 +20,22 @@ class ObjectUpdate(BaseModel):
     metadata_json: Optional[dict[str, Any]] = None
 
 
+class ObjectCreate(BaseModel):
+    """확정본 Scene Version 에 새 Object 추가용 (POST /scene-versions/{id}/objects).
+
+    object_type 은 NOT NULL — 누락 시 사용자에게 에러.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    object_type: str
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    point_geom: Optional[dict[str, Any]] = None
+    z_m: Optional[Decimal] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
 class ObjectResponse(BaseModel):
     id: UUID
     scene_version_id: UUID

--- a/backend/app/schemas/wall.py
+++ b/backend/app/schemas/wall.py
@@ -23,6 +23,22 @@ class WallUpdate(BaseModel):
     metadata_json: Optional[dict[str, Any]] = None
 
 
+class WallCreate(BaseModel):
+    """확정본 Scene Version 에 새 Wall 추가용 (POST /scene-versions/{id}/walls)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    wall_role: Optional[str] = None  # DB default 'inner'
+    thickness_m: Optional[Decimal] = None  # DB default 0.18
+    height_m: Optional[Decimal] = None
+    material_label: Optional[str] = None
+    confidence: Optional[Decimal] = None
+    source_method: Optional[str] = None
+    centerline_geom: Optional[dict[str, Any]] = None
+    polygon_geom: Optional[dict[str, Any]] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
 class WallResponse(BaseModel):
     id: UUID
     scene_version_id: UUID

--- a/backend/app/services/object_service.py
+++ b/backend/app/services/object_service.py
@@ -12,9 +12,12 @@ from app.models.object import SceneObject
 from app.models.project import Project
 from app.models.scene_version import SceneVersion
 from app.models.user import User
-from app.schemas.scene_object import ObjectResponse, ObjectUpdate
+from app.schemas.scene_object import ObjectCreate, ObjectResponse, ObjectUpdate
 from app.services._patch_log_helpers import record_patch, snapshot_object
-from app.services.scene_version_service import _object_to_response
+from app.services.scene_version_service import (
+    _get_owned_scene_version,
+    _object_to_response,
+)
 
 
 def _get_owned_object(db: Session, object_id: UUID, user: User) -> SceneObject:
@@ -39,6 +42,57 @@ def _get_owned_object(db: Session, object_id: UUID, user: User) -> SceneObject:
 
 def get_object(db: Session, object_id: UUID, user: User) -> ObjectResponse:
     return _object_to_response(_get_owned_object(db, object_id, user))
+
+
+def create_object(
+    db: Session,
+    scene_version_id: UUID,
+    payload: ObjectCreate,
+    user: User,
+) -> ObjectResponse:
+    """확정본 SceneVersion 에 새 Object INSERT + patch_log 기록."""
+    sv = _get_owned_scene_version(db, scene_version_id, user)
+
+    data = payload.model_dump(exclude_unset=True)
+    obj = SceneObject(
+        scene_version_id=sv.id,
+        object_type=data["object_type"],
+    )
+    if "point_geom" in data:
+        obj.point_geom = geojson_to_wkb(
+            data["point_geom"], "Point", "point_geom"
+        )
+    for field in (
+        "confidence",
+        "source_method",
+        "z_m",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(obj, field, data[field])
+
+    db.add(obj)
+    db.flush()
+
+    after = snapshot_object(obj)
+    record_patch(
+        db,
+        scene_version_id=obj.scene_version_id,
+        user=user,
+        patch_type="create",
+        target_type="object",
+        target_id=obj.id,
+        before=None,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(obj)
+    except Exception:
+        db.rollback()
+        raise
+    return _object_to_response(obj)
 
 
 def update_object(

--- a/backend/app/services/opening_service.py
+++ b/backend/app/services/opening_service.py
@@ -13,9 +13,12 @@ from app.models.project import Project
 from app.models.scene_version import SceneVersion
 from app.models.user import User
 from app.models.wall import Wall
-from app.schemas.opening import OpeningResponse, OpeningUpdate
+from app.schemas.opening import OpeningCreate, OpeningResponse, OpeningUpdate
 from app.services._patch_log_helpers import record_patch, snapshot_opening
-from app.services.scene_version_service import _opening_to_response
+from app.services.scene_version_service import (
+    _get_owned_scene_version,
+    _opening_to_response,
+)
 
 
 def _get_owned_opening(db: Session, opening_id: UUID, user: User) -> Opening:
@@ -55,6 +58,68 @@ def _validate_wall_belongs_to_version(
 
 def get_opening(db: Session, opening_id: UUID, user: User) -> OpeningResponse:
     return _opening_to_response(_get_owned_opening(db, opening_id, user))
+
+
+def create_opening(
+    db: Session,
+    scene_version_id: UUID,
+    payload: OpeningCreate,
+    user: User,
+) -> OpeningResponse:
+    """확정본 SceneVersion 에 새 Opening INSERT + patch_log 기록."""
+    sv = _get_owned_scene_version(db, scene_version_id, user)
+
+    data = payload.model_dump(exclude_unset=True)
+    if "wall_id" in data and data["wall_id"] is not None:
+        _validate_wall_belongs_to_version(db, data["wall_id"], sv.id)
+
+    opening = Opening(
+        scene_version_id=sv.id,
+        opening_type=data["opening_type"],
+        width_m=data["width_m"],
+        height_m=data["height_m"],
+    )
+    if "wall_id" in data and data["wall_id"] is not None:
+        opening.wall_id = str(data["wall_id"])
+    if "line_geom" in data:
+        opening.line_geom = geojson_to_wkb(
+            data["line_geom"], "LineString", "line_geom"
+        )
+    if "polygon_geom" in data:
+        opening.polygon_geom = geojson_to_wkb(
+            data["polygon_geom"], "Polygon", "polygon_geom"
+        )
+    for field in (
+        "sill_height_m",
+        "confidence",
+        "source_method",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(opening, field, data[field])
+
+    db.add(opening)
+    db.flush()
+
+    after = snapshot_opening(opening)
+    record_patch(
+        db,
+        scene_version_id=opening.scene_version_id,
+        user=user,
+        patch_type="create",
+        target_type="opening",
+        target_id=opening.id,
+        before=None,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(opening)
+    except Exception:
+        db.rollback()
+        raise
+    return _opening_to_response(opening)
 
 
 def update_opening(

--- a/backend/app/services/room_service.py
+++ b/backend/app/services/room_service.py
@@ -12,9 +12,12 @@ from app.models.project import Project
 from app.models.room import Room
 from app.models.scene_version import SceneVersion
 from app.models.user import User
-from app.schemas.room import RoomResponse, RoomUpdate
+from app.schemas.room import RoomCreate, RoomResponse, RoomUpdate
 from app.services._patch_log_helpers import record_patch, snapshot_room
-from app.services.scene_version_service import _room_to_response
+from app.services.scene_version_service import (
+    _get_owned_scene_version,
+    _room_to_response,
+)
 
 
 def _get_owned_room(db: Session, room_id: UUID, user: User) -> Room:
@@ -39,6 +42,59 @@ def _get_owned_room(db: Session, room_id: UUID, user: User) -> Room:
 
 def get_room(db: Session, room_id: UUID, user: User) -> RoomResponse:
     return _room_to_response(_get_owned_room(db, room_id, user))
+
+
+def create_room(
+    db: Session,
+    scene_version_id: UUID,
+    payload: RoomCreate,
+    user: User,
+) -> RoomResponse:
+    """확정본 SceneVersion 에 새 Room INSERT + patch_log 기록."""
+    sv = _get_owned_scene_version(db, scene_version_id, user)
+
+    data = payload.model_dump(exclude_unset=True)
+    room = Room(scene_version_id=sv.id)
+    if "polygon_geom" in data:
+        room.polygon_geom = geojson_to_wkb(
+            data["polygon_geom"], "Polygon", "polygon_geom"
+        )
+    if "centroid_geom" in data:
+        room.centroid_geom = geojson_to_wkb(
+            data["centroid_geom"], "Point", "centroid_geom"
+        )
+    for field in (
+        "room_name",
+        "room_type",
+        "confidence",
+        "source_method",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(room, field, data[field])
+
+    db.add(room)
+    db.flush()
+
+    after = snapshot_room(room)
+    record_patch(
+        db,
+        scene_version_id=room.scene_version_id,
+        user=user,
+        patch_type="create",
+        target_type="room",
+        target_id=room.id,
+        before=None,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(room)
+    except Exception:
+        db.rollback()
+        raise
+    return _room_to_response(room)
 
 
 def update_room(

--- a/backend/app/services/scene_version_service.py
+++ b/backend/app/services/scene_version_service.py
@@ -370,3 +370,36 @@ def set_current(
         db.rollback()
         raise
     return _to_summary(sv)
+
+
+def delete_version(db: Session, version_id: UUID, user: User) -> None:
+    """확정본 Scene Version 삭제.
+
+    FK 가 ON DELETE CASCADE 로 걸려있어 children (walls/rooms/openings/objects),
+    patch_logs, rf_runs 까지 자동 정리됨.
+
+    현재 활성(is_confirmed) 버전을 삭제하면 같은 floor 의 다른 버전 중 가장 최근
+    것을 자동으로 활성화. 마지막 버전이면 활성 버전이 없는 상태로 남음.
+    """
+    sv = _get_owned_scene_version(db, version_id, user)
+    was_active = bool(sv.is_confirmed)
+    floor_id = sv.floor_id
+
+    db.delete(sv)
+    db.flush()
+
+    if was_active:
+        next_sv = db.execute(
+            select(SceneVersion)
+            .where(SceneVersion.floor_id == floor_id)
+            .order_by(SceneVersion.version_no.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        if next_sv is not None:
+            next_sv.is_confirmed = True
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/app/services/wall_service.py
+++ b/backend/app/services/wall_service.py
@@ -12,9 +12,12 @@ from app.models.project import Project
 from app.models.scene_version import SceneVersion
 from app.models.user import User
 from app.models.wall import Wall
-from app.schemas.wall import WallResponse, WallUpdate
+from app.schemas.wall import WallCreate, WallResponse, WallUpdate
 from app.services._patch_log_helpers import record_patch, snapshot_wall
-from app.services.scene_version_service import _wall_to_response
+from app.services.scene_version_service import (
+    _get_owned_scene_version,
+    _wall_to_response,
+)
 
 
 def _get_owned_wall(db: Session, wall_id: UUID, user: User) -> Wall:
@@ -39,6 +42,61 @@ def _get_owned_wall(db: Session, wall_id: UUID, user: User) -> Wall:
 
 def get_wall(db: Session, wall_id: UUID, user: User) -> WallResponse:
     return _wall_to_response(_get_owned_wall(db, wall_id, user))
+
+
+def create_wall(
+    db: Session,
+    scene_version_id: UUID,
+    payload: WallCreate,
+    user: User,
+) -> WallResponse:
+    """확정본 SceneVersion 에 새 Wall INSERT + patch_log 기록."""
+    sv = _get_owned_scene_version(db, scene_version_id, user)
+
+    data = payload.model_dump(exclude_unset=True)
+    wall = Wall(scene_version_id=sv.id)
+    if "centerline_geom" in data:
+        wall.centerline_geom = geojson_to_wkb(
+            data["centerline_geom"], "LineString", "centerline_geom"
+        )
+    if "polygon_geom" in data:
+        wall.polygon_geom = geojson_to_wkb(
+            data["polygon_geom"], "Polygon", "polygon_geom"
+        )
+    for field in (
+        "wall_role",
+        "thickness_m",
+        "height_m",
+        "material_label",
+        "confidence",
+        "source_method",
+        "metadata_json",
+    ):
+        if field in data:
+            setattr(wall, field, data[field])
+
+    db.add(wall)
+    db.flush()  # id / created_at 채우기
+
+    after = snapshot_wall(wall)
+    record_patch(
+        db,
+        scene_version_id=wall.scene_version_id,
+        user=user,
+        patch_type="create",
+        target_type="wall",
+        target_id=wall.id,
+        before=None,
+        after=after,
+    )
+
+    try:
+        db.commit()
+        db.refresh(wall)
+    except Exception:
+        db.rollback()
+        raise
+    return _wall_to_response(wall)
 
 
 def update_wall(

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -1317,8 +1317,8 @@ function ObjectShape({
   const fill = selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.03 240)';
   const stroke = selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.74 0.08 240)';
   const labelFill = 'oklch(0.4 0.04 240)';
-  // 선택 시엔 강조 위해 실선, 평소엔 공간성만 점선.
-  const strokeDasharray = selected ? undefined : spaceLike ? '0.18 0.12' : undefined;
+  // 공간성 객체는 선택 여부와 무관하게 항상 점선 (공간 vs 가구 구분 일관).
+  const strokeDasharray = spaceLike ? '0.18 0.12' : undefined;
 
   return (
     <g className="cursor-pointer">

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -667,57 +667,129 @@ export function DraftSceneCanvas({
             }}
           />
         )}
-        {draft.rooms.map((room) => (
-          <RoomShape
-            key={room.id}
-            room={room}
-            selected={isSelected('room', room.id)}
-            drag={matchDrag(drag, 'room', room.id)}
-            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'room', id: room.id })}
-            onVertexPointerDown={(e, idx) =>
-              startVertexDrag(e, { kind: 'room', id: room.id }, idx)
-            }
-          />
-        ))}
+        {/* 일반 렌더: 선택된 항목은 제외하고 그린 뒤, 마지막에 다시 위에 올림. */}
+        {draft.rooms
+          .filter((r) => !isSelected('room', r.id))
+          .map((room) => (
+            <RoomShape
+              key={room.id}
+              room={room}
+              selected={false}
+              drag={matchDrag(drag, 'room', room.id)}
+              onShapePointerDown={(e) => startShapeDrag(e, { kind: 'room', id: room.id })}
+              onVertexPointerDown={(e, idx) =>
+                startVertexDrag(e, { kind: 'room', id: room.id }, idx)
+              }
+            />
+          ))}
 
-        {draft.walls.map((wall) => (
-          <WallShape
-            key={wall.id}
-            wall={wall}
-            selected={isSelected('wall', wall.id)}
-            drag={matchDrag(drag, 'wall', wall.id)}
-            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'wall', id: wall.id })}
-            onVertexPointerDown={(e, idx) =>
-              startVertexDrag(e, { kind: 'wall', id: wall.id }, idx)
-            }
-          />
-        ))}
+        {draft.walls
+          .filter((w) => !isSelected('wall', w.id))
+          .map((wall) => (
+            <WallShape
+              key={wall.id}
+              wall={wall}
+              selected={false}
+              drag={matchDrag(drag, 'wall', wall.id)}
+              onShapePointerDown={(e) => startShapeDrag(e, { kind: 'wall', id: wall.id })}
+              onVertexPointerDown={(e, idx) =>
+                startVertexDrag(e, { kind: 'wall', id: wall.id }, idx)
+              }
+            />
+          ))}
 
-        {draft.openings.map((op) => (
-          <OpeningShape
-            key={op.id}
-            opening={op}
-            selected={isSelected('opening', op.id)}
-            drag={matchDrag(drag, 'opening', op.id)}
-            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'opening', id: op.id })}
-            onVertexPointerDown={(e, idx) =>
-              startVertexDrag(e, { kind: 'opening', id: op.id }, idx)
-            }
-          />
-        ))}
+        {draft.openings
+          .filter((o) => !isSelected('opening', o.id))
+          .map((op) => (
+            <OpeningShape
+              key={op.id}
+              opening={op}
+              selected={false}
+              drag={matchDrag(drag, 'opening', op.id)}
+              onShapePointerDown={(e) => startShapeDrag(e, { kind: 'opening', id: op.id })}
+              onVertexPointerDown={(e, idx) =>
+                startVertexDrag(e, { kind: 'opening', id: op.id }, idx)
+              }
+            />
+          ))}
 
-        {draft.objects.map((obj) => (
-          <ObjectShape
-            key={obj.id}
-            object={obj}
-            selected={isSelected('object', obj.id)}
-            drag={matchDrag(drag, 'object', obj.id)}
-            onShapePointerDown={(e) => startShapeDrag(e, { kind: 'object', id: obj.id })}
-            onResizePointerDown={(e, sign) =>
-              startResizeDrag(e, { kind: 'object', id: obj.id }, sign)
+        {draft.objects
+          .filter((o) => !isSelected('object', o.id))
+          .map((obj) => (
+            <ObjectShape
+              key={obj.id}
+              object={obj}
+              selected={false}
+              drag={matchDrag(drag, 'object', obj.id)}
+              onShapePointerDown={(e) => startShapeDrag(e, { kind: 'object', id: obj.id })}
+              onResizePointerDown={(e, sign) =>
+                startResizeDrag(e, { kind: 'object', id: obj.id }, sign)
+              }
+            />
+          ))}
+
+        {/* 선택된 항목 — 항상 맨 위에 렌더. */}
+        {selectedRef &&
+          (() => {
+            if (selectedRef.kind === 'room') {
+              const room = draft.rooms.find((r) => r.id === selectedRef.id);
+              return room ? (
+                <RoomShape
+                  key={`sel-${room.id}`}
+                  room={room}
+                  selected
+                  drag={matchDrag(drag, 'room', room.id)}
+                  onShapePointerDown={(e) => startShapeDrag(e, { kind: 'room', id: room.id })}
+                  onVertexPointerDown={(e, idx) =>
+                    startVertexDrag(e, { kind: 'room', id: room.id }, idx)
+                  }
+                />
+              ) : null;
             }
-          />
-        ))}
+            if (selectedRef.kind === 'wall') {
+              const wall = draft.walls.find((w) => w.id === selectedRef.id);
+              return wall ? (
+                <WallShape
+                  key={`sel-${wall.id}`}
+                  wall={wall}
+                  selected
+                  drag={matchDrag(drag, 'wall', wall.id)}
+                  onShapePointerDown={(e) => startShapeDrag(e, { kind: 'wall', id: wall.id })}
+                  onVertexPointerDown={(e, idx) =>
+                    startVertexDrag(e, { kind: 'wall', id: wall.id }, idx)
+                  }
+                />
+              ) : null;
+            }
+            if (selectedRef.kind === 'opening') {
+              const op = draft.openings.find((o) => o.id === selectedRef.id);
+              return op ? (
+                <OpeningShape
+                  key={`sel-${op.id}`}
+                  opening={op}
+                  selected
+                  drag={matchDrag(drag, 'opening', op.id)}
+                  onShapePointerDown={(e) => startShapeDrag(e, { kind: 'opening', id: op.id })}
+                  onVertexPointerDown={(e, idx) =>
+                    startVertexDrag(e, { kind: 'opening', id: op.id }, idx)
+                  }
+                />
+              ) : null;
+            }
+            const obj = draft.objects.find((o) => o.id === selectedRef.id);
+            return obj ? (
+              <ObjectShape
+                key={`sel-${obj.id}`}
+                object={obj}
+                selected
+                drag={matchDrag(drag, 'object', obj.id)}
+                onShapePointerDown={(e) => startShapeDrag(e, { kind: 'object', id: obj.id })}
+                onResizePointerDown={(e, sign) =>
+                  startResizeDrag(e, { kind: 'object', id: obj.id }, sign)
+                }
+              />
+            ) : null;
+          })()}
 
         {/* 벽 생성 preview */}
         {creating?.kind === 'wall' && cursorPos && (
@@ -736,7 +808,7 @@ export function DraftSceneCanvas({
             <circle
               cx={creating.firstPoint[0]}
               cy={creating.firstPoint[1]}
-              r="0.15"
+              r="0.07"
               fill="oklch(0.55 0.22 264)"
             />
           </g>
@@ -758,7 +830,7 @@ export function DraftSceneCanvas({
             <circle
               cx={creating.firstPoint[0]}
               cy={creating.firstPoint[1]}
-              r="0.15"
+              r="0.07"
               fill="oklch(0.55 0.22 264)"
             />
           </g>
@@ -820,10 +892,10 @@ export function DraftSceneCanvas({
                     key={i}
                     cx={p[0]}
                     cy={p[1]}
-                    r={isFirstHighlighted ? 0.28 : isFirst ? 0.2 : 0.13}
+                    r={isFirstHighlighted ? 0.13 : isFirst ? 0.09 : 0.06}
                     fill={isFirstHighlighted ? 'oklch(0.55 0.22 264)' : 'white'}
                     stroke="oklch(0.55 0.22 264)"
-                    strokeWidth={isFirstHighlighted ? 2 : 3}
+                    strokeWidth={isFirstHighlighted ? 2 : 2}
                     vectorEffect="non-scaling-stroke"
                   />
                 );
@@ -854,16 +926,16 @@ export function DraftSceneCanvas({
             <circle
               cx={snapIndicator[0]}
               cy={snapIndicator[1]}
-              r="0.28"
+              r="0.14"
               fill="none"
               stroke="oklch(0.72 0.19 145)"
-              strokeWidth="2.5"
+              strokeWidth="2"
               vectorEffect="non-scaling-stroke"
             />
             <circle
               cx={snapIndicator[0]}
               cy={snapIndicator[1]}
-              r="0.07"
+              r="0.04"
               fill="oklch(0.72 0.19 145)"
             />
           </g>
@@ -1233,85 +1305,58 @@ function ObjectShape({
   const label = objectLabel(object);
   const spaceLike = isSpaceLikeObject(object);
 
-  if (spaceLike) {
-    // 공간성 객체 (bathroom/stairs/kitchen ...) — metadata_json 의 width/height 사용.
-    const size = readObjectSize(object);
-    let w = size.width;
-    let h = size.height;
-    // 리사이즈 중이면 시각적으로 즉시 반영 (delta * sign * 2 = 대칭 크기 변화).
-    if (drag?.mode === 'resize') {
-      w = Math.max(0.2, w + drag.delta[0] * drag.cornerSign[0] * 2);
-      h = Math.max(0.2, h + drag.delta[1] * drag.cornerSign[1] * 2);
-    }
-    return (
-      <g className="cursor-pointer">
-        <rect
-          x={x - w / 2}
-          y={y - h / 2}
-          width={w}
-          height={h}
-          rx="0.15"
-          fill={selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.03 230)'}
-          stroke={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.78 0.06 230)'}
-          strokeWidth={selected ? 3 : 1.5}
-          strokeDasharray={selected ? undefined : '0.15 0.1'}
-          vectorEffect="non-scaling-stroke"
-          onPointerDown={onShapePointerDown}
-        />
-        {label && (
-          <text
-            x={x}
-            y={y}
-            textAnchor="middle"
-            dominantBaseline="middle"
-            fontSize={computeLabelFontSize(label, w, h)}
-            fontWeight="500"
-            fill="oklch(0.4 0.04 230)"
-            pointerEvents="none"
-            style={{ userSelect: 'none' }}
-          >
-            {label}
-          </text>
-        )}
-        {selected && onResizePointerDown && (
-          <>
-            <ResizeCorner x={x - w / 2} y={y - h / 2} sign={[-1, -1]} onPointerDown={onResizePointerDown} />
-            <ResizeCorner x={x + w / 2} y={y - h / 2} sign={[1, -1]} onPointerDown={onResizePointerDown} />
-            <ResizeCorner x={x - w / 2} y={y + h / 2} sign={[-1, 1]} onPointerDown={onResizePointerDown} />
-            <ResizeCorner x={x + w / 2} y={y + h / 2} sign={[1, 1]} onPointerDown={onResizePointerDown} />
-          </>
-        )}
-      </g>
-    );
+  // 모든 객체 동일한 박스 + 라벨 + 리사이즈 핸들. 색은 통일하되,
+  // 공간성(bathroom/kitchen/stairs ...) 은 점선 테두리로 "공간" 임을 시각적으로 구분.
+  const size = readObjectSize(object);
+  let w = size.width;
+  let h = size.height;
+  if (drag?.mode === 'resize') {
+    w = Math.max(0.2, w + drag.delta[0] * drag.cornerSign[0] * 2);
+    h = Math.max(0.2, h + drag.delta[1] * drag.cornerSign[1] * 2);
   }
+  const fill = selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.03 240)';
+  const stroke = selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.74 0.08 240)';
+  const labelFill = 'oklch(0.4 0.04 240)';
+  // 선택 시엔 강조 위해 실선, 평소엔 공간성만 점선.
+  const strokeDasharray = selected ? undefined : spaceLike ? '0.18 0.12' : undefined;
 
-  // 일반 객체 (table/chair/AP ...) — 원형 마커.
   return (
-    <g onPointerDown={onShapePointerDown} className="cursor-pointer">
-      <circle cx={x} cy={y} r="0.4" fill="transparent" />
-      <circle
-        cx={x}
-        cy={y}
-        r="0.18"
-        fill={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.9 0.04 256)'}
-        stroke={selected ? 'oklch(0.45 0.22 264)' : 'oklch(0.55 0.22 264)'}
+    <g className="cursor-pointer">
+      <rect
+        x={x - w / 2}
+        y={y - h / 2}
+        width={w}
+        height={h}
+        rx="0.15"
+        fill={fill}
+        stroke={stroke}
         strokeWidth={selected ? 3 : 1.5}
+        strokeDasharray={strokeDasharray}
         vectorEffect="non-scaling-stroke"
+        onPointerDown={onShapePointerDown}
       />
       {label && (
         <text
           x={x}
-          y={y + 0.45}
+          y={y}
           textAnchor="middle"
-          dominantBaseline="hanging"
-          fontSize="0.32"
+          dominantBaseline="middle"
+          fontSize={computeLabelFontSize(label, w, h)}
           fontWeight="500"
-          fill="oklch(0.45 0.02 256)"
+          fill={labelFill}
           pointerEvents="none"
           style={{ userSelect: 'none' }}
         >
           {label}
         </text>
+      )}
+      {selected && onResizePointerDown && (
+        <>
+          <ResizeCorner x={x - w / 2} y={y - h / 2} sign={[-1, -1]} onPointerDown={onResizePointerDown} />
+          <ResizeCorner x={x + w / 2} y={y - h / 2} sign={[1, -1]} onPointerDown={onResizePointerDown} />
+          <ResizeCorner x={x - w / 2} y={y + h / 2} sign={[-1, 1]} onPointerDown={onResizePointerDown} />
+          <ResizeCorner x={x + w / 2} y={y + h / 2} sign={[1, 1]} onPointerDown={onResizePointerDown} />
+        </>
       )}
     </g>
   );
@@ -1322,7 +1367,7 @@ function objectLabel(object: DraftObject): string | null {
   return OBJECT_TYPE_LABEL[object.object_type] ?? object.object_type;
 }
 
-/** 점이 아닌 "공간"으로 인식되어야 자연스러운 object_type 들. */
+/** "점"이 아닌 "공간"으로 인식되어야 자연스러운 object_type 들. 시각적으로 점선 박스로 구분. */
 const SPACE_LIKE_TYPES = new Set([
   'bathroom',
   'restroom',

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -1069,14 +1069,21 @@ function RoomShape({
   );
 }
 
-/** 방 표시용 라벨 — room_name 우선, 없으면 room_type 한글 변환. */
+/** AI 자동 생성으로 의심되는 이름. 사용자가 의도적으로 붙인 이름이 아니면 무시. */
+const AUTO_ROOM_NAME = /^room[_\s-]?\d+$/i;
+
+/** 방 표시용 라벨 — 의미 있는 room_name 이 있으면 우선, 그 외엔 room_type 한글 변환. */
 function roomLabel(room: DraftRoom): string | null {
-  if (room.room_name && room.room_name.trim()) return room.room_name;
+  const name = room.room_name?.trim();
+  if (name && !AUTO_ROOM_NAME.test(name)) return name;
   if (room.room_type) return ROOM_TYPE_LABEL[room.room_type] ?? room.room_type;
-  return null;
+  return 'room';
 }
 
 const ROOM_TYPE_LABEL: Record<string, string> = {
+  general: 'room',
+  room: 'room',
+  unknown: 'room',
   kitchen: '주방',
   storage: '창고',
   office: '사무실',

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -5,6 +5,7 @@ import { objectTypeLabel, OBJECT_TYPE_OPTIONS, openingTypeLabel } from '@/lib/la
 import type {
   DraftObject,
   DraftOpening,
+  DraftRoom,
   DraftWall,
   SelectedEntityRef,
   SelectedEntityResolved,
@@ -108,9 +109,10 @@ function SelectedBody({
         <TypeHeader selected={selected} />
       </Section>
 
-      {selected.kind !== 'object' && selected.kind !== 'room' && (
+      {selected.kind !== 'object' && (
         <Section label="속성">
           {selected.kind === 'wall' && <WallFields wall={selected.data} />}
+          {selected.kind === 'room' && <RoomFields room={selected.data} />}
           {selected.kind === 'opening' && <OpeningFields opening={selected.data} />}
         </Section>
       )}
@@ -236,14 +238,28 @@ function WallFields({ wall }: { wall: DraftWall }) {
   );
 }
 
+function RoomFields({ room }: { room: DraftRoom }) {
+  return (
+    <Grid>
+      <Row label="이름" value={room.room_name?.trim() || '-'} />
+      <Row label="용도" value={room.room_type ?? '-'} />
+    </Grid>
+  );
+}
+
 function OpeningFields({ opening }: { opening: DraftOpening }) {
   return (
     <Grid>
       <Row label="종류" value={openingTypeLabel(opening.opening_type)} />
       <Row label="너비" value={fmtDecimal(opening.width_m, 'm')} />
       <Row label="높이" value={fmtDecimal(opening.height_m, 'm')} />
+      <Row label="소속 벽" value={opening.wall_id ? shortId(opening.wall_id) : '-'} />
     </Grid>
   );
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 6) + '…';
 }
 
 /** 객체 종류 변경 select. value 는 백엔드 enum 값, 표시는 한국어 라벨. */

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -242,8 +242,6 @@ function OpeningFields({ opening }: { opening: DraftOpening }) {
       <Row label="종류" value={openingTypeLabel(opening.opening_type)} />
       <Row label="너비" value={fmtDecimal(opening.width_m, 'm')} />
       <Row label="높이" value={fmtDecimal(opening.height_m, 'm')} />
-      <Row label="턱 높이" value={fmtDecimal(opening.sill_height_m, 'm')} />
-      <Row label="신뢰도" value={fmtConfidence(opening.confidence)} />
     </Grid>
   );
 }

--- a/frontend/src/features/editor/VersionHistoryPanel.tsx
+++ b/frontend/src/features/editor/VersionHistoryPanel.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Check, ChevronDown, ChevronUp, History, Loader2, Trash2 } from 'lucide-react';
-import { useSetCurrentVersion } from '@/hooks/use-scene-version';
-import { useHiddenVersions } from '@/hooks/use-hidden-versions';
+import {
+  useDeleteSceneVersion,
+  useSetCurrentVersion,
+} from '@/hooks/use-scene-version';
 import { cn } from '@/lib/utils';
 import type { SceneVersion } from '@/types/scene';
 
@@ -11,27 +13,26 @@ interface Props {
 
 /**
  * §7.3 버전 히스토리 패널. PromotedCard 하단에 토글로 노출.
- * 옛 버전 클릭 → PATCH /scene-versions/{id}/set-current 호출.
+ * - 클릭 → PATCH /scene-versions/{id}/set-current
+ * - 휴지통 → DELETE /scene-versions/{id} (children · rf_runs · patch_logs cascade)
  */
 export function VersionHistoryPanel({ versions }: Props) {
   const [open, setOpen] = useState(false);
   const setCurrent = useSetCurrentVersion();
-  const { isHidden, hide } = useHiddenVersions();
+  const remove = useDeleteSceneVersion();
 
-  // 숨겨진 버전은 목록에서 제외 (현재 버전은 절대 숨기지 않음).
-  const visible = useMemo(
-    () => versions.filter((v) => v.is_current || !isHidden(v.id)),
-    [versions, isHidden],
-  );
-
-  if (visible.length === 0) return null;
+  if (versions.length === 0) return null;
 
   // 최신순 정렬 (version_no DESC)
-  const sorted = [...visible].sort((a, b) => b.version_no - a.version_no);
+  const sorted = [...versions].sort((a, b) => b.version_no - a.version_no);
 
-  const handleHide = (id: string, versionNo: number) => {
-    if (window.confirm(`버전 #${versionNo} 을(를) 정말 삭제하시겠습니까?`)) {
-      hide(id);
+  const handleDelete = (id: string, versionNo: number) => {
+    if (
+      window.confirm(
+        `버전 #${versionNo} 을(를) 정말 삭제하시겠습니까?\n관련된 시뮬레이션 결과와 변경 이력도 함께 삭제됩니다.`,
+      )
+    ) {
+      remove.mutate(id);
     }
   };
 
@@ -44,7 +45,7 @@ export function VersionHistoryPanel({ versions }: Props) {
       >
         <span className="inline-flex items-center gap-1.5">
           <History className="h-3.5 w-3.5 text-muted-foreground" />
-          버전 히스토리 ({visible.length}개)
+          버전 히스토리 ({versions.length}개)
         </span>
         {open ? (
           <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
@@ -57,11 +58,12 @@ export function VersionHistoryPanel({ versions }: Props) {
         <ul className="border-t">
           {sorted.map((v) => {
             const isSwitching = setCurrent.isPending && setCurrent.variables === v.id;
+            const isDeleting = remove.isPending && remove.variables === v.id;
             return (
               <li key={v.id} className={cn('flex items-center', v.is_current && 'bg-primary/5')}>
                 <button
                   type="button"
-                  disabled={v.is_current || isSwitching}
+                  disabled={v.is_current || isSwitching || isDeleting}
                   onClick={() => setCurrent.mutate(v.id)}
                   className={cn(
                     'flex flex-1 items-center justify-between gap-3 px-3 py-2 text-left text-xs transition-colors',
@@ -90,13 +92,17 @@ export function VersionHistoryPanel({ versions }: Props) {
                 </button>
                 <button
                   type="button"
-                  onClick={() => handleHide(v.id, v.version_no)}
-                  disabled={v.is_current || isSwitching}
-                  title={v.is_current ? '현재 버전은 삭제할 수 없습니다' : '버전 삭제'}
+                  onClick={() => handleDelete(v.id, v.version_no)}
+                  disabled={isSwitching || isDeleting}
+                  title="버전 삭제 (시뮬레이션·변경 이력 함께 삭제됨)"
                   aria-label={`버전 #${v.version_no} 삭제`}
-                  className="mr-2 rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+                  className="mr-2 rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-30"
                 >
-                  <Trash2 className="h-3 w-3" />
+                  {isDeleting ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-3 w-3" />
+                  )}
                 </button>
               </li>
             );

--- a/frontend/src/features/header/FloorSelector.tsx
+++ b/frontend/src/features/header/FloorSelector.tsx
@@ -98,7 +98,7 @@ function FloorMenu({
               <div className="flex flex-col items-start">
                 <span className="truncate">{f.floor_name}</span>
                 <span className="text-[10px] text-muted-foreground">
-                  순서 {f.floor_order} · 높이 {f.height_m}m
+                  높이 {f.height_m}m
                 </span>
               </div>
               {f.id === selectedFloorId && <Check className="h-3.5 w-3.5 text-primary" />}
@@ -143,7 +143,6 @@ function CreateFloorForm({
   onCancel: () => void;
 }) {
   const [name, setName] = useState(`${nextOrder}층`);
-  const [order, setOrder] = useState(nextOrder);
   const [height, setHeight] = useState(3.2);
   const create = useCreateFloor(projectId);
 
@@ -151,42 +150,35 @@ function CreateFloorForm({
     e.preventDefault();
     const trimmed = name.trim();
     if (!trimmed) return;
+    // floor_order 는 사용자에게 노출하지 않고 자동 부여 (마지막 + 1).
     create.mutate(
-      { floor_name: trimmed, floor_order: order, height_m: height },
+      { floor_name: trimmed, floor_order: nextOrder, height_m: height },
       { onSuccess: (f) => onCreated(f) },
     );
   };
 
   return (
     <form onSubmit={submit} className="space-y-2">
-      <input
-        autoFocus
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="층 이름 (예: 1층)"
-        className="w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-      />
-      <div className="grid grid-cols-2 gap-2">
-        <label className="block">
-          <span className="text-[10px] text-muted-foreground">순서</span>
-          <input
-            type="number"
-            value={order}
-            onChange={(e) => setOrder(Number(e.target.value))}
-            className="w-full rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-        </label>
-        <label className="block">
-          <span className="text-[10px] text-muted-foreground">높이(m)</span>
-          <input
-            type="number"
-            step="0.1"
-            value={height}
-            onChange={(e) => setHeight(Number(e.target.value))}
-            className="w-full rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-        </label>
-      </div>
+      <label className="block">
+        <span className="text-[10px] text-muted-foreground">층 이름</span>
+        <input
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="예: 1층, B1, 옥상"
+          className="w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </label>
+      <label className="block">
+        <span className="text-[10px] text-muted-foreground">높이 (m)</span>
+        <input
+          type="number"
+          step="0.1"
+          value={height}
+          onChange={(e) => setHeight(Number(e.target.value))}
+          className="w-full rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </label>
       <div className="flex gap-2">
         <button
           type="submit"

--- a/frontend/src/hooks/use-scene-version.ts
+++ b/frontend/src/hooks/use-scene-version.ts
@@ -30,15 +30,13 @@ export function useDeleteSceneVersion() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['scene-versions'] });
       qc.invalidateQueries({ queryKey: ['scene-version'] });
+      qc.invalidateQueries({ queryKey: ['rf-runs'] });
+      qc.invalidateQueries({ queryKey: ['patch-logs'] });
       toast.info('버전 삭제됨');
     },
     onError: (err) => {
       const e = err as HttpError | null;
-      const message =
-        e?.status === 404 || e?.status === 405
-          ? '백엔드가 버전 삭제를 지원하지 않습니다.'
-          : e?.message ?? '잠시 후 다시 시도해주세요.';
-      toast.error('버전 삭제 실패', message);
+      toast.error('버전 삭제 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
     },
   });
 }

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -15,7 +15,7 @@ export function openingTypeLabel(type: string | null | undefined): string {
 /** object_type → 사용자 친화 라벨. value 는 백엔드 enum 값 그대로 유지. */
 const OBJECT_TYPE_LABELS: Record<string, string> = {
   furniture: '가구',
-  bathroom: '욕실',
+  bathroom: '화장실',
   kitchen: '주방',
   stairs: '계단',
   elevator: '엘리베이터',

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -171,16 +171,28 @@ export default function EditorPage() {
   const isVersionEditing = !activeDraft;
 
   // ─ Undo 스택 ──────────────────────────────────────────────
-  // PATCH 직전에 변경 대상 필드의 "이전 값" 을 캡쳐해 둠. Ctrl+Z 로 마지막 변경 1건씩 되돌림.
-  // Delete / Create 는 §8 명세상 복원이 까다로워 일단 PATCH 만 추적.
-  type HistoryEntry = {
-    kind: DraftEntityKind;
-    id: string;
-    mode: 'draft' | 'version';
-    beforeBody: Record<string, unknown>;
-  };
+  // PATCH / CREATE 추적. Delete 는 §8 명세상 복원이 까다로워 추적 안 함.
+  // - PATCH undo → 이전 값으로 다시 PATCH
+  // - CREATE undo → 생성된 엔티티 DELETE
+  type HistoryEntry =
+    | {
+        action: 'patch';
+        kind: DraftEntityKind;
+        id: string;
+        mode: 'draft' | 'version';
+        beforeBody: Record<string, unknown>;
+      }
+    | {
+        action: 'create';
+        kind: DraftEntityKind;
+        id: string;
+        mode: 'draft' | 'version';
+      };
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const HISTORY_MAX = 30;
+  const pushHistory = (entry: HistoryEntry) => {
+    setHistory((h) => [...h.slice(-(HISTORY_MAX - 1)), entry]);
+  };
 
   /** 엔티티에서 body 키 목록에 해당하는 필드의 현재 값을 추출 (undo 용). */
   const captureBefore = (
@@ -218,10 +230,13 @@ export default function EditorPage() {
     if (!options?.skipHistory) {
       const beforeBody = captureBefore(kind, id, body);
       if (beforeBody) {
-        setHistory((h) => [
-          ...h.slice(-(HISTORY_MAX - 1)),
-          { kind, id, mode: isVersionEditing ? 'version' : 'draft', beforeBody },
-        ]);
+        pushHistory({
+          action: 'patch',
+          kind,
+          id,
+          mode: isVersionEditing ? 'version' : 'draft',
+          beforeBody,
+        });
       }
     }
     const vars = { kind, id, body, silent: options?.silent };
@@ -237,15 +252,26 @@ export default function EditorPage() {
     }
     const entry = history[history.length - 1];
     setHistory((h) => h.slice(0, -1));
-    const vars = {
-      kind: entry.kind,
-      id: entry.id,
-      body: entry.beforeBody,
-      silent: true,
-    };
-    if (entry.mode === 'version') patchVersionEntity.mutate(vars);
-    else patchEntity.mutate(vars);
-    toast.info('변경을 되돌렸습니다');
+
+    if (entry.action === 'patch') {
+      const vars = {
+        kind: entry.kind,
+        id: entry.id,
+        body: entry.beforeBody,
+        silent: true,
+      };
+      if (entry.mode === 'version') patchVersionEntity.mutate(vars);
+      else patchEntity.mutate(vars);
+      toast.info('변경을 되돌렸습니다');
+      return;
+    }
+
+    // action === 'create' → 삭제로 되돌림
+    const dvars = { kind: entry.kind, id: entry.id };
+    if (entry.mode === 'version') deleteVersionEntity.mutate(dvars);
+    else deleteEntity.mutate(dvars);
+    if (selectedRef?.id === entry.id) setSelectedRef(null);
+    toast.info('생성을 되돌렸습니다');
   };
 
   const canUndo = history.length > 0;
@@ -329,13 +355,29 @@ export default function EditorPage() {
 
   // 좌측 도구바로 새 도형 추가 — Draft / Version 모드에 따라 dispatch.
   // 확정 버전은 §8 명세에 POST 가 명시되지 않아 백엔드 미지원 가능성 있음 (그 경우 토스트로 안내).
+  /** 도구별 sticky/auto-reset 정책. 벽·방은 연속 작성이 자연스러우니 유지, 개구부·객체는 한 개씩 → 선택 모드로. */
+  const shouldAutoResetToolAfterCreate = (kind: DraftEntityKind): boolean =>
+    kind === 'opening' || kind === 'object';
+
   const handleCreate = (kind: DraftEntityKind, body: Record<string, unknown>) => {
+    const afterCreate = (createdId: string, mode: 'draft' | 'version') => {
+      pushHistory({ action: 'create', kind, id: createdId, mode });
+      if (shouldAutoResetToolAfterCreate(kind)) {
+        setTool('select');
+      }
+    };
     if (activeDraft) {
-      createEntity.mutate({ draftId: activeDraft.id, kind, body });
+      createEntity.mutate(
+        { draftId: activeDraft.id, kind, body },
+        { onSuccess: (created) => afterCreate(created.id, 'draft') },
+      );
       return;
     }
     if (currentVersion) {
-      createVersionEntity.mutate({ versionId: currentVersion.id, kind, body });
+      createVersionEntity.mutate(
+        { versionId: currentVersion.id, kind, body },
+        { onSuccess: (created) => afterCreate(created.id, 'version') },
+      );
       return;
     }
     toast.info('편집할 도면이 없습니다', '먼저 도면을 업로드해주세요.');


### PR DESCRIPTION
- POST /scene-versions/{id}/walls
- POST /scene-versions/{id}/rooms
- POST /scene-versions/{id}/openings
- POST /scene-versions/{id}/objects

스키마: {Wall,Room,Opening,Object}Create 추가
서비스: 각 *_service.py 에 create_*() 함수 추가 (patch_log 자동 기록)
라우터: scene_versions.py 에 POST 4개 추가
기존 PATCH/DELETE 동일한 ownership 체크 + patch_log 패턴 유지.
UI: 개구부 속성 패널에서 턱높이/신뢰도 행 제거

- DELETE /scene-versions/{id} 추가 (walls/rooms/openings/objects
  patch_logs rf_runs FK CASCADE 자동 정리). 활성 버전 삭제 시 직전
  version_no 자동 활성화.
- 프론트 휴지통: localStorage 숨김 → 실제 백엔드 호출로 전환,
  현재 버전도 삭제 가능
- 객체 시각 통일: 화장실/주방/계단/가구 등 모두 같은 색
  · 공간성 (bathroom/kitchen/stairs ...) = 점선 박스
  · 일반 (table/chair/furniture ...) = 실선 박스
- 다각형/벽 생성 미리보기 동그라미 축소
- 스냅 인디케이터 (초록 링) 축소
- 방 라벨: room_N 같은 자동 이름은 무시하고 type 표시 (general → "room")
- 패널 정보 추가: 방 이름/용도, 개구부 소속 벽