### PR TITLE
feat: AP 배치 CRUD API 추가 (#62)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -65,6 +65,8 @@ class ErrorCode(StrEnum):
     INVALID_RF_RUN_STATUS = "INVALID_RF_RUN_STATUS"
     SCENE_VERSION_EXPORT_FAILED = "SCENE_VERSION_EXPORT_FAILED"
 
+    AP_LAYOUT_NOT_FOUND = "AP_LAYOUT_NOT_FOUND"
+
 
 class AppError(Exception):
     def __init__(self, code: ErrorCode, message: str, status_code: int):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.ap_layout import ApLayout
 from app.models.asset import Asset
 from app.models.draft_object import DraftObject
 from app.models.draft_opening import DraftOpening
@@ -48,5 +49,6 @@ __all__ = [
     "MeasurementLink",
     "MeasurementSession",
     "MeasurementPoint",
+    "ApLayout",
 ]
 

--- a/backend/app/models/ap_layout.py
+++ b/backend/app/models/ap_layout.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from geoalchemy2 import Geometry
+from sqlalchemy import DateTime, ForeignKey, Index, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ApLayout(Base):
+    __tablename__ = "ap_layouts"
+    __table_args__ = (
+        Index("idx_ap_layouts_rf_run", "rf_run_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    rf_run_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("rf_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    ap_name: Mapped[str] = mapped_column(String(60), nullable=False)
+    vendor_model: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    point_geom = mapped_column(Geometry("POINT", srid=0), nullable=False)
+    z_m: Mapped[Decimal] = mapped_column(Numeric(6, 3), nullable=False)
+    azimuth_deg: Mapped[Decimal] = mapped_column(
+        Numeric(6, 2), nullable=False, server_default=text("0")
+    )
+    tilt_deg: Mapped[Decimal] = mapped_column(
+        Numeric(6, 2), nullable=False, server_default=text("0")
+    )
+    power_dbm: Mapped[Decimal | None] = mapped_column(Numeric(6, 2), nullable=True)
+    channel_info_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        onupdate=text("now()"),
+    )

--- a/backend/app/routers/ap_layouts.py
+++ b/backend/app/routers/ap_layouts.py
@@ -1,0 +1,93 @@
+"""AP Layouts 라우터 (§14.3, §14.4)"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.ap_layout import (
+    ApLayoutCreate,
+    ApLayoutResponse,
+    ApLayoutUpdate,
+)
+from app.services import ap_layout_service
+
+
+router = APIRouter(prefix="/ap-layouts", tags=["ap-layouts"])
+rf_run_router = APIRouter(prefix="/rf-runs", tags=["ap-layouts"])
+
+
+@rf_run_router.get(
+    "/{rf_run_id}/ap-layouts",
+    response_model=list[ApLayoutResponse],
+    summary="RF Run 의 AP 배치 목록",
+)
+def list_ap_layouts(
+    rf_run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[ApLayoutResponse]:
+    return ap_layout_service.list_by_rf_run(
+        db, rf_run_id=rf_run_id, user=current_user
+    )
+
+
+@router.post(
+    "",
+    response_model=ApLayoutResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="AP 배치 확정",
+)
+def create_ap_layout(
+    payload: ApLayoutCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ApLayoutResponse:
+    return ap_layout_service.create_layout(db, payload=payload, user=current_user)
+
+
+@router.get(
+    "/{layout_id}",
+    response_model=ApLayoutResponse,
+    summary="AP 배치 단건 조회",
+)
+def get_ap_layout(
+    layout_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ApLayoutResponse:
+    return ap_layout_service.get_layout(db, layout_id=layout_id, user=current_user)
+
+
+@router.patch(
+    "/{layout_id}",
+    response_model=ApLayoutResponse,
+    summary="AP 배치 수정",
+)
+def update_ap_layout(
+    payload: ApLayoutUpdate,
+    layout_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ApLayoutResponse:
+    return ap_layout_service.update_layout(
+        db, layout_id=layout_id, payload=payload, user=current_user
+    )
+
+
+@router.delete(
+    "/{layout_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="AP 배치 삭제",
+)
+def delete_ap_layout(
+    layout_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    ap_layout_service.delete_layout(db, layout_id=layout_id, user=current_user)
+    return None

--- a/backend/app/schemas/ap_layout.py
+++ b/backend/app/schemas/ap_layout.py
@@ -1,0 +1,51 @@
+"""AP Layout DTO (§14)"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ApLayoutCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rf_run_id: UUID
+    ap_name: str = Field(..., min_length=1, max_length=60)
+    vendor_model: Optional[str] = Field(default=None, max_length=60)
+    point_geom: dict[str, Any]
+    z_m: float
+    azimuth_deg: float = 0
+    tilt_deg: float = 0
+    power_dbm: Optional[float] = None
+    channel_info_json: dict[str, Any] = Field(default_factory=dict)
+
+
+class ApLayoutUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ap_name: Optional[str] = Field(default=None, min_length=1, max_length=60)
+    vendor_model: Optional[str] = Field(default=None, max_length=60)
+    point_geom: Optional[dict[str, Any]] = None
+    z_m: Optional[float] = None
+    azimuth_deg: Optional[float] = None
+    tilt_deg: Optional[float] = None
+    power_dbm: Optional[float] = None
+    channel_info_json: Optional[dict[str, Any]] = None
+
+
+class ApLayoutResponse(BaseModel):
+    id: UUID
+    rf_run_id: UUID
+    ap_name: str
+    vendor_model: Optional[str] = None
+    point_geom: Optional[dict[str, Any]] = None
+    z_m: Decimal
+    azimuth_deg: Decimal
+    tilt_deg: Decimal
+    power_dbm: Optional[Decimal] = None
+    channel_info_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/ap_layout_service.py
+++ b/backend/app/services/ap_layout_service.py
@@ -1,0 +1,160 @@
+"""AP Layout CRUD (§14.3, §14.4)"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.core.geom import geojson_to_wkb, wkb_to_geojson
+from app.models.ap_layout import ApLayout
+from app.models.project import Project
+from app.models.rf_run import RfRun
+from app.models.user import User
+from app.schemas.ap_layout import (
+    ApLayoutCreate,
+    ApLayoutResponse,
+    ApLayoutUpdate,
+)
+
+
+def _to_response(layout: ApLayout) -> ApLayoutResponse:
+    return ApLayoutResponse(
+        id=layout.id,
+        rf_run_id=layout.rf_run_id,
+        ap_name=layout.ap_name,
+        vendor_model=layout.vendor_model,
+        point_geom=wkb_to_geojson(layout.point_geom),
+        z_m=layout.z_m,
+        azimuth_deg=layout.azimuth_deg,
+        tilt_deg=layout.tilt_deg,
+        power_dbm=layout.power_dbm,
+        channel_info_json=layout.channel_info_json or {},
+        created_at=layout.created_at,
+        updated_at=layout.updated_at,
+    )
+
+
+def _get_owned_rf_run(db: Session, rf_run_id: UUID, user: User) -> RfRun:
+    rr = db.execute(
+        select(RfRun)
+        .join(Project, RfRun.project_id == Project.id)
+        .where(
+            RfRun.id == str(rf_run_id),
+            Project.owner_user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if rr is None:
+        raise AppError(
+            ErrorCode.RF_RUN_NOT_FOUND,
+            "RF run not found.",
+            status_code=404,
+        )
+    return rr
+
+
+def _get_owned_layout(db: Session, layout_id: UUID, user: User) -> ApLayout:
+    layout = db.execute(
+        select(ApLayout)
+        .join(RfRun, ApLayout.rf_run_id == RfRun.id)
+        .join(Project, RfRun.project_id == Project.id)
+        .where(
+            ApLayout.id == str(layout_id),
+            Project.owner_user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if layout is None:
+        raise AppError(
+            ErrorCode.AP_LAYOUT_NOT_FOUND,
+            "AP layout not found.",
+            status_code=404,
+        )
+    return layout
+
+
+def list_by_rf_run(
+    db: Session, rf_run_id: UUID, user: User
+) -> list[ApLayoutResponse]:
+    rr = _get_owned_rf_run(db, rf_run_id, user)
+    rows = (
+        db.execute(
+            select(ApLayout)
+            .where(ApLayout.rf_run_id == rr.id)
+            .order_by(ApLayout.created_at.asc())
+        )
+        .scalars()
+        .all()
+    )
+    return [_to_response(r) for r in rows]
+
+
+def get_layout(db: Session, layout_id: UUID, user: User) -> ApLayoutResponse:
+    return _to_response(_get_owned_layout(db, layout_id, user))
+
+
+def create_layout(
+    db: Session, payload: ApLayoutCreate, user: User
+) -> ApLayoutResponse:
+    rr = _get_owned_rf_run(db, payload.rf_run_id, user)
+
+    layout = ApLayout(
+        rf_run_id=rr.id,
+        ap_name=payload.ap_name,
+        vendor_model=payload.vendor_model,
+        point_geom=geojson_to_wkb(payload.point_geom, "Point", "point_geom"),
+        z_m=payload.z_m,
+        azimuth_deg=payload.azimuth_deg,
+        tilt_deg=payload.tilt_deg,
+        power_dbm=payload.power_dbm,
+        channel_info_json=payload.channel_info_json or {},
+    )
+    db.add(layout)
+    try:
+        db.commit()
+        db.refresh(layout)
+    except Exception:
+        db.rollback()
+        raise
+    return _to_response(layout)
+
+
+def update_layout(
+    db: Session, layout_id: UUID, payload: ApLayoutUpdate, user: User
+) -> ApLayoutResponse:
+    layout = _get_owned_layout(db, layout_id, user)
+    data = payload.model_dump(exclude_unset=True)
+
+    if "point_geom" in data and data["point_geom"] is not None:
+        layout.point_geom = geojson_to_wkb(
+            data["point_geom"], "Point", "point_geom"
+        )
+    for field in (
+        "ap_name",
+        "vendor_model",
+        "z_m",
+        "azimuth_deg",
+        "tilt_deg",
+        "power_dbm",
+        "channel_info_json",
+    ):
+        if field in data:
+            setattr(layout, field, data[field])
+
+    try:
+        db.commit()
+        db.refresh(layout)
+    except Exception:
+        db.rollback()
+        raise
+    return _to_response(layout)
+
+
+def delete_layout(db: Session, layout_id: UUID, user: User) -> None:
+    layout = _get_owned_layout(db, layout_id, user)
+    db.delete(layout)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,10 @@ from app.routers.material_hypotheses import (
 )
 from app.routers.rf_runs import router as rf_runs_router
 from app.routers.rf_jobs import router as rf_jobs_router
+from app.routers.ap_layouts import (
+    router as ap_layouts_router,
+    rf_run_router as rf_run_ap_layouts_router,
+)
 from app.routers.jobs import router as jobs_router
 from app.routers.floorplan_jobs import router as floorplan_jobs_router
 from app.services.job_poller import job_poller_lifespan
@@ -117,5 +121,7 @@ app.include_router(wall_hypotheses_router)
 app.include_router(hypotheses_router)
 app.include_router(rf_runs_router)
 app.include_router(rf_jobs_router)
+app.include_router(ap_layouts_router)
+app.include_router(rf_run_ap_layouts_router)
 app.include_router(jobs_router)
 app.include_router(floorplan_jobs_router)

--- a/backend/migrations/versions/20260516_0007_add_ap_tables.py
+++ b/backend/migrations/versions/20260516_0007_add_ap_tables.py
@@ -1,0 +1,93 @@
+"""rebuild ap_layouts per spec §14.3/14.4 (AP recommendation 제외)
+
+기존 initial_schema 의 ap_layouts / ap_candidates / ap_layout_points 는
+명세와 구조가 달라 (layout=컨테이너, rf_run 미연결) 한 번도 사용 안 됨.
+명세 §14.3/14.4 (layout=AP 개별, rf_run 연결) 로 재구성.
+
+명세 §14.1/14.2 의 ap_candidates (자동 추천) 는 본 프로젝트 워크플로
+(사용자 수동 배치 → 시뮬 → 보고 옮기기) 에 맞지 않아 제외.
+
+Revision ID: 20260516_0007
+Revises: 20260511_0006
+Create Date: 2026-05-16 00:00:00
+
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from geoalchemy2 import Geometry
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260516_0007"
+down_revision: Union[str, Sequence[str], None] = "20260511_0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── 기존 더미 테이블 정리 (한 번도 안 쓰임) ─────────────────────────
+    op.execute("DROP TABLE IF EXISTS ap_layout_points CASCADE")
+    op.execute("DROP TABLE IF EXISTS ap_layouts CASCADE")
+    op.execute("DROP TABLE IF EXISTS ap_candidates CASCADE")
+
+    # ── §14.3/14.4 ap_layouts (AP 개별 배치) ──────────────────────────
+    op.create_table(
+        "ap_layouts",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "rf_run_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("rf_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("ap_name", sa.String(length=60), nullable=False),
+        sa.Column("vendor_model", sa.String(length=60), nullable=True),
+        sa.Column("point_geom", Geometry("POINT", srid=0), nullable=False),
+        sa.Column("z_m", sa.Numeric(6, 3), nullable=False),
+        sa.Column(
+            "azimuth_deg",
+            sa.Numeric(6, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "tilt_deg",
+            sa.Numeric(6, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("power_dbm", sa.Numeric(6, 2), nullable=True),
+        sa.Column(
+            "channel_info_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("idx_ap_layouts_rf_run", "ap_layouts", ["rf_run_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ap_layouts_rf_run", table_name="ap_layouts")
+    op.drop_table("ap_layouts")
+    # 기존 더미 테이블 복원은 하지 않음 (사용 안 됨)


### PR DESCRIPTION
## 요약
명세 §14.3/14.4 AP 배치 CRUD API 구현. 사용자가 배치한 AP를 DB에 영속화해서 새로고침/재시뮬 시에도 유지되도록.

> **명세 §14.1/14.2 (AP 후보 자동 추천) 제외.** 본 프로젝트 워크플로는 사용자 수동 배치 → 시뮬 → 결과 보고 옮기기 → 재시뮬 이라 추천 기능 불필요. 프론트 측 추천 UI 정리는 별도 협의.


## 변경 사항

### 신규 엔드포인트 (5개)
- `POST /ap-layouts` — AP 배치 추가
- `GET /ap-layouts/{layout_id}` — 단건 조회
- `PATCH /ap-layouts/{layout_id}` — 부분 수정
- `DELETE /ap-layouts/{layout_id}` — 삭제
- `GET /rf-runs/{rf_run_id}/ap-layouts` — RF Run별 목록

### DB
- `ap_layouts` 테이블 신규 (rf_run_id FK CASCADE, point_geom, z_m, azimuth/tilt/power, channel_info_json 등)
- 초기 스키마의 더미 `ap_layouts` / `ap_candidates` / `ap_layout_points` (모델/서비스/라우터 없이 만들어져만 있던 사용 안 된 테이블) drop 후 명세 구조로 재구성
- 마이그레이션: `20260516_0007_add_ap_tables`

### 파일
- 신규: `models/ap_layout.py`, `schemas/ap_layout.py`, `services/ap_layout_service.py`, `routers/ap_layouts.py`, `migrations/.../20260516_0007_add_ap_tables.py`
- 수정: `main.py`, `models/__init__.py`, `core/errors.py` (AP_LAYOUT_NOT_FOUND 추가)

## 테스트
로컬에서 시나리오 검증 완료:
- [x] POST 2건 → GET 목록 2건
- [x] GET 단건
- [x] PATCH (이름/좌표/전력 변경 → `updated_at` 갱신)
- [x] DELETE (204) → 목록 1건으로 감소
- [x] 권한: 타 유저 토큰으로 접근 → 404
- [x] 추천 엔드포인트 제거 확인: `POST /ap-candidates/generate` → 404

## 후속 (이번 PR 범위 외)
- `POST /rf-runs` 호출 시 백엔드가 `ap_layouts` 를 읽어와 SageMaker 페이로드에 자동 주입 (현재는 프론트가 직접 전송)
- 프론트의 AP 추천 UI (`useApCandidates`, "후보 생성" 버튼) 제거 — 친구와 협의