### PR TITLE
fix: 버전 전환 UX + 캔버스 viewBox 고정 외 기타 등등 이것저것

### DIFF
--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -36,6 +36,11 @@ function extendBounds(b: Bounds, x: number, y: number) {
   if (y > b.maxY) b.maxY = y;
 }
 
+/**
+ * 캔버스 viewBox 는 도면 구조(rooms/walls/openings) 만 기준으로 계산.
+ * 객체(가구) 는 캔버스 밖으로 이동될 수 있어 viewBox 에 포함 안 함 — 캔버스가
+ * 무한 확장되는 걸 방지. 밖으로 나간 가구는 그냥 잘려 보이게.
+ */
 function computeViewBox(draft: SceneDraft): { x: number; y: number; w: number; h: number } {
   const b = emptyBounds();
   for (const room of draft.rooms) {
@@ -51,19 +56,6 @@ function computeViewBox(draft: SceneDraft): { x: number; y: number; w: number; h
   for (const op of draft.openings) {
     const g = parseGeometry(op.line_geom);
     if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
-  }
-  for (const obj of draft.objects) {
-    const g = parseGeometry(obj.point_geom);
-    if (g?.type !== 'Point') continue;
-    const [x, y] = g.coordinates;
-    // 객체는 박스(W×H) 로 렌더링되므로 박스 모서리까지 bounds 에 포함.
-    const meta = (obj.metadata_json ?? {}) as Record<string, unknown>;
-    const w =
-      typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
-    const h =
-      typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
-    extendBounds(b, x - w / 2, y - h / 2);
-    extendBounds(b, x + w / 2, y + h / 2);
   }
   if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
   const w = b.maxX - b.minX || 1;
@@ -548,7 +540,15 @@ export function DraftSceneCanvas({
   onCreate,
   backgroundImageUrl,
 }: Props) {
-  const vb = computeViewBox(draft);
+  // viewBox 는 draft.id 가 바뀔 때만 재계산 → 같은 draft 안에서 도형이 줄거나, 객체가
+  // 캔버스 밖으로 이동해도 캔버스 자체는 절대 안 변함 (수축·확장 모두 안 함).
+  // 객체가 도면 밖으로 나가면 잘려 보이지만 캔버스 비율은 안정적.
+  const [vb, setVb] = useState(() => computeViewBox(draft));
+  const [prevDraftId, setPrevDraftId] = useState(draft.id);
+  if (prevDraftId !== draft.id) {
+    setPrevDraftId(draft.id);
+    setVb(computeViewBox(draft));
+  }
   const svgRef = useRef<SVGSVGElement>(null);
   const [drag, setDrag] = useState<DragState | null>(null);
   const [creating, setCreating] = useState<CreatingState>(null);
@@ -733,16 +733,44 @@ export function DraftSceneCanvas({
     // ─ shape 드래그: 엔티티 통째 이동 — 기준점을 벽 끝점/선분에 스냅 ─
     {
       const rawDelta: Coord = [raw[0] - drag.startSvg[0], raw[1] - drag.startSvg[1]];
-      const { delta, snapPoint } = computeShapeSnapDelta(
+      const { delta: snappedDelta, snapPoint } = computeShapeSnapDelta(
         draft,
         drag.ref,
         rawDelta,
         wallAnchors,
       );
+      // 객체(Point) 는 캔버스 viewBox 밖으로 못 나가도록 박스 모서리 기준 clamp.
+      // 벽/방/문창 등은 사용자가 의도적으로 외곽으로 끌 수 있어 clamp 안 함.
+      const delta = clampObjectDelta(snappedDelta, drag.ref, draft, vb);
       setSnapIndicator(snapPoint);
       setDrag((prev) => (prev ? { ...prev, delta } : null));
     }
   };
+
+  /** 객체가 viewBox 안에 머무르도록 delta clamp. 객체가 아니면 그대로 통과. */
+  function clampObjectDelta(
+    delta: Coord,
+    ref: SelectedEntityRef,
+    scene: SceneDraft,
+    vbox: { x: number; y: number; w: number; h: number },
+  ): Coord {
+    if (ref.kind !== 'object') return delta;
+    const obj = scene.objects.find((o) => o.id === ref.id);
+    const g = parseGeometry(obj?.point_geom);
+    if (g?.type !== 'Point') return delta;
+    const meta = (obj?.metadata_json ?? {}) as Record<string, unknown>;
+    const w = typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+    const h = typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+    const [cx, cy] = g.coordinates;
+    // 박스 중심이 들어갈 수 있는 범위: viewBox 안에 박스 전체가 들어가도록.
+    const minCx = vbox.x + w / 2;
+    const maxCx = vbox.x + vbox.w - w / 2;
+    const minCy = vbox.y + h / 2;
+    const maxCy = vbox.y + vbox.h - h / 2;
+    const clampedX = Math.max(minCx, Math.min(maxCx, cx + delta[0]));
+    const clampedY = Math.max(minCy, Math.min(maxCy, cy + delta[1]));
+    return [clampedX - cx, clampedY - cy];
+  }
 
   const handleSvgPointerUp = (e: React.PointerEvent<SVGSVGElement>) => {
     if (!drag) return;

--- a/frontend/src/features/editor/PromotedCard.tsx
+++ b/frontend/src/features/editor/PromotedCard.tsx
@@ -75,7 +75,12 @@ export function PromotedCard({ version, versions, onReupload }: PromotedCardProp
         변경 이력 {totalPatchLogs} 건 (확정 후 수정 시 기록됩니다)
       </div>
 
-      {versions && versions.length > 1 && <VersionHistoryPanel versions={versions} />}
+      {versions && versions.length > 1 && (
+        <VersionHistoryPanel
+          versions={versions}
+          onSwitched={() => setMinimized(true)}
+        />
+      )}
 
       <div className="mt-5 flex flex-wrap justify-end gap-2">
         <button

--- a/frontend/src/features/editor/VersionHistoryPanel.tsx
+++ b/frontend/src/features/editor/VersionHistoryPanel.tsx
@@ -9,6 +9,8 @@ import type { SceneVersion } from '@/types/scene';
 
 interface Props {
   versions: SceneVersion[];
+  /** 버전 전환 성공 후 호출 — 상위에서 PromotedCard 를 최소화시키는 데 사용. */
+  onSwitched?: () => void;
 }
 
 /**
@@ -16,7 +18,7 @@ interface Props {
  * - 클릭 → PATCH /scene-versions/{id}/set-current
  * - 휴지통 → DELETE /scene-versions/{id} (children · rf_runs · patch_logs cascade)
  */
-export function VersionHistoryPanel({ versions }: Props) {
+export function VersionHistoryPanel({ versions, onSwitched }: Props) {
   const [open, setOpen] = useState(false);
   const setCurrent = useSetCurrentVersion();
   const remove = useDeleteSceneVersion();
@@ -64,7 +66,11 @@ export function VersionHistoryPanel({ versions }: Props) {
                 <button
                   type="button"
                   disabled={v.is_current || isSwitching || isDeleting}
-                  onClick={() => setCurrent.mutate(v.id)}
+                  onClick={() =>
+                    setCurrent.mutate(v.id, {
+                      onSuccess: () => onSwitched?.(),
+                    })
+                  }
                   className={cn(
                     'flex flex-1 items-center justify-between gap-3 px-3 py-2 text-left text-xs transition-colors',
                     !v.is_current && 'hover:bg-muted/60 disabled:opacity-50',

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -53,6 +53,11 @@ function extendBounds(b: Bounds, x: number, y: number) {
   if (y > b.maxY) b.maxY = y;
 }
 
+/**
+ * 캔버스 viewBox 는 도면 구조(rooms/walls/openings) 만 기준으로 계산.
+ * 객체(가구/공간 박스) 는 건물 밖으로 삐져나갈 수 있어 viewBox 에서 제외 — 캔버스가
+ * 일그러지지 않도록 고정. 밖으로 나간 객체는 잘려 보이지만 캔버스 비율은 안정적.
+ */
 function computeViewBox(scene: SceneVersion | null | undefined): {
   x: number;
   y: number;
@@ -72,16 +77,6 @@ function computeViewBox(scene: SceneVersion | null | undefined): {
   for (const op of scene?.openings ?? []) {
     const g = parseGeometry(op.line_geom);
     if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
-  }
-  for (const obj of scene?.objects ?? []) {
-    const g = parseGeometry(obj.point_geom);
-    if (g?.type !== 'Point') continue;
-    const [x, y] = g.coordinates;
-    const meta = (obj.metadata_json ?? {}) as Record<string, unknown>;
-    const w = typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
-    const h = typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
-    extendBounds(b, x - w / 2, y - h / 2);
-    extendBounds(b, x + w / 2, y + h / 2);
   }
   if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
   const w = b.maxX - b.minX || 1;
@@ -107,7 +102,10 @@ export function SimulationCanvas({
   onClearPending,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const vb = useMemo(() => computeViewBox(sceneVersion), [sceneVersion]);
+  // viewBox 는 scene version id 가 바뀔 때만 재계산 → 같은 도면 안에서 도형이 변해도
+  // 캔버스가 자동 줌인/아웃 하지 않도록 고정.
+  const sceneId = sceneVersion?.id ?? null;
+  const vb = useMemo(() => computeViewBox(sceneVersion), [sceneId]);
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOffset, setDragOffset] = useState<Coord>([0, 0]);
 

--- a/frontend/src/hooks/use-scene-version.ts
+++ b/frontend/src/hooks/use-scene-version.ts
@@ -24,8 +24,10 @@ export function useSceneVersion(versionId: UUID | null) {
     queryKey: ['scene-version', versionId] as const,
     queryFn: () => sceneVersionApi.get(versionId as UUID),
     enabled: !!versionId,
-    // 버전 전환 시 새 detail 이 도착하기 전까지 이전 데이터를 유지 — 캔버스가 잠깐
-    // 비어 보이고 업로드 화면으로 떨어지는 현상 방지.
+    // 한 번 방문한 버전은 5분간 캐시 활용 → 다음 전환 시 즉시 표시.
+    staleTime: 5 * 60_000,
+    // 전환 중엔 이전 버전 데이터를 그대로 유지 → 캔버스가 빈 화면으로 떨어지지 않음.
+    // 삭제된 버전이 stale 데이터로 남는 부작용은 useDeleteSceneVersion 의 removeQueries 로 차단.
     placeholderData: keepPreviousData,
   });
 }
@@ -35,7 +37,10 @@ export function useDeleteSceneVersion() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (versionId: UUID) => sceneVersionApi.remove(versionId),
-    onSuccess: () => {
+    onSuccess: (_data, versionId) => {
+      // 삭제된 버전의 detail 캐시 자체를 제거 — invalidate 만 하면 stale 데이터가
+      // 다른 hook 의 placeholder 등에서 재사용될 수 있어 깨끗하게 지움.
+      qc.removeQueries({ queryKey: ['scene-version', versionId], exact: true });
       qc.invalidateQueries({ queryKey: ['scene-versions'] });
       qc.invalidateQueries({ queryKey: ['scene-version'] });
       qc.invalidateQueries({ queryKey: ['rf-runs'] });
@@ -80,11 +85,11 @@ export function useSetCurrentVersion() {
       toast.success(`버전 #${data.version_no} 으로 전환됨`, '이 버전을 기준으로 작업합니다.');
     },
     onSettled: () => {
-      // 전체 scene-version 관련 캐시 + 드래프트/패치로그도 같이 새로 고침.
+      // 리스트만 새로 받아오고 detail 캐시는 staleTime 안이면 그대로 활용.
+      // (set-current 는 detail 내용엔 영향 없고 is_current 플래그만 바꾸므로
+      // 굳이 무거운 detail 을 다시 fetch 할 필요 없음.)
       qc.invalidateQueries({ queryKey: ['scene-versions'] });
-      qc.invalidateQueries({ queryKey: ['scene-version'] });
       qc.invalidateQueries({ queryKey: ['scene-drafts'] });
-      qc.invalidateQueries({ queryKey: ['patch-logs'] });
     },
   });
 }

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -745,6 +745,14 @@ export default function EditorPage() {
                 onCreate={handleCreate}
                 backgroundImageUrl={backgroundImageUrl}
               />
+            ) : currentVersion ? (
+              // 버전이 선택돼있고 detail 로딩 중 — 파일 업로드 화면 대신 스피너.
+              <div className="flex flex-1 items-center justify-center bg-muted/30">
+                <div className="flex flex-col items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                  <p className="text-sm">버전 #{currentVersion.version_no} 도면 불러오는 중…</p>
+                </div>
+              </div>
             ) : (
               <CanvasArea
                 fileInputRef={fileInputRef}

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -235,7 +235,7 @@ function CanvasModeBar({ apsCount }: { apsCount: number }) {
       </span>
       <span className="font-semibold">AP 배치 모드</span>
       <span className="text-muted-foreground">
-        — 우측 "AP 추가" 누르고 도면을 클릭하세요 ({apsCount}/8 · 백엔드 최대 8개)
+        — 우측 "AP 추가" 누르고 도면을 클릭하세요 ({apsCount}/8)
       </span>
     </div>
   );


### PR DESCRIPTION
- 시뮬레이션: 도면 위 AP 클릭 배치, 추가 모드 시 패널 축소
- 모바일 앱 페이지: 헤더의 "모바일 앱 연결" 버튼을 카드 하단 파란 버튼으로 이동
- 객체 종류 옵션을 DB 실측 5개로 축소 (furniture/bathroom/stairs/sofa/table)
- 객체 드래그 시 벽 끝점 스냅 비활성화 (박스 건물 밖 이탈 방지)
- 확정 카드 등장 fade-in 애니메이션 + key 로 토글 시 재발화
- 문/창문 라벨 오프셋 0.22m → 0.17m
- 버전 전환 시 캔버스 깜박임 방지 (staleTime 5분 + keepPreviousData)
- set-current 의 detail 캐시 무효화 제거 → 같은 버전 재방문 즉시 표시
- 전환하기 누르면 PromotedCard 자동 최소화
- 캔버스 viewBox 를 draft.id 기준으로 고정 (그룹 리사이즈 결과 시각화)
- viewBox 계산에서 객체 제외 → 캔버스 무한 확장 방지
- 객체 드래그 시 viewBox 밖으로 못 나가게 clamp
- 버전 detail 로딩 중엔 파일 업로드 대신 스피너 표시
- 문/창문 라벨 오프셋 0.17m- - 