### PR TITLE
Feat/70

### DIFF
--- a/backend/app/schemas/rf_map.py
+++ b/backend/app/schemas/rf_map.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -24,6 +24,9 @@ class RfMapResponse(BaseModel):
     map_type: str
     resolution_cm: int
     storage_url: str
+    # storage_url 이 s3:// 면 자동 발급한 presigned GET URL (TTL: RF_PRESIGNED_URL_EXPIRES_SECONDS).
+    # 프론트는 이걸 <img src> 로 바로 사용. 로컬/HTTP URL 이면 None.
+    url: Optional[str] = None
     bounds_json: dict[str, Any] = Field(default_factory=dict)
     metrics_json: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime

--- a/backend/app/services/rf_run_service.py
+++ b/backend/app/services/rf_run_service.py
@@ -148,6 +148,19 @@ def get_rf_run(db: Session, rf_run_id: UUID, user: User) -> RfRunResponse:
     return _to_response(_get_owned_rf_run(db, rf_run_id, user))
 
 
+def _rf_map_to_response(m: RfMap) -> RfMapResponse:
+    """storage_url 이 s3:// 면 presigned URL 도 같이 채워서 반환."""
+    resp = RfMapResponse.model_validate(m, from_attributes=True)
+    if m.storage_url and m.storage_url.startswith("s3://"):
+        from app.services import _s3
+        try:
+            resp = resp.model_copy(update={"url": _s3.presigned_get_url(m.storage_url)})
+        except Exception:
+            # presigned 발급 실패 시 url=None 유지 (storage_url 은 남음)
+            pass
+    return resp
+
+
 def list_maps(
     db: Session, rf_run_id: UUID, user: User
 ) -> list[RfMapResponse]:
@@ -161,7 +174,7 @@ def list_maps(
         .scalars()
         .all()
     )
-    return [RfMapResponse.model_validate(m, from_attributes=True) for m in rows]
+    return [_rf_map_to_response(m) for m in rows]
 
 
 # ---------------------------------------------------------------------------
@@ -249,4 +262,4 @@ def create_rf_map(
     except Exception:
         db.rollback()
         raise
-    return RfMapResponse.model_validate(rf_map, from_attributes=True)
+    return _rf_map_to_response(rf_map)

--- a/backend/app/services/scene_version_export.py
+++ b/backend/app/services/scene_version_export.py
@@ -26,6 +26,46 @@ DEFAULT_WALL_THICKNESS_M = 0.12
 DEFAULT_WALL_HEIGHT_M = 2.6
 DEFAULT_WALL_MATERIAL = "plasterboard"
 
+# Sionna 1.0.2 의 ITURadioMaterial type 인자가 받는 enum (소문자, prefix 없음).
+# 출처: ITU-R P.2040 표준. 컨테이너 (`apps/sagemaker_rf_inference`) 가
+# scene.json 의 walls[*].material 을 그대로 ITURadioMaterial(name, type, ...)
+# 의 type 으로 넘기므로, 이 set 안의 값만 보내야 함.
+SIONNA_MATERIAL_SET: set[str] = {
+    "vacuum",
+    "concrete",
+    "brick",
+    "plasterboard",
+    "wood",
+    "glass",
+    "ceiling_board",
+    "chipboard",
+    "floorboard",
+    "metal",
+    "very_dry_ground",
+    "medium_dry_ground",
+    "wet_ground",
+}
+# 우리 material_code → Sionna enum.
+MATERIAL_ALIAS: dict[str, str] = {
+    "drywall": "plasterboard",
+    "marble": "concrete",   # Sionna 1.0.2 에 marble 없음 → 가장 비슷한 concrete 로
+    "plywood": "wood",
+}
+SIONNA_FALLBACK = "plasterboard"
+
+
+def _to_sionna_material(name: str | None) -> str:
+    if not name:
+        return SIONNA_FALLBACK
+    key = name.lower().strip()
+    # 옛 ITU prefix 가 묻어있으면 떼어냄
+    if key.startswith("itu_"):
+        key = key[len("itu_"):]
+    key = MATERIAL_ALIAS.get(key, key)
+    if key in SIONNA_MATERIAL_SET:
+        return key
+    return SIONNA_FALLBACK
+
 
 def export_scene_version_to_scene_json(
     db: Session, scene_version_id: str
@@ -65,7 +105,7 @@ def export_scene_version_to_scene_json(
                 "y2": float(y2),
                 "thickness": float(w.thickness_m or DEFAULT_WALL_THICKNESS_M),
                 "height": float(w.height_m or DEFAULT_WALL_HEIGHT_M),
-                "material": w.material_label or DEFAULT_WALL_MATERIAL,
+                "material": _to_sionna_material(w.material_label or DEFAULT_WALL_MATERIAL),
             }
         )
 

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -200,7 +200,7 @@ export default function SimulationPage() {
               <div className="h-full p-6">
                 <SimulationVisualization
                   state={state}
-                  mapUrl={rfMapsQuery.data?.[0]?.storage_url}
+                  mapUrl={rfMapsQuery.data?.[0]?.url ?? rfMapsQuery.data?.[0]?.storage_url}
                 />
               </div>
             )}

--- a/frontend/src/types/rf.ts
+++ b/frontend/src/types/rf.ts
@@ -62,6 +62,8 @@ export interface RfMap {
   map_type: string;
   resolution_cm: number;
   storage_url: string;
+  /** storage_url 이 s3:// 면 백엔드가 발급한 presigned GET URL. <img src> 로 바로 사용. */
+  url?: string | null;
   bounds_json: Record<string, unknown>;
   metrics_json: Record<string, unknown>;
   created_at: ISODateString;


### PR DESCRIPTION
## 요약
시뮬 성공해도 프론트 heatmap 빈 화면이던 문제 해결. `rf_maps.storage_url` 이 `s3://` 형식이라 `<img src>` 로 못 쓰던 거 → 백엔드가 presigned GET URL 을 응답에 같이 발급, 프론트는 그 URL 그대로 사용.

세션 중 발견된 Sionna ITU material 이름 매핑 버그 수정도 같이 포함.

Closes #70

## 변경 사항

### 백엔드
- `app/schemas/rf_map.py` — `RfMapResponse.url: Optional[str]` 필드 추가 (presigned GET URL, TTL `RF_PRESIGNED_URL_EXPIRES_SECONDS`)
- `app/services/rf_run_service.py` — `_rf_map_to_response()` 헬퍼 추가, `list_maps` / `create_rf_map` 가 사용. s3:// URL 인 경우만 presigned 발급, 실패 시 `url=None`
- `app/services/scene_version_export.py` — Sionna RT 재질 이름 매핑 (`SIONNA_MATERIAL_SET` + `MATERIAL_ALIAS`). ITU-R P.2040 표준 enum 의 raw 이름 (소문자, prefix 없음) 으로 변환

### 프론트
- `types/rf.ts` — `RfMap.url?: string | null` 추가
- `pages/SimulationPage.tsx` — `mapUrl` 에 `url ?? storage_url` (url 우선, fallback)

## 테스트 (로컬)
- 기존에 성공한 rf_run (`b3dae2d5...`) 의 maps 조회 → 응답에 `url` 필드 들어옴 ✓
- 그 presigned URL 직접 GET → 200, 132B 다운로드 (heatmap.png 실제 데이터) ✓
- `storage_url` 도 그대로 유지 (디버깅용) ✓
- frontend `tsc --noEmit` 통과 ✓
- 프론트에서 시뮬 종단 테스트: heatmap 이미지 화면에 표시 확인 ✓