### PR TITLE
feat: Asset 저장소 S3 이관 + presigned 다운로드 API (#65)

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -12,9 +12,16 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.user import User
+from pydantic import BaseModel
+
 from app.schemas.asset import AssetResponse
 from app.schemas.scene_draft import AnalyzeFromAssetRequest, AnalyzeFromAssetResponse
 from app.services import asset_service, scene_draft_service
+
+
+class AssetDownloadUrlResponse(BaseModel):
+    url: str
+    expires_in: int
 
 
 
@@ -77,10 +84,26 @@ def get_asset(
     return AssetResponse.model_validate(asset)
 
 
+@assets_router.get(
+    "/{asset_id}/download-url",
+    response_model=AssetDownloadUrlResponse,
+    summary="자산 파일 presigned GET URL 발급 (S3)",
+)
+def get_asset_download_url(
+    asset_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> AssetDownloadUrlResponse:
+    url, expires_in = asset_service.get_asset_download_url(
+        db=db, asset_id=asset_id, user=current_user
+    )
+    return AssetDownloadUrlResponse(url=url, expires_in=expires_in)
+
+
 @assets_router.delete(
     "/{asset_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="자산 삭제 (DB row + 파일 시스템)",
+    summary="자산 삭제 (DB row + S3 객체)",
 )
 def delete_asset(
     asset_id: UUID = Path(...),

--- a/backend/app/services/_s3.py
+++ b/backend/app/services/_s3.py
@@ -1,0 +1,131 @@
+"""S3 공용 헬퍼.
+
+여기 helper 들은 sync (boto3 가 native sync) 라 FastAPI handler 에서 호출 시
+`await run_in_threadpool(...)` 으로 감싸야 이벤트 루프 안 막힘. 짧은 작업
+(presigned URL 생성, 작은 파일 upload/delete) 은 직접 호출해도 큰 문제 없음.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from app.core.aws import BOTO_CONFIG
+from app.core.errors import AppError, ErrorCode
+from app.core.settings import (
+    AWS_REGION,
+    AWS_S3_BUCKET,
+    RF_PRESIGNED_URL_EXPIRES_SECONDS,
+)
+
+
+@lru_cache(maxsize=1)
+def _client():
+    return boto3.client("s3", region_name=AWS_REGION, config=BOTO_CONFIG)
+
+
+def _require_bucket() -> str:
+    if not AWS_S3_BUCKET:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            "AWS_S3_BUCKET not configured.",
+            status_code=503,
+        )
+    return AWS_S3_BUCKET
+
+
+def split_s3_uri(uri: str) -> tuple[str, str]:
+    """s3://bucket/key/path → (bucket, 'key/path')."""
+    if not uri or not uri.startswith("s3://"):
+        raise ValueError(f"Not an s3:// URI: {uri!r}")
+    rest = uri[len("s3://") :]
+    bucket, _, key = rest.partition("/")
+    if not bucket or not key:
+        raise ValueError(f"Malformed S3 URI: {uri!r}")
+    return bucket, key
+
+
+def build_s3_uri(key: str, bucket: Optional[str] = None) -> str:
+    return f"s3://{bucket or _require_bucket()}/{key}"
+
+
+def upload_bytes(
+    key: str, body: bytes, content_type: Optional[str] = None
+) -> str:
+    """업로드 후 s3:// URI 반환."""
+    bucket = _require_bucket()
+    extra: dict = {}
+    if content_type:
+        extra["ContentType"] = content_type
+    try:
+        _client().put_object(Bucket=bucket, Key=key, Body=body, **extra)
+    except (BotoCoreError, ClientError) as exc:
+        raise AppError(
+            ErrorCode.FILE_STORAGE_ERROR,
+            f"Failed to upload to S3: {exc}",
+            status_code=502,
+        ) from exc
+    return build_s3_uri(key, bucket)
+
+
+def delete_object(s3_uri: str) -> None:
+    """S3 delete 는 idempotent (객체 없어도 200). 단, 권한/네트워크 에러는 raise."""
+    try:
+        bucket, key = split_s3_uri(s3_uri)
+    except ValueError:
+        return  # 옛 로컬 경로 등은 무시
+    try:
+        _client().delete_object(Bucket=bucket, Key=key)
+    except (BotoCoreError, ClientError) as exc:
+        raise AppError(
+            ErrorCode.FILE_STORAGE_ERROR,
+            f"Failed to delete S3 object: {exc}",
+            status_code=502,
+        ) from exc
+
+
+def download_bytes(s3_uri: str) -> bytes:
+    bucket, key = split_s3_uri(s3_uri)
+    try:
+        obj = _client().get_object(Bucket=bucket, Key=key)
+        return obj["Body"].read()
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404"):
+            raise AppError(
+                ErrorCode.UPLOADED_FILE_NOT_FOUND,
+                f"S3 object not found: {s3_uri}",
+                status_code=404,
+            ) from exc
+        raise AppError(
+            ErrorCode.FILE_STORAGE_ERROR,
+            f"Failed to read S3 object: {exc}",
+            status_code=502,
+        ) from exc
+    except BotoCoreError as exc:
+        raise AppError(
+            ErrorCode.FILE_STORAGE_ERROR,
+            f"Failed to read S3 object: {exc}",
+            status_code=502,
+        ) from exc
+
+
+def presigned_get_url(
+    s3_uri: str,
+    expires_seconds: int = RF_PRESIGNED_URL_EXPIRES_SECONDS,
+) -> str:
+    bucket, key = split_s3_uri(s3_uri)
+    try:
+        return _client().generate_presigned_url(
+            ClientMethod="get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=int(expires_seconds),
+        )
+    except (BotoCoreError, ClientError) as exc:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"Failed to generate presigned URL: {exc}",
+            status_code=502,
+        ) from exc

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -1,7 +1,6 @@
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 from typing import Optional
 from uuid import UUID, uuid4
@@ -11,11 +10,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
-from app.core.settings import ASSETS_DIR
+from app.core.settings import RF_PRESIGNED_URL_EXPIRES_SECONDS
 from app.models.asset import Asset
 from app.models.floor import Floor
 from app.models.project import Project
 from app.models.user import User
+from app.services import _s3
 
 ALLOWED_EXTENSIONS: dict[str, str] = {
     "png": "image/png",
@@ -107,30 +107,12 @@ def _validate_asset_type(asset_type: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 파일 저장 헬퍼
+# S3 키 빌더
 # ---------------------------------------------------------------------------
-def _build_storage_path(
+def _build_s3_key(
     project_id: str, floor_id: str, asset_id: UUID, ext: str
-) -> Path:
-    return Path(ASSETS_DIR) / str(project_id) / str(floor_id) / f"{asset_id}.{ext}"
-
-
-def _save_upload_to_disk(upload: UploadFile, dest: Path) -> int:
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with dest.open("wb") as f:
-            shutil.copyfileobj(upload.file, f)
-    except OSError as e:
-        if dest.exists():
-            dest.unlink(missing_ok=True)
-        raise AppError(
-            code=ErrorCode.FILE_STORAGE_ERROR,
-            message=f"Failed to save file: {e}",
-            status_code=500,
-        ) from e
-    finally:
-        upload.file.close()
-    return dest.stat().st_size
+) -> str:
+    return f"assets/{project_id}/{floor_id}/{asset_id}.{ext}"
 
 
 # ---------------------------------------------------------------------------
@@ -150,13 +132,17 @@ def create_asset(
     # 2. 권한 체크 (project_id 확보)
     floor, project = _get_owned_floor_or_404(db, floor_id, user)
 
-    # 3. 디스크 저장
+    # 3. 본문 읽기 + S3 업로드
     asset_id = uuid4()
-    storage_path = _build_storage_path(project.id, floor.id, asset_id, ext)
-    file_size = _save_upload_to_disk(upload, storage_path)
+    key = _build_s3_key(project.id, floor.id, asset_id, ext)
+    mime_type = ALLOWED_EXTENSIONS[ext]
+    try:
+        body = upload.file.read()
+    finally:
+        upload.file.close()
+    s3_uri = _s3.upload_bytes(key, body, content_type=mime_type)
 
     # 4. DB row 생성
-    mime_type = ALLOWED_EXTENSIONS[ext]
     asset = Asset(
         id=str(asset_id),
         project_id=project.id,
@@ -164,9 +150,9 @@ def create_asset(
         uploaded_by=user.id,
         asset_type=asset_type,
         source_format=ext,
-        storage_url=str(storage_path),
+        storage_url=s3_uri,
         mime_type=mime_type,
-        file_size_bytes=file_size,
+        file_size_bytes=len(body),
         metadata_json={},
     )
     try:
@@ -175,8 +161,8 @@ def create_asset(
         db.refresh(asset)
     except Exception:
         db.rollback()
-        if storage_path.exists():
-            storage_path.unlink(missing_ok=True)
+        # DB 실패 시 업로드된 S3 객체 정리
+        _s3.delete_object(s3_uri)
         raise
 
     return asset
@@ -204,10 +190,31 @@ def get_asset(db: Session, asset_id: UUID, user: User) -> Asset:
     return asset
 
 
+def get_asset_download_url(
+    db: Session, asset_id: UUID, user: User
+) -> tuple[str, int]:
+    """presigned GET URL + 만료 초 반환."""
+    asset, _floor, _project = _get_owned_asset_or_404(db, asset_id, user)
+    if not asset.storage_url or not asset.storage_url.startswith("s3://"):
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            "Asset is not on S3 (legacy local path).",
+            status_code=404,
+        )
+    url = _s3.presigned_get_url(
+        asset.storage_url, expires_seconds=RF_PRESIGNED_URL_EXPIRES_SECONDS
+    )
+    return url, RF_PRESIGNED_URL_EXPIRES_SECONDS
+
+
 def delete_asset(db: Session, asset_id: UUID, user: User) -> None:
     asset, _floor, _project = _get_owned_asset_or_404(db, asset_id, user)
+    s3_uri = asset.storage_url if asset.storage_url else None
 
-    storage_path = Path(asset.storage_url) if asset.storage_url else None
+    # S3 먼저 — 실패 시 (예: AccessDenied) DB 행 유지해서 재시도 가능.
+    # 성공 시 idempotent (S3 객체 없어도 200) 라 DB 만 남은 상태에서도 안전.
+    if s3_uri and s3_uri.startswith("s3://"):
+        _s3.delete_object(s3_uri)
 
     try:
         db.delete(asset)
@@ -215,9 +222,3 @@ def delete_asset(db: Session, asset_id: UUID, user: User) -> None:
     except Exception:
         db.rollback()
         raise
-
-    if storage_path is not None and storage_path.exists():
-        try:
-            storage_path.unlink()
-        except OSError:
-            pass

--- a/backend/app/services/measurement_service.py
+++ b/backend/app/services/measurement_service.py
@@ -154,8 +154,17 @@ def _floorplan_info_from_asset(db: Session, asset_id: str | None) -> FloorplanIn
     if asset is None:
         return FloorplanInfoDTO()
     metadata = asset.metadata_json or {}
+    # S3 객체면 presigned URL 발급 (모바일이 직접 다운로드 가능하게).
+    # 비-S3 (옛 로컬 경로) 면 그대로 노출 — 어차피 외부 접근 불가지만 fallback.
+    url = asset.storage_url
+    if url and url.startswith("s3://"):
+        from app.services import _s3
+        try:
+            url = _s3.presigned_get_url(url)
+        except Exception:
+            url = None
     return FloorplanInfoDTO(
-        url=asset.storage_url,
+        url=url,
         width_px=metadata.get("width_px"),
         height_px=metadata.get("height_px"),
         scale_m_per_px=metadata.get("scale_m_per_px"),

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -280,42 +280,39 @@ async def analyze_from_asset(
     /upload/floorplan/analyze 와 동일하게 Job 패턴 사용 → 202 응답 + job_id.
     완료 조회는 GET /floorplan-jobs/{job_id}.
     """
-    from pathlib import Path
-
+    from app.services import _s3
     from app.services.asset_service import _get_owned_asset_or_404
     from app.services.floorplan_job_service import submit_floorplan_analysis
 
     asset, _floor, _project = _get_owned_asset_or_404(db, asset_id, current_user)
 
-    storage_path = Path(asset.storage_url)
-    if not storage_path.exists():
+    if not asset.storage_url or not asset.storage_url.startswith("s3://"):
         raise AppError(
             ErrorCode.UPLOADED_FILE_NOT_FOUND,
-            f"Asset file not found on storage: {asset.storage_url}",
+            f"Asset is not on S3: {asset.storage_url}",
             status_code=500,
         )
 
-    try:
-        content = storage_path.read_bytes()
-    except OSError as exc:
-        raise AppError(
-            ErrorCode.FILE_SAVE_FAILED,
-            f"Failed to read asset file: {exc}",
-            status_code=500,
-        ) from exc
+    # S3 에서 본문 다운로드. 이후 submit_floorplan_analysis 가 SageMaker 입력용으로
+    # 다시 S3 에 올린다 (현재 흐름 유지). 추후 source_s3_uri 직접 전달로 최적화 가능.
+    content = _s3.download_bytes(asset.storage_url)
 
+    filename = asset.storage_url.rsplit("/", 1)[-1] or f"{asset.id}.{asset.source_format or 'bin'}"
+    s3_bucket, s3_key = _s3.split_s3_uri(asset.storage_url)
     upload_metadata = UploadStorageMetadataDTO(
-        provider="local",
-        original_filename=storage_path.name,
+        provider="s3",
+        original_filename=filename,
         content_type=asset.mime_type,
         size_bytes=asset.file_size_bytes,
-        local_saved_path=str(storage_path),
+        s3_uri=asset.storage_url,
+        s3_bucket=s3_bucket,
+        s3_key=s3_key,
     )
 
     job = await submit_floorplan_analysis(
         db,
         image_bytes=content,
-        filename=storage_path.name,
+        filename=filename,
         content_type=asset.mime_type or "application/octet-stream",
         real_width_m=real_width_m,
         project_id=asset.project_id,


### PR DESCRIPTION
## 요약
Asset(도면 이미지) 저장소를 **로컬 디스크 → S3** 로 이관. 다운로드는 `FileResponse` 스트리밍 대신 **S3 presigned GET URL** 발급으로 변경. 프론트는 그 URL 을 `<img src>` 로 직접 사용 → 백엔드 메모리/대역폭 절약 + 다른 디바이스/계정에서도 도면 접근 가능.

Closes #65

## 변경 사항

### 신규
- `app/services/_s3.py` — boto3 공용 헬퍼 (`upload_bytes`, `delete_object`, `presigned_get_url`, `download_bytes`, `split_s3_uri`)
- `GET /assets/{asset_id}/download-url` → `{ url, expires_in: 3600 }`

### 변경
- `POST /floors/{id}/assets` — 디스크 저장 제거 → S3 `put_object` (`s3://{bucket}/assets/{project_id}/{floor_id}/{asset_id}.{ext}`)
- `DELETE /assets/{id}` — 디스크 unlink → S3 `delete_object` (S3 먼저 → DB. 실패 시 DB 유지)
- `POST /assets/{id}/analyze` — 로컬 `Path` 읽기 → S3 `download_bytes` 후 기존 SageMaker 흐름
- `measurement_service` — floorplan url 응답 시 S3 객체면 presigned URL 발급

## 파일
- `app/services/_s3.py` 신규
- `app/services/asset_service.py` 재작성 (S3 기반)
- `app/services/scene_draft_service.py` analyze_from_asset S3 대응
- `app/services/measurement_service.py` presigned URL 적용
- `app/routers/assets.py` `/download-url` 추가

## 마이그레이션
- 모델/스키마/Alembic 변경 없음 (`storage_url` Text 컬럼 그대로 S3 URI 저장)
- **기존 로컬 asset 파일 버림** — 이관 안 함. 옛 DB 행의 `storage_url` 은 로컬 경로 상태로 남아있어 `/download-url` 호출 시 404

## IAM 요구사항
S3Access 정책 Action 에 다음 3개 필요 (이번 PR 진행 중 `s3:DeleteObject` 추가):
- `s3:PutObject`
- `s3:GetObject`
- `s3:DeleteObject`

## 테스트
- [x] 업로드 → `storage_url=s3://...` 저장
- [x] presigned URL 발급 → `X-Amz-Signature` 포함 실제 URL
- [x] presigned URL 직접 GET → 200, 바이트 일치 (69B)
- [x] 권한: 타 유저 토큰 → 404
- [x] DELETE → 204, S3 객체 사라짐 (HEAD 404), DB row 사라짐 (GET 404)

## 후속 (이번 PR 범위 외)
- 프론트엔드: `useLocalFloorplanImage` 우회 제거 → `/assets/{id}/download-url` 사용
- `submit_floorplan_analysis` 가 source 를 다시 S3 업로드하는 부분 → `source_s3_uri` 직접 전달로 최적화
- 옛 로컬 `backend/data/assets/` 디렉토리 청소