### PR TITLE
feat: 시뮬 AP 배치 UI + 모바일 앱 연결 버튼 이동 + 잡 UX

### DIFF
--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -239,9 +239,9 @@ function getEntityRefPoints(draft: SceneDraft, ref: SelectedEntityRef): Coord[] 
     const g = parseGeometry(draft.rooms.find((r) => r.id === ref.id)?.polygon_geom);
     return g?.type === 'Polygon' ? g.coordinates[0] ?? [] : [];
   }
-  // object — Point 하나
-  const g = parseGeometry(draft.objects.find((o) => o.id === ref.id)?.point_geom);
-  return g?.type === 'Point' ? [g.coordinates] : [];
+  // object — 스냅 비활성화. 객체 중심점을 벽 끝점에 붙이면 박스가 건물 밖으로 나가는
+  // 부작용이 있어, 객체는 자유 배치가 자연스럽다.
+  return [];
 }
 
 /** 점 p 를 선분 a-b 에 수직투영한 좌표. */
@@ -1618,7 +1618,7 @@ function OpeningShape({
   // 수직 단위 벡터
   const nx = -dy / len;
   const ny = dx / len;
-  const offsetM = 0.22;
+  const offsetM = 0.17;
   const labelX = midX + nx * offsetM;
   const labelY = midY + ny * offsetM;
   return (

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -54,10 +54,16 @@ function computeViewBox(draft: SceneDraft): { x: number; y: number; w: number; h
   }
   for (const obj of draft.objects) {
     const g = parseGeometry(obj.point_geom);
-    if (g?.type === 'Point') {
-      const [x, y] = g.coordinates;
-      extendBounds(b, x, y);
-    }
+    if (g?.type !== 'Point') continue;
+    const [x, y] = g.coordinates;
+    // 객체는 박스(W×H) 로 렌더링되므로 박스 모서리까지 bounds 에 포함.
+    const meta = (obj.metadata_json ?? {}) as Record<string, unknown>;
+    const w =
+      typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+    const h =
+      typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+    extendBounds(b, x - w / 2, y - h / 2);
+    extendBounds(b, x + w / 2, y + h / 2);
   }
   if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
   const w = b.maxX - b.minX || 1;
@@ -88,6 +94,21 @@ type DragState =
       cornerSign: [-1 | 1, -1 | 1];
       startSvg: Coord;
       delta: Coord;
+    }
+  | {
+      // 빈 캔버스에서 사각형 드래그 → 영역 내부 도형 일괄 선택.
+      mode: 'marquee';
+      startSvg: Coord;
+      currentSvg: Coord;
+      additive: boolean;
+    }
+  | {
+      // 다중 선택 bbox 의 모서리 드래그 → 모든 선택 도형을 같은 비율로 스케일.
+      // fixed=고정 모서리(반대편), startCorner=드래그 시작 좌표, currentCorner=현재 커서.
+      mode: 'group-resize';
+      fixed: Coord;
+      startCorner: Coord;
+      currentCorner: Coord;
     };
 
 /** 생성 진행 중 임시 상태. */
@@ -307,6 +328,158 @@ function computeShapeSnapDelta(
   return { delta: rawDelta, snapPoint: null };
 }
 
+/** 두 코너 좌표로 (x,y,w,h) 사각형 정규화. w,h 는 항상 ≥ 0. */
+function normalizeRect(
+  a: Coord,
+  b: Coord,
+): { x: number; y: number; w: number; h: number } {
+  const x = Math.min(a[0], b[0]);
+  const y = Math.min(a[1], b[1]);
+  const w = Math.abs(a[0] - b[0]);
+  const h = Math.abs(a[1] - b[1]);
+  return { x, y, w, h };
+}
+
+/** 점이 사각형 안인지. */
+function pointInRect(
+  pt: Coord,
+  rect: { x: number; y: number; w: number; h: number },
+): boolean {
+  return (
+    pt[0] >= rect.x &&
+    pt[0] <= rect.x + rect.w &&
+    pt[1] >= rect.y &&
+    pt[1] <= rect.y + rect.h
+  );
+}
+
+/**
+ * 마퀴 영역 안에 들어간 도형 ref 들 수집.
+ * - wall/opening (LineString) → 양 끝점 모두 영역 안일 때
+ * - room (Polygon) → 외곽링 모든 점이 영역 안일 때
+ * - object (Point) → 박스 4 모서리가 영역 안일 때 (박스가 통째로 들어와야 선택됨)
+ */
+function collectEntitiesInRect(
+  draft: SceneDraft,
+  rect: { x: number; y: number; w: number; h: number },
+): SelectedEntityRef[] {
+  const hits: SelectedEntityRef[] = [];
+  for (const wall of draft.walls) {
+    const g = parseGeometry(wall.centerline_geom);
+    if (g?.type !== 'LineString') continue;
+    if (g.coordinates.every((p) => pointInRect(p, rect))) {
+      hits.push({ kind: 'wall', id: wall.id });
+    }
+  }
+  for (const op of draft.openings) {
+    const g = parseGeometry(op.line_geom);
+    if (g?.type !== 'LineString') continue;
+    if (g.coordinates.every((p) => pointInRect(p, rect))) {
+      hits.push({ kind: 'opening', id: op.id });
+    }
+  }
+  for (const room of draft.rooms) {
+    const g = parseGeometry(room.polygon_geom);
+    if (g?.type !== 'Polygon') continue;
+    const outer = g.coordinates[0] ?? [];
+    if (outer.length > 0 && outer.every((p) => pointInRect(p, rect))) {
+      hits.push({ kind: 'room', id: room.id });
+    }
+  }
+  for (const obj of draft.objects) {
+    const g = parseGeometry(obj.point_geom);
+    if (g?.type !== 'Point') continue;
+    const [cx, cy] = g.coordinates;
+    const meta = (obj.metadata_json ?? {}) as Record<string, unknown>;
+    const w =
+      typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+    const h =
+      typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+    const corners: Coord[] = [
+      [cx - w / 2, cy - h / 2],
+      [cx + w / 2, cy - h / 2],
+      [cx - w / 2, cy + h / 2],
+      [cx + w / 2, cy + h / 2],
+    ];
+    if (corners.every((p) => pointInRect(p, rect))) {
+      hits.push({ kind: 'object', id: obj.id });
+    }
+  }
+  return hits;
+}
+
+/** group-resize 드래그에서 sx, sy 추출. 0 으로 나눠지면 1 유지(축에 평행한 corner 일 때). */
+function groupResizeScale(
+  drag: Extract<DragState, { mode: 'group-resize' }>,
+): { sx: number; sy: number } {
+  const dx0 = drag.startCorner[0] - drag.fixed[0];
+  const dy0 = drag.startCorner[1] - drag.fixed[1];
+  const dx1 = drag.currentCorner[0] - drag.fixed[0];
+  const dy1 = drag.currentCorner[1] - drag.fixed[1];
+  const sx = Math.abs(dx0) > 1e-6 ? dx1 / dx0 : 1;
+  const sy = Math.abs(dy0) > 1e-6 ? dy1 / dy0 : 1;
+  // 최소 스케일 — 너무 작아지면 선택군이 점으로 수렴해버리므로 floor.
+  const MIN = 0.05;
+  return {
+    sx: Math.abs(sx) < MIN ? Math.sign(sx) * MIN || MIN : sx,
+    sy: Math.abs(sy) < MIN ? Math.sign(sy) * MIN || MIN : sy,
+  };
+}
+
+/** 고정점(fix) 기준으로 (x, y) 를 (sx, sy) 만큼 스케일. */
+function scaleAround(pt: Coord, fix: Coord, sx: number, sy: number): Coord {
+  return [fix[0] + (pt[0] - fix[0]) * sx, fix[1] + (pt[1] - fix[1]) * sy];
+}
+
+/** 선택된 도형들의 AABB(미니멈 경계상자). 없으면 null. */
+function computeSelectionBounds(
+  draft: SceneDraft,
+  refs: SelectedEntityRef[],
+): { x: number; y: number; w: number; h: number } | null {
+  const b = emptyBounds();
+  let any = false;
+  for (const ref of refs) {
+    if (ref.kind === 'wall') {
+      const g = parseGeometry(draft.walls.find((w) => w.id === ref.id)?.centerline_geom);
+      if (g?.type === 'LineString')
+        for (const [x, y] of g.coordinates) {
+          extendBounds(b, x, y);
+          any = true;
+        }
+    } else if (ref.kind === 'opening') {
+      const g = parseGeometry(draft.openings.find((o) => o.id === ref.id)?.line_geom);
+      if (g?.type === 'LineString')
+        for (const [x, y] of g.coordinates) {
+          extendBounds(b, x, y);
+          any = true;
+        }
+    } else if (ref.kind === 'room') {
+      const g = parseGeometry(draft.rooms.find((r) => r.id === ref.id)?.polygon_geom);
+      if (g?.type === 'Polygon')
+        for (const ring of g.coordinates)
+          for (const [x, y] of ring) {
+            extendBounds(b, x, y);
+            any = true;
+          }
+    } else {
+      const obj = draft.objects.find((o) => o.id === ref.id);
+      const g = parseGeometry(obj?.point_geom);
+      if (g?.type !== 'Point') continue;
+      const [cx, cy] = g.coordinates;
+      const meta = (obj?.metadata_json ?? {}) as Record<string, unknown>;
+      const w =
+        typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+      const h =
+        typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+      extendBounds(b, cx - w / 2, cy - h / 2);
+      extendBounds(b, cx + w / 2, cy + h / 2);
+      any = true;
+    }
+  }
+  if (!any || !isFinite(b.minX)) return null;
+  return { x: b.minX, y: b.minY, w: b.maxX - b.minX, h: b.maxY - b.minY };
+}
+
 function polygonCentroid(points: Coord[]): Coord {
   if (points.length === 0) return [0, 0];
   const n = points.length;
@@ -330,8 +503,27 @@ function polygonBounds(points: Coord[]): { w: number; h: number } {
 
 interface Props {
   draft: SceneDraft;
-  selectedRef?: SelectedEntityRef | null;
-  onSelect?: (ref: SelectedEntityRef | null) => void;
+  /** 선택된 도형들. 단일 선택이면 길이 1, 다중 선택이면 N. */
+  selectedRefs?: SelectedEntityRef[];
+  /**
+   * 도형 선택 콜백.
+   * - additive=true (Shift+클릭): 기존 선택에 추가/토글
+   * - additive=false (일반 클릭): 단일 선택으로 교체
+   * - ref=null: 전체 해제
+   */
+  onSelect?: (ref: SelectedEntityRef | null, options?: { additive?: boolean }) => void;
+  /** Marquee 드래그 종료 시 영역 내부 도형들을 한꺼번에 선택. additive=true 면 기존 선택에 합집합. */
+  onSelectMany?: (refs: SelectedEntityRef[], options?: { additive?: boolean }) => void;
+  /**
+   * 다중 선택 bbox 모서리 드래그 종료 시, 고정점과 스케일을 알려줌.
+   * 호출 측이 각 선택 도형 좌표/메타데이터를 변환해서 PATCH 한다.
+   */
+  onGroupResizeEnd?: (params: {
+    fixed: Coord;
+    sx: number;
+    sy: number;
+    refs: SelectedEntityRef[];
+  }) => void;
   /** 드래그 종료 시 새 geometry. 호출 측이 적절한 *_geom 필드로 PATCH 한다. */
   onDragEnd?: (ref: SelectedEntityRef, geometry: GeoJsonGeometry) => void;
   /** 공간성 객체 박스 리사이즈 종료. metadata_json 의 width_m/height_m 업데이트용. */
@@ -346,8 +538,10 @@ interface Props {
 
 export function DraftSceneCanvas({
   draft,
-  selectedRef,
+  selectedRefs,
   onSelect,
+  onSelectMany,
+  onGroupResizeEnd,
   onDragEnd,
   onResizeObject,
   tool = 'select',
@@ -361,6 +555,10 @@ export function DraftSceneCanvas({
   const [cursorPos, setCursorPos] = useState<Coord | null>(null);
   // 스냅 발생 시 표시할 위치 (초록 링). 스냅 안 되면 null.
   const [snapIndicator, setSnapIndicator] = useState<Coord | null>(null);
+
+  // 단일 선택일 때의 primary ref. vertex/resize 핸들·라벨은 단일 선택 시에만 의미.
+  const selectedRef: SelectedEntityRef | null =
+    selectedRefs && selectedRefs.length === 1 ? selectedRefs[0] : null;
 
   // 스냅 anchor = 벽 끝점만. 드래그/선택 중인 벽은 자기 자신에 안 붙도록 제외.
   const wallAnchors = useMemo(
@@ -421,7 +619,16 @@ export function DraftSceneCanvas({
     if (!pt) return;
     svgRef.current?.setPointerCapture(e.pointerId);
     setDrag({ mode: 'shape', ref, startSvg: pt, delta: [0, 0] });
-    onSelect?.(ref);
+    // Shift+클릭: 추가 선택. 그 외엔 단일 선택으로 교체.
+    // 이미 선택된 도형을 드래그 시작할 땐 선택 유지 (다중 선택 드래그 자연스럽게).
+    const alreadySelected = !!selectedRefs?.some(
+      (r) => r.kind === ref.kind && r.id === ref.id,
+    );
+    if (e.shiftKey) {
+      onSelect?.(ref, { additive: true });
+    } else if (!alreadySelected) {
+      onSelect?.(ref);
+    }
   };
 
   const startVertexDrag = (
@@ -452,6 +659,22 @@ export function DraftSceneCanvas({
     onSelect?.(ref);
   };
 
+  const startGroupResizeDrag = (
+    e: React.PointerEvent,
+    fixedCorner: Coord,
+    startCorner: Coord,
+  ) => {
+    if (tool !== 'select') return;
+    e.stopPropagation();
+    svgRef.current?.setPointerCapture(e.pointerId);
+    setDrag({
+      mode: 'group-resize',
+      fixed: fixedCorner,
+      startCorner,
+      currentCorner: startCorner,
+    });
+  };
+
   const handleSvgPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
     const raw = getSvgPoint(e);
     if (!raw) return;
@@ -470,6 +693,20 @@ export function DraftSceneCanvas({
 
     if (!drag) {
       if (!isCreationMode) setSnapIndicator(null);
+      return;
+    }
+
+    // ─ marquee 드래그: 사각형만 갱신, 실 선택은 pointerUp 에서. ─
+    if (drag.mode === 'marquee') {
+      setDrag((prev) => (prev && prev.mode === 'marquee' ? { ...prev, currentSvg: raw } : prev));
+      return;
+    }
+
+    // ─ group-resize: 현재 모서리 위치만 갱신. 미리보기는 effective* 가 처리. ─
+    if (drag.mode === 'group-resize') {
+      setDrag((prev) =>
+        prev && prev.mode === 'group-resize' ? { ...prev, currentCorner: raw } : prev,
+      );
       return;
     }
 
@@ -517,6 +754,35 @@ export function DraftSceneCanvas({
     const captured = drag;
     setDrag(null);
     setSnapIndicator(null);
+
+    // marquee: 박스 크기가 임계 이상이면 영역 안 도형 일괄 선택; 미만이면 단순 클릭으로 보고 선택 해제.
+    if (captured.mode === 'marquee') {
+      const rect = normalizeRect(captured.startSvg, captured.currentSvg);
+      const tiny =
+        rect.w < DRAG_THRESHOLD_M && rect.h < DRAG_THRESHOLD_M;
+      if (tiny) {
+        if (!captured.additive) onSelect?.(null);
+        return;
+      }
+      const hits = collectEntitiesInRect(draft, rect);
+      onSelectMany?.(hits, { additive: captured.additive });
+      return;
+    }
+
+    // group-resize: scale 이 의미 있는 경우 한해 상위로 전달.
+    if (captured.mode === 'group-resize') {
+      const { sx, sy } = groupResizeScale(captured);
+      const meaningful = Math.abs(sx - 1) > 0.01 || Math.abs(sy - 1) > 0.01;
+      if (meaningful && selectedRefs && selectedRefs.length >= 2) {
+        onGroupResizeEnd?.({
+          fixed: captured.fixed,
+          sx,
+          sy,
+          refs: selectedRefs,
+        });
+      }
+      return;
+    }
 
     const [dx, dy] = captured.delta;
     if (Math.abs(dx) < DRAG_THRESHOLD_M && Math.abs(dy) < DRAG_THRESHOLD_M) return;
@@ -626,12 +892,17 @@ export function DraftSceneCanvas({
       return;
     }
 
-    // select 모드: 빈 영역 클릭 → 선택 해제
-    if (e.target === e.currentTarget) onSelect?.(null);
+    // select 모드: 빈 영역 → marquee 드래그 시작 (작은 움직임이면 pointerUp 에서 선택 해제로 처리).
+    if (e.target === e.currentTarget) {
+      const pt = getSvgPoint(e);
+      if (!pt) return;
+      svgRef.current?.setPointerCapture(e.pointerId);
+      setDrag({ mode: 'marquee', startSvg: pt, currentSvg: pt, additive: e.shiftKey });
+    }
   };
 
   const isSelected = (kind: SelectedEntityRef['kind'], id: string) =>
-    selectedRef?.kind === kind && selectedRef.id === id;
+    !!selectedRefs?.some((r) => r.kind === kind && r.id === id);
 
   return (
     <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[#f8fafc] p-6 [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
@@ -728,67 +999,111 @@ export function DraftSceneCanvas({
             />
           ))}
 
-        {/* 선택된 항목 — 항상 맨 위에 렌더. */}
-        {selectedRef &&
-          (() => {
-            if (selectedRef.kind === 'room') {
-              const room = draft.rooms.find((r) => r.id === selectedRef.id);
-              return room ? (
-                <RoomShape
-                  key={`sel-${room.id}`}
-                  room={room}
-                  selected
-                  drag={matchDrag(drag, 'room', room.id)}
-                  onShapePointerDown={(e) => startShapeDrag(e, { kind: 'room', id: room.id })}
-                  onVertexPointerDown={(e, idx) =>
-                    startVertexDrag(e, { kind: 'room', id: room.id }, idx)
-                  }
-                />
-              ) : null;
-            }
-            if (selectedRef.kind === 'wall') {
-              const wall = draft.walls.find((w) => w.id === selectedRef.id);
-              return wall ? (
-                <WallShape
-                  key={`sel-${wall.id}`}
-                  wall={wall}
-                  selected
-                  drag={matchDrag(drag, 'wall', wall.id)}
-                  onShapePointerDown={(e) => startShapeDrag(e, { kind: 'wall', id: wall.id })}
-                  onVertexPointerDown={(e, idx) =>
-                    startVertexDrag(e, { kind: 'wall', id: wall.id }, idx)
-                  }
-                />
-              ) : null;
-            }
-            if (selectedRef.kind === 'opening') {
-              const op = draft.openings.find((o) => o.id === selectedRef.id);
-              return op ? (
-                <OpeningShape
-                  key={`sel-${op.id}`}
-                  opening={op}
-                  selected
-                  drag={matchDrag(drag, 'opening', op.id)}
-                  onShapePointerDown={(e) => startShapeDrag(e, { kind: 'opening', id: op.id })}
-                  onVertexPointerDown={(e, idx) =>
-                    startVertexDrag(e, { kind: 'opening', id: op.id }, idx)
-                  }
-                />
-              ) : null;
-            }
-            const obj = draft.objects.find((o) => o.id === selectedRef.id);
-            return obj ? (
-              <ObjectShape
-                key={`sel-${obj.id}`}
-                object={obj}
+        {/* 선택된 항목들 — 항상 맨 위에 렌더 (단일/다중 모두). */}
+        {(selectedRefs ?? []).map((ref) => {
+          if (ref.kind === 'room') {
+            const room = draft.rooms.find((r) => r.id === ref.id);
+            return room ? (
+              <RoomShape
+                key={`sel-${room.id}`}
+                room={room}
                 selected
-                drag={matchDrag(drag, 'object', obj.id)}
-                onShapePointerDown={(e) => startShapeDrag(e, { kind: 'object', id: obj.id })}
-                onResizePointerDown={(e, sign) =>
-                  startResizeDrag(e, { kind: 'object', id: obj.id }, sign)
+                drag={groupDrag(drag, selectedRefs, 'room', room.id)}
+                onShapePointerDown={(e) => startShapeDrag(e, { kind: 'room', id: room.id })}
+                onVertexPointerDown={(e, idx) =>
+                  startVertexDrag(e, { kind: 'room', id: room.id }, idx)
                 }
               />
             ) : null;
+          }
+          if (ref.kind === 'wall') {
+            const wall = draft.walls.find((w) => w.id === ref.id);
+            return wall ? (
+              <WallShape
+                key={`sel-${wall.id}`}
+                wall={wall}
+                selected
+                drag={groupDrag(drag, selectedRefs, 'wall', wall.id)}
+                onShapePointerDown={(e) => startShapeDrag(e, { kind: 'wall', id: wall.id })}
+                onVertexPointerDown={(e, idx) =>
+                  startVertexDrag(e, { kind: 'wall', id: wall.id }, idx)
+                }
+              />
+            ) : null;
+          }
+          if (ref.kind === 'opening') {
+            const op = draft.openings.find((o) => o.id === ref.id);
+            return op ? (
+              <OpeningShape
+                key={`sel-${op.id}`}
+                opening={op}
+                selected
+                drag={groupDrag(drag, selectedRefs, 'opening', op.id)}
+                onShapePointerDown={(e) => startShapeDrag(e, { kind: 'opening', id: op.id })}
+                onVertexPointerDown={(e, idx) =>
+                  startVertexDrag(e, { kind: 'opening', id: op.id }, idx)
+                }
+              />
+            ) : null;
+          }
+          const obj = draft.objects.find((o) => o.id === ref.id);
+          return obj ? (
+            <ObjectShape
+              key={`sel-${obj.id}`}
+              object={obj}
+              selected
+              drag={groupDrag(drag, selectedRefs, 'object', obj.id)}
+              onShapePointerDown={(e) => startShapeDrag(e, { kind: 'object', id: obj.id })}
+              onResizePointerDown={(e, sign) =>
+                startResizeDrag(e, { kind: 'object', id: obj.id }, sign)
+              }
+            />
+          ) : null;
+        })}
+
+        {/* 다중 선택 bbox + 4 모서리 그룹 리사이즈 핸들 */}
+        {tool === 'select' &&
+          selectedRefs &&
+          selectedRefs.length >= 2 &&
+          drag?.mode !== 'group-resize' &&
+          (() => {
+            const b = computeSelectionBounds(draft, selectedRefs);
+            if (!b || b.w < 0.1 || b.h < 0.1) return null;
+            const corners: { sign: [-1 | 1, -1 | 1]; x: number; y: number }[] = [
+              { sign: [-1, -1], x: b.x, y: b.y },
+              { sign: [1, -1], x: b.x + b.w, y: b.y },
+              { sign: [-1, 1], x: b.x, y: b.y + b.h },
+              { sign: [1, 1], x: b.x + b.w, y: b.y + b.h },
+            ];
+            return (
+              <g>
+                <rect
+                  x={b.x}
+                  y={b.y}
+                  width={b.w}
+                  height={b.h}
+                  fill="none"
+                  stroke="oklch(0.55 0.22 264)"
+                  strokeWidth="1.5"
+                  strokeDasharray="0.18 0.12"
+                  vectorEffect="non-scaling-stroke"
+                  pointerEvents="none"
+                />
+                {corners.map((c) => (
+                  <GroupResizeHandle
+                    key={`gr-${c.sign[0]}-${c.sign[1]}`}
+                    x={c.x}
+                    y={c.y}
+                    onPointerDown={(e) => {
+                      // 반대편 모서리가 고정점.
+                      const fx = c.sign[0] === -1 ? b.x + b.w : b.x;
+                      const fy = c.sign[1] === -1 ? b.y + b.h : b.y;
+                      startGroupResizeDrag(e, [fx, fy], [c.x, c.y]);
+                    }}
+                  />
+                ))}
+              </g>
+            );
           })()}
 
         {/* 벽 생성 preview */}
@@ -920,6 +1235,27 @@ export function DraftSceneCanvas({
           />
         )}
 
+        {/* Marquee 선택 박스 — 영역 안 도형들을 일괄 선택 */}
+        {drag?.mode === 'marquee' &&
+          (() => {
+            const r = normalizeRect(drag.startSvg, drag.currentSvg);
+            if (r.w < DRAG_THRESHOLD_M && r.h < DRAG_THRESHOLD_M) return null;
+            return (
+              <rect
+                x={r.x}
+                y={r.y}
+                width={r.w}
+                height={r.h}
+                fill="oklch(0.62 0.18 264 / 0.08)"
+                stroke="oklch(0.62 0.18 264)"
+                strokeWidth="1.5"
+                strokeDasharray="4 3"
+                vectorEffect="non-scaling-stroke"
+                pointerEvents="none"
+              />
+            );
+          })()}
+
         {/* 스냅 인디케이터 — 끝점/축에 딱 붙었을 때 초록 링 */}
         {snapIndicator && (
           <g pointerEvents="none">
@@ -990,37 +1326,79 @@ function matchDrag(
   kind: SelectedEntityRef['kind'],
   id: string,
 ): DragState | null {
-  if (drag && drag.ref.kind === kind && drag.ref.id === id) return drag;
+  // marquee/group-resize 모드는 특정 ref 가 없음 — 도형별 단일 매칭 대상 아님.
+  if (!drag || drag.mode === 'marquee' || drag.mode === 'group-resize') return null;
+  if (drag.ref.kind === kind && drag.ref.id === id) return drag;
+  return null;
+}
+
+/**
+ * 다중 선택 + shape 드래그 시 그룹 미리보기용.
+ * 드래그 중인 도형이 선택군에 포함되고 현재 도형도 선택군에 있다면 같은 delta 를 적용한
+ * 가상 shape-drag 상태를 반환 (실 PATCH 는 pointerUp 에서 일괄 처리).
+ */
+function groupDrag(
+  drag: DragState | null,
+  selectedRefs: SelectedEntityRef[] | undefined,
+  kind: SelectedEntityRef['kind'],
+  id: string,
+): DragState | null {
+  const exact = matchDrag(drag, kind, id);
+  if (exact) return exact;
+  if (!drag || !selectedRefs || selectedRefs.length < 2) return null;
+  const thisInSelection = selectedRefs.some((r) => r.kind === kind && r.id === id);
+  if (!thisInSelection) return null;
+  // group-resize: 선택된 모든 도형이 같은 변환을 받음.
+  if (drag.mode === 'group-resize') return drag;
+  // shape 드래그: 드래그된 도형이 선택군에 속하면 같은 delta 를 다른 선택 도형에도 미리보기.
+  if (drag.mode === 'shape') {
+    const draggedInSelection = selectedRefs.some(
+      (r) => r.kind === drag.ref.kind && r.id === drag.ref.id,
+    );
+    if (!draggedInSelection) return null;
+    return {
+      mode: 'shape',
+      ref: { kind, id },
+      startSvg: drag.startSvg,
+      delta: drag.delta,
+    };
+  }
   return null;
 }
 
 /** drag 진행 중인 도형의 effective coords 계산 (rendering 용). */
 function effectiveLineCoords(coords: Coord[], drag: DragState | null): Coord[] {
-  if (!drag) return coords;
+  if (!drag || drag.mode === 'marquee' || drag.mode === 'resize') return coords;
+  if (drag.mode === 'group-resize') {
+    const { sx, sy } = groupResizeScale(drag);
+    return coords.map((c) => scaleAround(c, drag.fixed, sx, sy));
+  }
   const [dx, dy] = drag.delta;
   if (drag.mode === 'shape') {
     return coords.map(([x, y]) => [x + dx, y + dy] as Coord);
   }
-  if (drag.mode === 'vertex') {
-    return moveLineStringVertex(coords, drag.vertexIndex, dx, dy);
-  }
-  return coords;
+  return moveLineStringVertex(coords, drag.vertexIndex, dx, dy);
 }
 
 function effectivePolygonRings(rings: Coord[][], drag: DragState | null): Coord[][] {
-  if (!drag) return rings;
+  if (!drag || drag.mode === 'marquee' || drag.mode === 'resize') return rings;
+  if (drag.mode === 'group-resize') {
+    const { sx, sy } = groupResizeScale(drag);
+    return rings.map((r) => r.map((c) => scaleAround(c, drag.fixed, sx, sy)));
+  }
   const [dx, dy] = drag.delta;
   if (drag.mode === 'shape') {
     return rings.map((r) => r.map(([x, y]) => [x + dx, y + dy] as Coord));
   }
-  if (drag.mode === 'vertex') {
-    return movePolygonVertex(rings, drag.vertexIndex, dx, dy);
-  }
-  return rings;
+  return movePolygonVertex(rings, drag.vertexIndex, dx, dy);
 }
 
 function effectivePoint(p: Coord, drag: DragState | null): Coord {
   if (!drag) return p;
+  if (drag.mode === 'group-resize') {
+    const { sx, sy } = groupResizeScale(drag);
+    return scaleAround(p, drag.fixed, sx, sy);
+  }
   if (drag.mode !== 'shape') return p;
   const [dx, dy] = drag.delta;
   return [p[0] + dx, p[1] + dy];
@@ -1313,6 +1691,10 @@ function ObjectShape({
   if (drag?.mode === 'resize') {
     w = Math.max(0.2, w + drag.delta[0] * drag.cornerSign[0] * 2);
     h = Math.max(0.2, h + drag.delta[1] * drag.cornerSign[1] * 2);
+  } else if (drag?.mode === 'group-resize') {
+    const { sx, sy } = groupResizeScale(drag);
+    w = Math.max(0.2, w * Math.abs(sx));
+    h = Math.max(0.2, h * Math.abs(sy));
   }
   const fill = selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.03 240)';
   const stroke = selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.74 0.08 240)';
@@ -1467,6 +1849,32 @@ const OBJECT_TYPE_LABEL: Record<string, string> = {
   utility: '다용도실',
   lobby: '로비',
 };
+
+function GroupResizeHandle({
+  x,
+  y,
+  onPointerDown,
+}: {
+  x: number;
+  y: number;
+  onPointerDown: (e: React.PointerEvent) => void;
+}) {
+  return (
+    <g onPointerDown={onPointerDown} className="cursor-nwse-resize">
+      <rect x={x - 0.18} y={y - 0.18} width="0.36" height="0.36" fill="transparent" />
+      <rect
+        x={x - 0.08}
+        y={y - 0.08}
+        width="0.16"
+        height="0.16"
+        fill="white"
+        stroke="oklch(0.55 0.22 264)"
+        strokeWidth="2"
+        vectorEffect="non-scaling-stroke"
+      />
+    </g>
+  );
+}
 
 function VertexHandle({
   x,

--- a/frontend/src/features/editor/PromotedCard.tsx
+++ b/frontend/src/features/editor/PromotedCard.tsx
@@ -27,7 +27,10 @@ export function PromotedCard({ version, versions, onReupload }: PromotedCardProp
 
   if (minimized) {
     return (
-      <div className="pointer-events-auto absolute right-6 top-6 flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs shadow-md">
+      <div
+        key="promoted-min"
+        className="pointer-events-auto absolute right-6 top-6 flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs shadow-md motion-safe:animate-in motion-safe:fade-in motion-safe:duration-300 motion-safe:ease-out"
+      >
         <CheckCircle2 className="h-4 w-4 text-primary" />
         <span className="font-medium">버전 #{displayVersion.version_no} 활성</span>
         <button
@@ -43,7 +46,10 @@ export function PromotedCard({ version, versions, onReupload }: PromotedCardProp
   }
 
   return (
-    <div className="rounded-xl border bg-card p-6 shadow-sm">
+    <div
+      key="promoted-full"
+      className="rounded-xl border bg-card p-6 shadow-sm motion-safe:animate-in motion-safe:fade-in motion-safe:duration-500 motion-safe:ease-out"
+    >
       <div className="flex items-start gap-3">
         <CheckCircle2 className="mt-0.5 h-6 w-6 text-primary" />
         <div className="flex-1">

--- a/frontend/src/features/editor/PromotedCard.tsx
+++ b/frontend/src/features/editor/PromotedCard.tsx
@@ -14,15 +14,22 @@ interface PromotedCardProps {
 export function PromotedCard({ version, versions, onReupload }: PromotedCardProps) {
   const [minimized, setMinimized] = useState(false);
 
+  // versions 리스트에 is_current 가 잡혀있으면 그쪽을 진실의 원천으로 사용.
+  // (justPromoted 로 캡처된 stale version prop 이 전환 후에도 따라오지 않는 문제 해결.)
+  const displayVersion = versions?.find((v) => v.is_current) ?? version;
+
   // 확정본 변경 이력 (§9.1) — Draft 단계 변경은 안 쌓이고, 확정 후 PATCH 시 기록됨.
-  const patchLogsQuery = useVersionPatchLogs(version.id, { page: 1, page_size: 1 });
+  const patchLogsQuery = useVersionPatchLogs(displayVersion.id, {
+    page: 1,
+    page_size: 1,
+  });
   const totalPatchLogs = patchLogsQuery.data?.total ?? 0;
 
   if (minimized) {
     return (
       <div className="pointer-events-auto absolute right-6 top-6 flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs shadow-md">
         <CheckCircle2 className="h-4 w-4 text-primary" />
-        <span className="font-medium">버전 #{version.version_no} 활성</span>
+        <span className="font-medium">버전 #{displayVersion.version_no} 활성</span>
         <button
           type="button"
           onClick={() => setMinimized(false)}
@@ -40,9 +47,9 @@ export function PromotedCard({ version, versions, onReupload }: PromotedCardProp
       <div className="flex items-start gap-3">
         <CheckCircle2 className="mt-0.5 h-6 w-6 text-primary" />
         <div className="flex-1">
-          <h3 className="text-lg font-semibold">버전 #{version.version_no} 확정 완료</h3>
+          <h3 className="text-lg font-semibold">버전 #{displayVersion.version_no} 확정 완료</h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            {version.is_current
+            {displayVersion.is_current
               ? '이어서 편집하시려면 오른쪽 위 최소화 버튼을 눌러 캔버스로 돌아가세요.'
               : '새 버전이 저장되었습니다.'}
           </p>

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 import { Check, ChevronDown, RotateCcw, ScanLine, Sparkles, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { objectTypeLabel, OBJECT_TYPE_OPTIONS, openingTypeLabel } from '@/lib/labels';
+import {
+  materialLabel,
+  objectTypeLabel,
+  OBJECT_TYPE_OPTIONS,
+  openingTypeLabel,
+  roomTypeLabel,
+  wallRoleLabel,
+} from '@/lib/labels';
 import type {
   DraftObject,
   DraftOpening,
@@ -20,6 +27,8 @@ import {
 
 interface PropertiesPanelProps {
   selected: SelectedEntityResolved | null;
+  /** 다중 선택 시 총 개수. 1 이하면 selected 단일 편집 UI 노출. */
+  selectedCount?: number;
   /** 선택된 엔티티 삭제 (백엔드 DELETE 호출). */
   onDelete?: () => void;
   /** 선택된 엔티티 90° 시계방향 회전. 객체(Point) 는 회전 무의미. */
@@ -46,6 +55,7 @@ const KIND_LABELS: Record<SelectedEntityResolved['kind'], string> = {
 
 export function PropertiesPanel({
   selected,
+  selectedCount,
   onDelete,
   onRotate,
   onUpdateMaterial,
@@ -55,13 +65,20 @@ export function PropertiesPanel({
   isSaving,
   isDeleting,
 }: PropertiesPanelProps) {
+  const isMulti = (selectedCount ?? 0) > 1;
   return (
     <aside className="flex w-80 shrink-0 flex-col gap-5 overflow-y-auto border-l bg-background p-5">
       <h2 className="text-sm font-semibold tracking-tight text-foreground">
         속성 (선택된 객체)
       </h2>
 
-      {selected ? (
+      {isMulti ? (
+        <MultiSelectBody
+          count={selectedCount ?? 0}
+          onDelete={onDelete}
+          isDeleting={!!isDeleting}
+        />
+      ) : selected ? (
         <SelectedBody
           selected={selected}
           onDelete={onDelete}
@@ -79,6 +96,42 @@ export function PropertiesPanel({
 
       <MobileScanCard />
     </aside>
+  );
+}
+
+function MultiSelectBody({
+  count,
+  onDelete,
+  isDeleting,
+}: {
+  count: number;
+  onDelete?: () => void;
+  isDeleting: boolean;
+}) {
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4">
+      <div>
+        <p className="text-xs font-medium text-muted-foreground">선택됨</p>
+        <p className="mt-1 text-base font-semibold">{count}개 항목</p>
+      </div>
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        여러 도형이 선택돼 있습니다. 캔버스에서 드래그하면 함께 이동하고,
+        아래 버튼으로 한꺼번에 삭제할 수 있어요.
+        <br />
+        개별 속성 편집은 하나만 선택했을 때 가능합니다.
+      </p>
+      {onDelete && (
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={isDeleting}
+          className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          {isDeleting ? '삭제 중…' : `${count}개 모두 삭제`}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -229,10 +282,10 @@ function TypeHeader({ selected }: { selected: SelectedEntityResolved }) {
 function WallFields({ wall }: { wall: DraftWall }) {
   return (
     <Grid>
-      <Row label="역할" value={wall.wall_role} />
+      <Row label="역할" value={wallRoleLabel(wall.wall_role)} />
       <Row label="두께" value={fmtDecimal(wall.thickness_m, 'm')} />
       <Row label="높이" value={fmtDecimal(wall.height_m, 'm')} />
-      <Row label="재질" value={wall.material_label ?? '-'} />
+      <Row label="재질" value={materialLabel(wall.material_label)} />
       <Row label="신뢰도" value={fmtConfidence(wall.confidence)} />
     </Grid>
   );
@@ -242,7 +295,7 @@ function RoomFields({ room }: { room: DraftRoom }) {
   return (
     <Grid>
       <Row label="이름" value={room.room_name?.trim() || '-'} />
-      <Row label="용도" value={room.room_type ?? '-'} />
+      <Row label="용도" value={roomTypeLabel(room.room_type)} />
     </Grid>
   );
 }

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -220,20 +220,19 @@ function SelectedBody({
       )}
 
       <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={onRotate}
-          disabled={isSaving || !onRotate || selected.kind === 'object'}
-          title={
-            selected.kind === 'object'
-              ? '점 객체는 회전이 적용되지 않습니다'
-              : '90° 시계방향 회전'
-          }
-          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border bg-background px-3 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <RotateCcw className="h-4 w-4" />
-          {isSaving ? '회전 중…' : '회전 90°'}
-        </button>
+        {/* 회전은 점 객체엔 의미 없음 — 그 외 종류에서만 노출. */}
+        {selected.kind !== 'object' && onRotate && (
+          <button
+            type="button"
+            onClick={onRotate}
+            disabled={isSaving}
+            title="90° 시계방향 회전"
+            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border bg-background px-3 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RotateCcw className="h-4 w-4" />
+            {isSaving ? '회전 중…' : '회전 90°'}
+          </button>
+        )}
         <button
           type="button"
           onClick={onDelete}

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -1,0 +1,609 @@
+import { useMemo, useRef, useState } from 'react';
+import { parseGeometry, type Coord } from '@/features/editor/geometry-utils';
+import type {
+  DraftObject,
+  DraftOpening,
+  DraftRoom,
+  DraftWall,
+  SceneVersion,
+} from '@/types/scene';
+import { cn } from '@/lib/utils';
+
+export interface PlacedAp {
+  id: string;          // 'ap1', 'ap2', ... — 사용자/SageMaker 식별자
+  x_m: number;
+  y_m: number;
+  z_m: number;
+}
+
+/** 모든 AP 에 공통 적용되는 출력 파워 (백엔드 simulation.tx_power_dbm 으로 보냄). */
+export const DEFAULT_TX_POWER_DBM = 20;
+
+const MAX_APS = 8;
+const DEFAULT_AP_Z_M = 2.5;
+
+interface Props {
+  sceneVersion: SceneVersion | null | undefined;
+  /** 원본 도면 이미지 (배경에 연하게 깔림). */
+  backgroundImageUrl?: string | null;
+  aps: PlacedAp[];
+  onAdd: (ap: PlacedAp) => void;
+  onMove: (id: string, x: number, y: number) => void;
+  onRemove: (id: string) => void;
+  /** true 면 다음 캔버스 클릭이 새 AP 추가. false 면 기존 AP 드래그/삭제만. */
+  pending: boolean;
+  onClearPending: () => void;
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function emptyBounds(): Bounds {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+}
+
+function extendBounds(b: Bounds, x: number, y: number) {
+  if (x < b.minX) b.minX = x;
+  if (y < b.minY) b.minY = y;
+  if (x > b.maxX) b.maxX = x;
+  if (y > b.maxY) b.maxY = y;
+}
+
+function computeViewBox(scene: SceneVersion | null | undefined): {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+} {
+  const b = emptyBounds();
+  for (const room of scene?.rooms ?? []) {
+    const g = parseGeometry(room.polygon_geom);
+    if (g?.type === 'Polygon')
+      for (const ring of g.coordinates) for (const [x, y] of ring) extendBounds(b, x, y);
+  }
+  for (const wall of scene?.walls ?? []) {
+    const g = parseGeometry(wall.centerline_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  for (const op of scene?.openings ?? []) {
+    const g = parseGeometry(op.line_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  for (const obj of scene?.objects ?? []) {
+    const g = parseGeometry(obj.point_geom);
+    if (g?.type !== 'Point') continue;
+    const [x, y] = g.coordinates;
+    const meta = (obj.metadata_json ?? {}) as Record<string, unknown>;
+    const w = typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+    const h = typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+    extendBounds(b, x - w / 2, y - h / 2);
+    extendBounds(b, x + w / 2, y + h / 2);
+  }
+  if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
+  const w = b.maxX - b.minX || 1;
+  const h = b.maxY - b.minY || 1;
+  const padding = Math.max(w, h) * 0.05;
+  return { x: b.minX - padding, y: b.minY - padding, w: w + 2 * padding, h: h + 2 * padding };
+}
+
+/**
+ * 시뮬레이션 페이지 캔버스 — 확정 버전 도형(rooms/walls/openings/objects)을 read-only 로
+ * 보여주고, 그 위에 사용자가 AP 를 자유롭게 배치/드래그/삭제. 최대 8개.
+ *
+ * 렌더링 스타일은 공간편집(DraftSceneCanvas) 와 시각적으로 일치시킨다.
+ */
+export function SimulationCanvas({
+  sceneVersion,
+  backgroundImageUrl,
+  aps,
+  onAdd,
+  onMove,
+  onRemove,
+  pending,
+  onClearPending,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const vb = useMemo(() => computeViewBox(sceneVersion), [sceneVersion]);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [dragOffset, setDragOffset] = useState<Coord>([0, 0]);
+
+  const getSvgPoint = (e: React.PointerEvent): Coord | null => {
+    const svg = svgRef.current;
+    if (!svg) return null;
+    const pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return null;
+    const t = pt.matrixTransform(ctm.inverse());
+    return [t.x, t.y];
+  };
+
+  const handleSvgPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (dragId) return;
+    if (!pending) return;
+    if (e.target !== e.currentTarget) return; // AP 또는 도형 위 클릭은 새 AP 추가가 아님
+    if (aps.length >= MAX_APS) return;
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    onAdd({
+      id: nextApId(aps),
+      x_m: pt[0],
+      y_m: pt[1],
+      z_m: DEFAULT_AP_Z_M,
+    });
+    onClearPending();
+  };
+
+  const handleApPointerDown = (e: React.PointerEvent, ap: PlacedAp) => {
+    e.stopPropagation();
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    svgRef.current?.setPointerCapture(e.pointerId);
+    setDragId(ap.id);
+    setDragOffset([pt[0] - ap.x_m, pt[1] - ap.y_m]);
+  };
+
+  const handleSvgPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!dragId) return;
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    onMove(dragId, pt[0] - dragOffset[0], pt[1] - dragOffset[1]);
+  };
+
+  const handleSvgPointerUp = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!dragId) return;
+    try {
+      svgRef.current?.releasePointerCapture(e.pointerId);
+    } catch {
+      /* already released */
+    }
+    setDragId(null);
+  };
+
+  const cursorClass = pending
+    ? 'cursor-crosshair'
+    : dragId
+    ? 'cursor-grabbing'
+    : 'cursor-default';
+
+  return (
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[#f8fafc] p-6 [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
+      <svg
+        ref={svgRef}
+        viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
+        preserveAspectRatio="xMidYMid meet"
+        className={cn('h-full w-full select-none', cursorClass)}
+        onPointerDown={handleSvgPointerDown}
+        onPointerMove={handleSvgPointerMove}
+        onPointerUp={handleSvgPointerUp}
+        onPointerCancel={handleSvgPointerUp}
+      >
+        {backgroundImageUrl && (
+          <image
+            href={backgroundImageUrl}
+            xlinkHref={backgroundImageUrl}
+            x={vb.x}
+            y={vb.y}
+            width={vb.w}
+            height={vb.h}
+            preserveAspectRatio="xMidYMid meet"
+            opacity={0.35}
+            pointerEvents="none"
+            onError={() => {
+              console.warn('[SimulationCanvas] 배경 도면 이미지 로드 실패:', backgroundImageUrl);
+            }}
+          />
+        )}
+        {(sceneVersion?.rooms ?? []).map((r) => (
+          <RoomShape key={r.id} room={r} />
+        ))}
+        {(sceneVersion?.walls ?? []).map((w) => (
+          <WallShape key={w.id} wall={w} />
+        ))}
+        {(sceneVersion?.openings ?? []).map((o) => (
+          <OpeningShape key={o.id} opening={o} />
+        ))}
+        {(sceneVersion?.objects ?? []).map((o) => (
+          <ObjectShape key={o.id} object={o} />
+        ))}
+
+        {aps.map((ap) => (
+          <ApMarker
+            key={ap.id}
+            ap={ap}
+            isDragging={dragId === ap.id}
+            onPointerDown={(e) => handleApPointerDown(e, ap)}
+            onRemove={() => onRemove(ap.id)}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+// ============================================
+// 도형 (read-only) — 공간편집 DraftSceneCanvas 와 시각적 동일.
+// ============================================
+
+function RoomShape({ room }: { room: DraftRoom }) {
+  const g = parseGeometry(room.polygon_geom);
+  if (g?.type !== 'Polygon') return null;
+  const ring = g.coordinates[0];
+  if (!ring || ring.length === 0) return null;
+  const isClosed =
+    ring.length > 0 &&
+    ring[0][0] === ring[ring.length - 1][0] &&
+    ring[0][1] === ring[ring.length - 1][1];
+  const labelPts = isClosed ? ring.slice(0, -1) : ring;
+  const points = ring.map(([x, y]) => `${x},${y}`).join(' ');
+  const label = roomLabel(room);
+  const center = polygonCentroid(labelPts);
+  const bb = polygonBounds(labelPts);
+  return (
+    <g pointerEvents="none">
+      <polygon
+        points={points}
+        fill="oklch(0.95 0.01 256)"
+        stroke="oklch(0.86 0 0)"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      {label && (
+        <text
+          x={center[0]}
+          y={center[1]}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={computeLabelFontSize(label, bb.w, bb.h)}
+          fontWeight="600"
+          fill="oklch(0.35 0.02 256)"
+          style={{ userSelect: 'none' }}
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function WallShape({ wall }: { wall: DraftWall }) {
+  const g = parseGeometry(wall.centerline_geom);
+  if (g?.type !== 'LineString') return null;
+  const start = g.coordinates[0];
+  const end = g.coordinates[g.coordinates.length - 1];
+  if (!start || !end) return null;
+  return (
+    <line
+      x1={start[0]}
+      y1={start[1]}
+      x2={end[0]}
+      y2={end[1]}
+      stroke="oklch(0.25 0 0)"
+      strokeWidth="4"
+      strokeLinecap="round"
+      vectorEffect="non-scaling-stroke"
+      pointerEvents="none"
+    />
+  );
+}
+
+function OpeningShape({ opening }: { opening: DraftOpening }) {
+  const g = parseGeometry(opening.line_geom);
+  if (g?.type !== 'LineString') return null;
+  const start = g.coordinates[0];
+  const end = g.coordinates[g.coordinates.length - 1];
+  if (!start || !end) return null;
+  const isDoor = opening.opening_type === 'door';
+  const color = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  const label = isDoor ? '문' : '창문';
+  const midX = (start[0] + end[0]) / 2;
+  const midY = (start[1] + end[1]) / 2;
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  const len = Math.hypot(dx, dy) || 1;
+  const nx = -dy / len;
+  const ny = dx / len;
+  const offsetM = 0.17;
+  const labelX = midX + nx * offsetM;
+  const labelY = midY + ny * offsetM;
+  return (
+    <g pointerEvents="none">
+      <line
+        x1={start[0]}
+        y1={start[1]}
+        x2={end[0]}
+        y2={end[1]}
+        stroke={color}
+        strokeWidth="5"
+        strokeLinecap="butt"
+        vectorEffect="non-scaling-stroke"
+      />
+      <text
+        x={labelX}
+        y={labelY}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={OPENING_LABEL_FONT_SIZE_M}
+        fontWeight="500"
+        fill={color}
+        style={{ userSelect: 'none' }}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+function ObjectShape({ object }: { object: DraftObject }) {
+  const g = parseGeometry(object.point_geom);
+  if (g?.type !== 'Point') return null;
+  const [x, y] = g.coordinates;
+  const meta = (object.metadata_json ?? {}) as Record<string, unknown>;
+  const w = typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : SPACE_DEFAULT_SIZE_M;
+  const h = typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : SPACE_DEFAULT_SIZE_M;
+  const label = objectLabel(object);
+  const spaceLike = isSpaceLikeObject(object);
+  const strokeDasharray = spaceLike ? '0.18 0.12' : undefined;
+  return (
+    <g pointerEvents="none">
+      <rect
+        x={x - w / 2}
+        y={y - h / 2}
+        width={w}
+        height={h}
+        rx="0.15"
+        fill="oklch(0.95 0.03 240)"
+        stroke="oklch(0.74 0.08 240)"
+        strokeWidth="1.5"
+        strokeDasharray={strokeDasharray}
+        vectorEffect="non-scaling-stroke"
+      />
+      {label && (
+        <text
+          x={x}
+          y={y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={computeLabelFontSize(label, w, h)}
+          fontWeight="500"
+          fill="oklch(0.4 0.04 240)"
+          style={{ userSelect: 'none' }}
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+}
+
+// ============================================
+// AP 마커 (드래그 + 라벨 + 삭제) — 도형보다 작게.
+// ============================================
+
+function ApMarker({
+  ap,
+  isDragging,
+  onPointerDown,
+  onRemove,
+}: {
+  ap: PlacedAp;
+  isDragging: boolean;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onRemove: () => void;
+}) {
+  const fill = 'oklch(0.55 0.22 254)';
+  const r = 0.13;
+  // lucide Wifi 아이콘 (24x24 viewBox) 을 r 안에 들어갈 크기로 스케일.
+  const iconSize = r * 1.3; // 원 지름의 약 65%
+  const iconScale = iconSize / 24;
+  return (
+    <g className={isDragging ? 'cursor-grabbing' : 'cursor-grab'}>
+      <circle
+        cx={ap.x_m}
+        cy={ap.y_m}
+        r={r}
+        fill={fill}
+        onPointerDown={onPointerDown}
+      />
+      {/* lucide Wifi 아이콘 path 인라인 — 우측 "AP 추가" 패널과 동일 모양. */}
+      <g
+        transform={`translate(${ap.x_m - iconSize / 2}, ${ap.y_m - iconSize / 2}) scale(${iconScale})`}
+        pointerEvents="none"
+        fill="none"
+        stroke="white"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 20h.01" />
+        <path d="M2 8.82a15 15 0 0 1 20 0" />
+        <path d="M5 12.859a10 10 0 0 1 14 0" />
+        <path d="M8.5 16.429a5 5 0 0 1 7 0" />
+      </g>
+      {/* 라벨 박스 */}
+      <g pointerEvents="none">
+        <rect
+          x={ap.x_m - 0.18}
+          y={ap.y_m + r + 0.04}
+          width="0.36"
+          height="0.16"
+          rx="0.04"
+          fill="white"
+          stroke="oklch(0.85 0.02 240)"
+          strokeWidth="1"
+          vectorEffect="non-scaling-stroke"
+        />
+        <text
+          x={ap.x_m}
+          y={ap.y_m + r + 0.12}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="0.1"
+          fontWeight="600"
+          fill="oklch(0.25 0.04 240)"
+          style={{ userSelect: 'none' }}
+        >
+          {ap.id.toUpperCase()}
+        </text>
+      </g>
+      {/* 삭제 버튼 — 우측 상단 작은 빨간 원 + × 표시 */}
+      <g
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="cursor-pointer"
+      >
+        <circle
+          cx={ap.x_m + r * 0.85}
+          cy={ap.y_m - r * 0.85}
+          r="0.055"
+          fill="oklch(0.65 0.21 25)"
+          stroke="white"
+          strokeWidth="1"
+          vectorEffect="non-scaling-stroke"
+        />
+        <text
+          x={ap.x_m + r * 0.85}
+          y={ap.y_m - r * 0.85 + 0.003}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="0.07"
+          fontWeight="700"
+          fill="white"
+          pointerEvents="none"
+          style={{ userSelect: 'none' }}
+        >
+          ×
+        </text>
+      </g>
+    </g>
+  );
+}
+
+// ============================================
+// 라벨/유틸 — 공간편집과 일관된 매핑.
+// ============================================
+
+const AUTO_ROOM_NAME = /^room[_\s-]?\d+$/i;
+const SPACE_DEFAULT_SIZE_M = 1.6;
+const OPENING_LABEL_FONT_SIZE_M = 0.13;
+
+const ROOM_TYPE_LABEL: Record<string, string> = {
+  general: 'room',
+  room: 'room',
+  unknown: 'room',
+  kitchen: '주방',
+  storage: '창고',
+  office: '사무실',
+  meeting: '회의실',
+  bathroom: '화장실',
+  lobby: '로비',
+  hall: '홀',
+  corridor: '복도',
+  dining: '식당',
+  bedroom: '침실',
+  livingroom: '거실',
+};
+
+const OBJECT_TYPE_LABEL: Record<string, string> = {
+  table: '테이블',
+  chair: '의자',
+  desk: '책상',
+  sofa: '소파',
+  bed: '침대',
+  ap: 'AP',
+  furniture: '가구',
+  counter: '카운터',
+  refrigerator: '냉장고',
+  toilet: '변기',
+  sink: '세면대',
+  bathtub: '욕조',
+  door: '문',
+  window: '창문',
+  bathroom: '화장실',
+  restroom: '화장실',
+  toilet_room: '화장실',
+  kitchen: '주방',
+  stairs: '계단',
+  staircase: '계단',
+  elevator: '엘리베이터',
+  closet: '벽장',
+  storage: '창고',
+  pantry: '팬트리',
+  utility: '다용도실',
+  lobby: '로비',
+};
+
+const SPACE_LIKE_TYPES = new Set([
+  'bathroom',
+  'restroom',
+  'toilet_room',
+  'kitchen',
+  'stairs',
+  'staircase',
+  'elevator',
+  'closet',
+  'storage',
+  'pantry',
+  'utility',
+  'lobby',
+]);
+
+function roomLabel(room: DraftRoom): string | null {
+  const name = room.room_name?.trim();
+  if (name && !AUTO_ROOM_NAME.test(name)) return name;
+  if (room.room_type) return ROOM_TYPE_LABEL[room.room_type] ?? room.room_type;
+  return 'room';
+}
+
+function objectLabel(object: DraftObject): string | null {
+  if (!object.object_type) return null;
+  return OBJECT_TYPE_LABEL[object.object_type] ?? object.object_type;
+}
+
+function isSpaceLikeObject(o: DraftObject): boolean {
+  return !!o.object_type && SPACE_LIKE_TYPES.has(o.object_type);
+}
+
+function polygonCentroid(points: Coord[]): Coord {
+  if (points.length === 0) return [0, 0];
+  const n = points.length;
+  const sx = points.reduce((s, p) => s + p[0], 0);
+  const sy = points.reduce((s, p) => s + p[1], 0);
+  return [sx / n, sy / n];
+}
+
+function polygonBounds(points: Coord[]): { w: number; h: number } {
+  if (points.length === 0) return { w: 0, h: 0 };
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const [x, y] of points) {
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  }
+  return { w: maxX - minX, h: maxY - minY };
+}
+
+function computeLabelFontSize(label: string, w: number, h: number): number {
+  const charCount = Math.max(1, label.length);
+  const widthFit = (w * 0.5) / charCount;
+  const heightFit = h * 0.35;
+  const size = Math.min(widthFit, heightFit, OPENING_LABEL_FONT_SIZE_M);
+  return Math.max(0.08, size);
+}
+
+function nextApId(aps: PlacedAp[]): string {
+  const used = new Set(aps.map((a) => a.id));
+  for (let i = 1; i <= MAX_APS; i++) {
+    const id = `ap${i}`;
+    if (!used.has(id)) return id;
+  }
+  return `ap${aps.length + 1}`;
+}

--- a/frontend/src/hooks/use-scene-version.ts
+++ b/frontend/src/hooks/use-scene-version.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { sceneVersionApi } from '@/api/scene-version';
 import type { UUID } from '@/types/common';
 import type { PromoteRequest } from '@/types/scene';
@@ -19,6 +24,9 @@ export function useSceneVersion(versionId: UUID | null) {
     queryKey: ['scene-version', versionId] as const,
     queryFn: () => sceneVersionApi.get(versionId as UUID),
     enabled: !!versionId,
+    // 버전 전환 시 새 detail 이 도착하기 전까지 이전 데이터를 유지 — 캔버스가 잠깐
+    // 비어 보이고 업로드 화면으로 떨어지는 현상 방지.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -46,14 +54,37 @@ export function useSetCurrentVersion() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (versionId: UUID) => sceneVersionApi.setCurrent(versionId),
-    onSuccess: (data) => {
-      qc.invalidateQueries({ queryKey: ['scene-versions'] });
-      qc.invalidateQueries({ queryKey: ['scene-version', data.id] });
-      toast.success(`버전 #${data.version_no} 으로 전환됨`, '이 버전을 기준으로 작업합니다.');
+    // 낙관적 업데이트 — 리스트 캐시의 is_current 를 즉시 새 버전 쪽으로 옮긴다.
+    // refetch 가 끝나기 전에도 캔버스가 새 버전 상세를 가리키도록.
+    onMutate: async (versionId) => {
+      await qc.cancelQueries({ queryKey: ['scene-versions'] });
+      const snapshot = qc.getQueriesData<unknown>({ queryKey: ['scene-versions'] });
+      qc.setQueriesData<unknown>({ queryKey: ['scene-versions'] }, (old) => {
+        if (!Array.isArray(old)) return old;
+        return (old as Array<{ id: UUID; is_current: boolean }>).map((v) => ({
+          ...v,
+          is_current: v.id === versionId,
+        }));
+      });
+      return { snapshot };
     },
-    onError: (err) => {
+    onError: (err, _vars, ctx) => {
+      // 롤백.
+      if (ctx?.snapshot) {
+        for (const [key, data] of ctx.snapshot) qc.setQueryData(key, data);
+      }
       const e = err as HttpError | null;
       toast.error('버전 전환 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
+    },
+    onSuccess: (data) => {
+      toast.success(`버전 #${data.version_no} 으로 전환됨`, '이 버전을 기준으로 작업합니다.');
+    },
+    onSettled: () => {
+      // 전체 scene-version 관련 캐시 + 드래프트/패치로그도 같이 새로 고침.
+      qc.invalidateQueries({ queryKey: ['scene-versions'] });
+      qc.invalidateQueries({ queryKey: ['scene-version'] });
+      qc.invalidateQueries({ queryKey: ['scene-drafts'] });
+      qc.invalidateQueries({ queryKey: ['patch-logs'] });
     },
   });
 }

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import {
   LayoutGrid,
   Map,
@@ -25,6 +25,9 @@ const NAV = [
 
 export function AppLayout() {
   const [mobileConnectOpen, setMobileConnectOpen] = useState(false);
+  // /mobile 페이지에선 헤더의 "모바일 앱 연결" 버튼을 숨기고 페이지 내 카드 하단에 배치.
+  const location = useLocation();
+  const isMobileAppPage = location.pathname.startsWith('/mobile');
 
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-background">
@@ -78,14 +81,16 @@ export function AppLayout() {
             <FloorSelector />
           </div>
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setMobileConnectOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
-            >
-              <Smartphone className="h-4 w-4" />
-              모바일 앱 연결
-            </button>
+            {!isMobileAppPage && (
+              <button
+                type="button"
+                onClick={() => setMobileConnectOpen(true)}
+                className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
+              >
+                <Smartphone className="h-4 w-4" />
+                모바일 앱 연결
+              </button>
+            )}
             <ProfileMenu />
           </div>
         </header>

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -35,3 +35,60 @@ export function objectTypeLabel(type: string | null | undefined): string {
   const key = (type ?? '').toLowerCase();
   return OBJECT_TYPE_LABELS[key] ?? type ?? '객체';
 }
+
+/** 벽의 wall_role → 한국어 라벨. */
+const WALL_ROLE_LABELS: Record<string, string> = {
+  inner: '내벽',
+  outer: '외벽',
+  partition: '칸막이',
+};
+
+export function wallRoleLabel(role: string | null | undefined): string {
+  const key = (role ?? '').toLowerCase();
+  return WALL_ROLE_LABELS[key] ?? role ?? '-';
+}
+
+/** 재질(material_label) → 한국어 라벨. value 는 백엔드 enum 그대로 유지. */
+const MATERIAL_LABELS: Record<string, string> = {
+  concrete: '콘크리트',
+  brick: '벽돌',
+  drywall: '석고보드',
+  gypsum_board: '석고보드',
+  glass: '유리',
+  wood: '목재',
+  metal: '금속',
+  steel: '강철',
+  stone: '석재',
+  plaster: '회벽',
+  tile: '타일',
+};
+
+export function materialLabel(material: string | null | undefined): string {
+  const key = (material ?? '').toLowerCase();
+  return MATERIAL_LABELS[key] ?? material ?? '-';
+}
+
+/** room_type → 한국어 라벨. 미상이면 그대로 반환. */
+const ROOM_TYPE_LABELS: Record<string, string> = {
+  general: '일반',
+  living: '거실',
+  living_room: '거실',
+  bedroom: '침실',
+  kitchen: '주방',
+  bathroom: '화장실',
+  office: '사무실',
+  hallway: '복도',
+  corridor: '복도',
+  lobby: '로비',
+  storage: '창고',
+  closet: '붙박이장',
+  utility: '다용도실',
+  balcony: '베란다',
+  dining: '식당',
+  dining_room: '식당',
+};
+
+export function roomTypeLabel(type: string | null | undefined): string {
+  const key = (type ?? '').toLowerCase();
+  return ROOM_TYPE_LABELS[key] ?? type ?? '-';
+}

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -28,8 +28,19 @@ const OBJECT_TYPE_LABELS: Record<string, string> = {
   closet: '붙박이장',
 };
 
-/** 객체 종류 변경 select 의 옵션 (백엔드 enum 값). */
-export const OBJECT_TYPE_OPTIONS = Object.keys(OBJECT_TYPE_LABELS);
+/**
+ * 객체 종류 변경 select 의 옵션 (백엔드 enum 값).
+ * 2026-05-16 DB 조회 기준 실제 사용되는 값(`SELECT DISTINCT object_type FROM objects/draft_objects`).
+ * AI 모델이 새 클래스를 뱉으면 라벨 매핑(OBJECT_TYPE_LABELS) 에는 있으니 표시는 정상.
+ * 단, 사용자가 이 선택지를 통해 변경할 수 있는 값만 여기에 둔다.
+ */
+export const OBJECT_TYPE_OPTIONS = [
+  'furniture',
+  'bathroom',
+  'stairs',
+  'sofa',
+  'table',
+];
 
 export function objectTypeLabel(type: string | null | undefined): string {
   const key = (type ?? '').toLowerCase();

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -78,7 +78,51 @@ export default function EditorPage() {
 
   const [justPromoted, setJustPromoted] = useState<SceneVersion | null>(null);
   const [pendingFileName, setPendingFileName] = useState<string | null>(null);
-  const [selectedRef, setSelectedRef] = useState<SelectedEntityRef | null>(null);
+  // 다중 선택 지원 — selectedRef 는 primary (length 1 일 때만 유효).
+  const [selectedRefs, setSelectedRefs] = useState<SelectedEntityRef[]>([]);
+  const selectedRef: SelectedEntityRef | null =
+    selectedRefs.length === 1 ? selectedRefs[0] : null;
+  const setSelectedRef = (ref: SelectedEntityRef | null) =>
+    setSelectedRefs(ref ? [ref] : []);
+  /** 도형 클릭/Shift+클릭 핸들러. additive=true 면 토글, false 면 단일 교체. */
+  const handleSelect = (
+    ref: SelectedEntityRef | null,
+    options?: { additive?: boolean },
+  ) => {
+    if (!ref) {
+      setSelectedRefs([]);
+      return;
+    }
+    if (options?.additive) {
+      setSelectedRefs((prev) => {
+        const exists = prev.some((r) => r.kind === ref.kind && r.id === ref.id);
+        return exists
+          ? prev.filter((r) => !(r.kind === ref.kind && r.id === ref.id))
+          : [...prev, ref];
+      });
+      return;
+    }
+    setSelectedRefs([ref]);
+  };
+
+  /** Marquee 드래그 종료 시 영역 내부 도형들을 한꺼번에 선택. */
+  const handleSelectMany = (
+    refs: SelectedEntityRef[],
+    options?: { additive?: boolean },
+  ) => {
+    if (!options?.additive) {
+      setSelectedRefs(refs);
+      return;
+    }
+    setSelectedRefs((prev) => {
+      const merged = [...prev];
+      for (const r of refs) {
+        const exists = merged.some((m) => m.kind === r.kind && m.id === r.id);
+        if (!exists) merged.push(r);
+      }
+      return merged;
+    });
+  };
 
   // 분석 Job 추적 — POST /upload/floorplan/analyze 가 즉시 202 + job_id 만 반환.
   // 실제 완료 여부는 useFloorplanJob 폴링으로 확인.
@@ -298,27 +342,166 @@ export default function EditorPage() {
   }, [history, isVersionEditing]);
 
   // 드래그 (shape 평행이동 / vertex 개별 이동) 종료 시 새 geometry 로 PATCH.
+  // 다중 선택 + shape 모드 → 같은 변위(delta) 를 모든 선택 도형에 적용 (그룹 이동).
   const handleDragEnd = (
     ref: SelectedEntityRef,
     geometry: GeoJsonGeometry,
   ) => {
     const body = geomFieldFor(ref.kind, geometry);
     if (!body) return;
+
+    // 다중 선택 + 이동된 도형이 선택군 안에 있으면 → 그룹 이동.
+    const isMulti =
+      selectedRefs.length > 1 &&
+      selectedRefs.some((r) => r.kind === ref.kind && r.id === ref.id);
+    if (isMulti && baseScene) {
+      const delta = computeDragDelta(ref, geometry, baseScene);
+      if (delta) {
+        const [dx, dy] = delta;
+        for (const other of selectedRefs) {
+          if (other.kind === ref.kind && other.id === ref.id) {
+            runPatch(ref.kind, ref.id, body, { silent: true });
+          } else {
+            translateAndPatch(other, dx, dy);
+          }
+        }
+        return;
+      }
+    }
+
     runPatch(ref.kind, ref.id, body, { silent: true });
   };
 
-  // 선택된 엔티티 삭제
-  const handleDeleteSelected = () => {
-    if (!selectedRef) return;
-    const onSuccess = () => setSelectedRef(null);
-    if (isVersionEditing) {
-      deleteVersionEntity.mutate(
-        { kind: selectedRef.kind, id: selectedRef.id },
-        { onSuccess },
-      );
-    } else {
-      deleteEntity.mutate({ kind: selectedRef.kind, id: selectedRef.id }, { onSuccess });
+  /** 엔티티의 geometry 를 dx,dy 만큼 평행이동시킨 새 geometry 로 PATCH. */
+  const translateAndPatch = (ref: SelectedEntityRef, dx: number, dy: number) => {
+    if (!baseScene) return;
+    const list =
+      ref.kind === 'wall'
+        ? baseScene.walls
+        : ref.kind === 'room'
+        ? baseScene.rooms
+        : ref.kind === 'opening'
+        ? baseScene.openings
+        : baseScene.objects;
+    const entity = (list as Array<{ id: string }>).find((e) => e.id === ref.id) as
+      | Record<string, unknown>
+      | undefined;
+    if (!entity) return;
+    const geomFieldName =
+      ref.kind === 'wall'
+        ? 'centerline_geom'
+        : ref.kind === 'room'
+        ? 'polygon_geom'
+        : ref.kind === 'opening'
+        ? 'line_geom'
+        : 'point_geom';
+    const g = parseGeometry(entity[geomFieldName] as Record<string, unknown> | null | undefined);
+    if (!g) return;
+    const moved = (() => {
+      if (g.type === 'Point') {
+        return {
+          type: 'Point' as const,
+          coordinates: [g.coordinates[0] + dx, g.coordinates[1] + dy] as [number, number],
+        };
+      }
+      if (g.type === 'LineString') {
+        return {
+          type: 'LineString' as const,
+          coordinates: g.coordinates.map(([x, y]) => [x + dx, y + dy] as [number, number]),
+        };
+      }
+      return {
+        type: 'Polygon' as const,
+        coordinates: g.coordinates.map((ring) =>
+          ring.map(([x, y]) => [x + dx, y + dy] as [number, number]),
+        ),
+      };
+    })();
+    const body = geomFieldFor(ref.kind, moved);
+    if (body) runPatch(ref.kind, ref.id, body, { silent: true });
+  };
+
+  /** 그룹 리사이즈 종료 — 각 선택 도형 좌표 / 객체 W·H 를 같은 비율로 변환해 PATCH. */
+  const handleGroupResizeEnd = ({
+    fixed,
+    sx,
+    sy,
+    refs,
+  }: {
+    fixed: [number, number];
+    sx: number;
+    sy: number;
+    refs: SelectedEntityRef[];
+  }) => {
+    if (!baseScene) return;
+    const scale = (x: number, y: number): [number, number] => [
+      fixed[0] + (x - fixed[0]) * sx,
+      fixed[1] + (y - fixed[1]) * sy,
+    ];
+    for (const ref of refs) {
+      if (ref.kind === 'wall' || ref.kind === 'opening') {
+        const list = ref.kind === 'wall' ? baseScene.walls : baseScene.openings;
+        const field = ref.kind === 'wall' ? 'centerline_geom' : 'line_geom';
+        const entity = (list as Array<{ id: string } & Record<string, unknown>>).find(
+          (e) => e.id === ref.id,
+        );
+        const g = parseGeometry(entity?.[field] as Record<string, unknown> | null | undefined);
+        if (g?.type !== 'LineString') continue;
+        const scaled = {
+          type: 'LineString' as const,
+          coordinates: g.coordinates.map(([x, y]) => scale(x, y)),
+        };
+        const body = geomFieldFor(ref.kind, scaled);
+        if (body) runPatch(ref.kind, ref.id, body, { silent: true });
+      } else if (ref.kind === 'room') {
+        const room = baseScene.rooms.find((r) => r.id === ref.id);
+        const g = parseGeometry(room?.polygon_geom);
+        if (g?.type !== 'Polygon') continue;
+        const scaled = {
+          type: 'Polygon' as const,
+          coordinates: g.coordinates.map((ring) => ring.map(([x, y]) => scale(x, y))),
+        };
+        const body = geomFieldFor('room', scaled);
+        if (body) runPatch('room', ref.id, body, { silent: true });
+      } else {
+        const obj = baseScene.objects.find((o) => o.id === ref.id);
+        const g = parseGeometry(obj?.point_geom);
+        if (g?.type !== 'Point') continue;
+        const [cx, cy] = g.coordinates;
+        const [nx, ny] = scale(cx, cy);
+        const meta = (obj?.metadata_json ?? {}) as Record<string, unknown>;
+        const curW =
+          typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+        const curH =
+          typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+        const newW = Math.max(0.2, curW * Math.abs(sx));
+        const newH = Math.max(0.2, curH * Math.abs(sy));
+        runPatch(
+          'object',
+          ref.id,
+          {
+            point_geom: { type: 'Point', coordinates: [nx, ny] },
+            metadata_json: { ...meta, width_m: newW, height_m: newH },
+          },
+          { silent: true },
+        );
+      }
     }
+  };
+
+  // 선택된 엔티티들 삭제 (다중 선택 지원)
+  const handleDeleteSelected = () => {
+    if (selectedRefs.length === 0) return;
+    const onSuccess = () => setSelectedRefs([]);
+    selectedRefs.forEach((r, idx) => {
+      const last = idx === selectedRefs.length - 1;
+      const vars = { kind: r.kind, id: r.id };
+      if (isVersionEditing) {
+        deleteVersionEntity.mutate(vars, last ? { onSuccess } : undefined);
+      } else {
+        deleteEntity.mutate(vars, last ? { onSuccess } : undefined);
+      }
+    });
   };
 
   // 벽 재질 변경
@@ -552,8 +735,10 @@ export default function EditorPage() {
             {editingScene ? (
               <DraftSceneCanvas
                 draft={editingScene}
-                selectedRef={selectedRef}
-                onSelect={setSelectedRef}
+                selectedRefs={selectedRefs}
+                onSelect={handleSelect}
+                onSelectMany={handleSelectMany}
+                onGroupResizeEnd={handleGroupResizeEnd}
                 onDragEnd={handleDragEnd}
                 onResizeObject={handleResizeObject}
                 tool={tool}
@@ -629,6 +814,7 @@ export default function EditorPage() {
 
       <PropertiesPanel
         selected={resolvedSelected}
+        selectedCount={selectedRefs.length}
         onUpdateObjectType={handleUpdateObjectType}
         onDelete={handleDeleteSelected}
         onRotate={handleRotateSelected}
@@ -723,6 +909,30 @@ function geomFieldFor(
     return { polygon_geom: geometry };
   if (kind === 'object' && geometry.type === 'Point')
     return { point_geom: geometry };
+  return null;
+}
+
+/**
+ * 드래그된 엔티티의 변위(dx, dy) 계산.
+ * 새 geometry 의 첫 좌표 - 이전 geometry 의 첫 좌표. 그룹 이동 시 다른 도형들에 같은 변위 적용.
+ */
+function computeDragDelta(
+  ref: SelectedEntityRef,
+  newGeom: GeoJsonGeometry,
+  scene: SceneDraft,
+): [number, number] | null {
+  const oldGeom = readGeometryOf(ref, scene);
+  if (!oldGeom) return null;
+  const oldFirst = firstCoord(oldGeom);
+  const newFirst = firstCoord(newGeom);
+  if (!oldFirst || !newFirst) return null;
+  return [newFirst[0] - oldFirst[0], newFirst[1] - oldFirst[1]];
+}
+
+function firstCoord(g: GeoJsonGeometry): [number, number] | null {
+  if (g.type === 'Point') return g.coordinates as [number, number];
+  if (g.type === 'LineString') return g.coordinates[0] ?? null;
+  if (g.type === 'Polygon') return g.coordinates[0]?.[0] ?? null;
   return null;
 }
 

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import { Camera, MapPin, Smartphone } from 'lucide-react';
+import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
 
 const FLOW_STEPS = [
   '권한 동의 (시작하기 전)',
@@ -9,12 +11,14 @@ const FLOW_STEPS = [
 ];
 
 export default function MobileAppPage() {
+  const [connectOpen, setConnectOpen] = useState(false);
   return (
     <div className="h-full overflow-auto bg-muted/20 p-10">
       <div className="mx-auto flex max-w-6xl items-start justify-center gap-12">
         <PhoneMockup />
-        <InfoCard />
+        <InfoCard onConnectClick={() => setConnectOpen(true)} />
       </div>
+      <MobileConnectModal open={connectOpen} onClose={() => setConnectOpen(false)} />
     </div>
   );
 }
@@ -103,29 +107,40 @@ function PermissionRow({
   );
 }
 
-function InfoCard() {
+function InfoCard({ onConnectClick }: { onConnectClick: () => void }) {
   return (
-    <section className="w-[360px] shrink-0 rounded-2xl border bg-background p-6 shadow-sm">
-      <header className="flex items-center gap-2">
-        <Smartphone className="h-5 w-5 text-foreground" strokeWidth={1.8} />
-        <h3 className="text-base font-bold">모바일 앱 프로토타입</h3>
-      </header>
+    <div className="flex w-[360px] shrink-0 flex-col gap-3">
+      <section className="rounded-2xl border bg-background p-6 shadow-sm">
+        <header className="flex items-center gap-2">
+          <Smartphone className="h-5 w-5 text-foreground" strokeWidth={1.8} />
+          <h3 className="text-base font-bold">모바일 앱 프로토타입</h3>
+        </header>
 
-      <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">
-        비전문가인 소상공인이 현장에서 간편하게 와이파이 품질을 측정하고
-        가구를 스캔할 수 있도록 돕는 Android 컴패니언 앱 디자인입니다.
-      </p>
+        <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">
+          비전문가인 소상공인이 현장에서 간편하게 와이파이 품질을 측정하고
+          가구를 스캔할 수 있도록 돕는 Android 컴패니언 앱 디자인입니다.
+        </p>
 
-      <h4 className="mt-6 text-sm font-semibold">주요 화면 플로우</h4>
-      <ul className="mt-3 space-y-2 text-[13px] text-foreground/80">
-        {FLOW_STEPS.map((step) => (
-          <li key={step} className="flex items-start gap-2">
-            <span className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/60" />
-            <span>{step}</span>
-          </li>
-        ))}
-      </ul>
-    </section>
+        <h4 className="mt-6 text-sm font-semibold">주요 화면 플로우</h4>
+        <ul className="mt-3 space-y-2 text-[13px] text-foreground/80">
+          {FLOW_STEPS.map((step) => (
+            <li key={step} className="flex items-start gap-2">
+              <span className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/60" />
+              <span>{step}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <button
+        type="button"
+        onClick={onConnectClick}
+        className="inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+      >
+        <Smartphone className="h-4 w-4" />
+        모바일 앱 연결
+      </button>
+    </div>
   );
 }
 

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -11,8 +11,11 @@ import {
   Trash2,
   Wifi,
 } from 'lucide-react';
+import { useMemo } from 'react';
 import { useAppStore } from '@/stores/app-store';
-import { useFloorVersions } from '@/hooks/use-scene-version';
+import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
+import { useAsset, useFloorAssets } from '@/hooks/use-assets';
+import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { useCreateRfRun, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
 import {
   useApCandidates,
@@ -27,7 +30,14 @@ import {
   SimulationHistory,
   type SimulationHistoryItem,
 } from '@/features/simulation/SimulationHistory';
+import {
+  DEFAULT_TX_POWER_DBM,
+  SimulationCanvas,
+  type PlacedAp,
+} from '@/features/simulation/SimulationCanvas';
+import { toast } from '@/stores/toast-store';
 import type { ApCandidate, ApLayout } from '@/types/ap-layout';
+import { cn } from '@/lib/utils';
 
 type SimulationState = 'idle' | 'running' | 'complete';
 
@@ -39,6 +49,29 @@ export default function SimulationPage() {
     versionsQuery.data?.find((v) => v.is_current) ?? versionsQuery.data?.[0] ?? null;
 
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
+
+  // 사용자가 배치한 AP 목록 + 추가 모드(true 면 다음 클릭이 새 AP 추가).
+  const [aps, setAps] = useState<PlacedAp[]>([]);
+  const [pendingAdd, setPendingAdd] = useState(false);
+
+  // 캔버스 배경으로 보여줄 확정 버전 상세 (rooms/walls/openings/objects 포함).
+  const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
+
+  // 배경 도면 이미지 — EditorPage 와 동일한 3단계 fallback.
+  const sourceAssetId = versionDetailQuery.data?.source_asset_id ?? null;
+  const sourceAssetQuery = useAsset(sourceAssetId);
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan');
+  const fallbackAsset = useMemo(() => {
+    const list = floorAssetsQuery.data ?? [];
+    if (list.length === 0) return null;
+    return [...list].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
+  }, [floorAssetsQuery.data]);
+  const localImage = useLocalFloorplanImage(floorId);
+  const backgroundImageUrl =
+    sourceAssetQuery.data?.storage_url ??
+    fallbackAsset?.storage_url ??
+    localImage ??
+    null;
 
   const createRfRun = useCreateRfRun();
   const rfRunPoll = useRfRun(activeRunId);
@@ -54,10 +87,29 @@ export default function SimulationPage() {
 
   const handleStart = () => {
     if (!currentVersion) return;
+    if (aps.length === 0) {
+      toast.info('AP 를 1개 이상 배치해주세요', '캔버스 우측의 "AP 추가하기" 에서 종류를 선택하고 클릭하세요.');
+      return;
+    }
     createRfRun.mutate(
       {
         scene_version_id: currentVersion.id,
         run_type: 'forward',
+        access_points: aps.map((ap) => ({
+          id: ap.id,
+          x_m: ap.x_m,
+          y_m: ap.y_m,
+          z_m: ap.z_m,
+        })),
+        simulation: {
+          frequency_hz: 2.4e9,
+          tx_power_dbm: DEFAULT_TX_POWER_DBM,
+          resolution_m: 0.5,
+          measurement_plane_z_m: 1.0,
+          max_depth: 3,
+          samples_per_tx: 100_000,
+          seed: 42,
+        },
       },
       { onSuccess: (data) => setActiveRunId(data.id) },
     );
@@ -66,6 +118,12 @@ export default function SimulationPage() {
   const handleReset = () => {
     setActiveRunId(null);
   };
+
+  const handleAddAp = (ap: PlacedAp) => setAps((prev) => [...prev, ap]);
+  const handleMoveAp = (id: string, x: number, y: number) =>
+    setAps((prev) => prev.map((a) => (a.id === id ? { ...a, x_m: x, y_m: y } : a)));
+  const handleRemoveAp = (id: string) =>
+    setAps((prev) => prev.filter((a) => a.id !== id));
 
   // 메트릭 추출 (백엔드가 metrics_json 안에 다양한 키로 넣을 수 있어 유연하게)
   const metrics = parseMetrics(
@@ -97,6 +155,7 @@ export default function SimulationPage() {
         state={state}
         hasVersion={!!currentVersion}
         isStarting={createRfRun.isPending}
+        apsCount={aps.length}
         onStart={handleStart}
         onReset={handleReset}
       />
@@ -117,11 +176,34 @@ export default function SimulationPage() {
         />
       ) : (
         <div className="mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
-          <div className="min-h-0 rounded-2xl border bg-background p-6 shadow-sm">
-            <SimulationVisualization
-              state={state}
-              mapUrl={rfMapsQuery.data?.[0]?.storage_url}
-            />
+          <div className="relative min-h-0 overflow-hidden rounded-2xl border bg-background shadow-sm">
+            {state === 'idle' ? (
+              <>
+                <CanvasModeBar apsCount={aps.length} />
+                <SimulationCanvas
+                  sceneVersion={versionDetailQuery.data}
+                  backgroundImageUrl={backgroundImageUrl}
+                  aps={aps}
+                  onAdd={handleAddAp}
+                  onMove={handleMoveAp}
+                  onRemove={handleRemoveAp}
+                  pending={pendingAdd}
+                  onClearPending={() => setPendingAdd(false)}
+                />
+                <ApAddPanel
+                  active={pendingAdd}
+                  onToggle={() => setPendingAdd((v) => !v)}
+                  disabled={aps.length >= 8}
+                />
+              </>
+            ) : (
+              <div className="h-full p-6">
+                <SimulationVisualization
+                  state={state}
+                  mapUrl={rfMapsQuery.data?.[0]?.storage_url}
+                />
+              </div>
+            )}
           </div>
 
           <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
@@ -144,16 +226,93 @@ export default function SimulationPage() {
   );
 }
 
+/** 캔버스 좌상단 모드 안내. */
+function CanvasModeBar({ apsCount }: { apsCount: number }) {
+  return (
+    <div className="pointer-events-none absolute left-4 top-4 z-10 flex items-center gap-2 rounded-full border bg-card/95 px-3 py-1.5 text-xs shadow-sm backdrop-blur">
+      <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Play className="h-2.5 w-2.5 fill-current" />
+      </span>
+      <span className="font-semibold">AP 배치 모드</span>
+      <span className="text-muted-foreground">
+        — 우측 "AP 추가" 누르고 도면을 클릭하세요 ({apsCount}/8 · 백엔드 최대 8개)
+      </span>
+    </div>
+  );
+}
+
+/** 캔버스 우상단 "AP 추가하기" 토글 패널.
+ *  active=true (배치 모드) 이면 작은 칩으로 축소돼서 우상단 모서리 클릭 가능하게 함.
+ */
+function ApAddPanel({
+  active,
+  onToggle,
+  disabled,
+}: {
+  active: boolean;
+  onToggle: () => void;
+  disabled: boolean;
+}) {
+  if (active) {
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        title="클릭하여 배치 모드 취소"
+        className="absolute right-4 top-4 z-10 inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary/10 px-3 py-1.5 text-[11px] font-medium text-primary shadow-sm backdrop-blur hover:bg-primary/20"
+      >
+        <span
+          className="flex h-4 w-4 items-center justify-center rounded-full text-white"
+          style={{ backgroundColor: 'oklch(0.55 0.22 254)' }}
+        >
+          <Wifi className="h-2.5 w-2.5" />
+        </span>
+        도면 클릭으로 배치 · 취소
+      </button>
+    );
+  }
+
+  return (
+    <div className="absolute right-4 top-4 z-10 w-32 rounded-xl border bg-card p-3 shadow-md">
+      <p className="mb-2 text-center text-xs font-semibold text-muted-foreground">
+        AP 추가하기
+      </p>
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={disabled}
+        className={cn(
+          'flex w-full flex-col items-center gap-1.5 rounded-lg border bg-background p-2 text-[11px] font-medium transition-colors hover:bg-accent',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+      >
+        <span
+          className="flex h-9 w-9 items-center justify-center rounded-full text-white"
+          style={{ backgroundColor: 'oklch(0.55 0.22 254)' }}
+        >
+          <Wifi className="h-4 w-4" />
+        </span>
+        AP 추가
+      </button>
+      {disabled && (
+        <p className="mt-2 text-center text-[10px] text-destructive">최대 8개</p>
+      )}
+    </div>
+  );
+}
+
 function PageHeader({
   state,
   hasVersion,
   isStarting,
+  apsCount,
   onStart,
   onReset,
 }: {
   state: SimulationState;
   hasVersion: boolean;
   isStarting: boolean;
+  apsCount: number;
   onStart: () => void;
   onReset: () => void;
 }) {
@@ -171,7 +330,12 @@ function PageHeader({
           <button
             type="button"
             onClick={onStart}
-            disabled={!hasVersion || isStarting}
+            disabled={!hasVersion || isStarting || apsCount === 0}
+            title={
+              apsCount === 0
+                ? 'AP 를 1개 이상 배치해주세요'
+                : '시뮬레이션 실행'
+            }
             className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Play className="h-4 w-4 fill-current" />

--- a/frontend/src/types/rf.ts
+++ b/frontend/src/types/rf.ts
@@ -9,9 +9,33 @@ export type RfRunStatus =
   | 'failed'
   | string;
 
+/** §13.1 RF 시뮬레이션 access point. 1~8 개. */
+export interface AccessPointDTO {
+  id: string;
+  x_m: number;
+  y_m: number;
+  z_m: number;
+}
+
+/** §13.1 RF 시뮬레이션 파라미터. SageMaker 입력. */
+export interface RfSimulationParams {
+  frequency_hz: number;
+  tx_power_dbm: number;
+  resolution_m?: number;
+  measurement_plane_z_m?: number;
+  max_depth?: number;
+  samples_per_tx?: number;
+  seed?: number;
+}
+
 export interface RfRunCreate {
   scene_version_id: UUID;
   run_type?: string;
+  /** access_points + simulation 둘 다 있으면 SageMaker 실제 호출. */
+  access_points?: AccessPointDTO[];
+  simulation?: RfSimulationParams;
+  metadata?: Record<string, unknown>;
+  /** Legacy 호환 (deprecated). */
   request_json?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
- 시뮬레이션: 도면 위 AP 클릭 배치, 추가 모드 시 패널 축소
- 모바일 앱 페이지: 헤더의 "모바일 앱 연결" 버튼을 카드 하단 파란 버튼으로 이동
- 객체 종류 옵션을 DB 실측 5개로 축소 (furniture/bathroom/stairs/sofa/table)
- 객체 드래그 시 벽 끝점 스냅 비활성화 (박스 건물 밖 이탈 방지)
- 확정 카드 등장 fade-in 애니메이션 + key 로 토글 시 재발화
- 문/창문 라벨 오프셋 0.22m → 0.17m