### PR TITLE
Feat/69

### DIFF
--- a/backend/app/services/floorplan_job_service.py
+++ b/backend/app/services/floorplan_job_service.py
@@ -196,10 +196,12 @@ async def _complete_floorplan_job(
     current_user: User,
     output_prefix: str,
 ) -> Job:
+    source_s3_uri = (job.input_json or {}).get("sagemaker", {}).get("source_s3_uri")
     inference = await run_in_threadpool(
         sagemaker_inference_service.download_result,
         str(job.id),
         output_prefix,
+        source_s3_uri,
     )
 
     input_meta = job.input_json or {}

--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -58,6 +58,7 @@ class FusionService:
             real_width_m,
             result.prob_map_local_path,
             sagemaker_meta,
+            result.source_image_local_path,
         )
         return scene
 
@@ -67,6 +68,7 @@ class FusionService:
         real_width_m: float,
         prob_map_local_path,
         sagemaker_meta: dict[str, Any] | None = None,
+        source_image_local_path=None,
     ) -> SceneSchema:
         geo_service = GeometryService(
             pixel_width=ml_output.meta.original_width,
@@ -76,9 +78,13 @@ class FusionService:
         topo_service = TopologyService()
         scale_ratio = geo_service.scale_ratio
 
-        # wall_extraction 은 .npy 파일 경로를 받아 prob_map 로딩
+        # wall_extraction 은 .npy 파일 경로를 받아 prob_map 로딩.
+        # source_image 있으면 §69 multi-threshold + OCR scoring 흐름 활성화.
         raw_coords = wall_extractor.execute_from_prob_map(
-            prob_map_local_path, threshold=None, detections=ml_output.detections
+            prob_map_local_path,
+            threshold=None,
+            detections=ml_output.detections,
+            image_path=source_image_local_path,
         )
 
         raw_walls: list[Wall] = []

--- a/backend/app/services/sagemaker_inference_service.py
+++ b/backend/app/services/sagemaker_inference_service.py
@@ -80,6 +80,8 @@ class InferenceResult:
     image_width_px: int
     image_height_px: int
     result_payload: dict[str, Any]      # 원본 result.json (디버깅/메트릭)
+    # 원본 도면 이미지 (S3 에서 다운). OCR/선분 검출에 필요. 다운로드 실패 시 None.
+    source_image_local_path: Path | None = None
 
     def cleanup(self) -> None:
         try:
@@ -338,9 +340,15 @@ class SageMakerInferenceService:
         return "running"
 
     # ----- 3. download_result -----
-    def download_result(self, job_id: str, output_prefix: str) -> InferenceResult:
+    def download_result(
+        self,
+        job_id: str,
+        output_prefix: str,
+        source_s3_uri: str | None = None,
+    ) -> InferenceResult:
         """result.json + raw outputs 를 temp 디렉토리로 다운로드.
 
+        source_s3_uri 가 주어지면 원본 도면 이미지도 같이 다운 (OCR/선분 검출용).
         호출 후 반드시 InferenceResult.cleanup() 으로 정리할 것.
         """
         bucket, prefix_key = _split_s3_uri(output_prefix)
@@ -369,6 +377,20 @@ class SageMakerInferenceService:
                 502,
             ) from exc
 
+        # 원본 이미지 다운 (best-effort — 실패해도 인퍼런스 결과 자체는 살림).
+        source_image_path: Path | None = None
+        if source_s3_uri:
+            try:
+                src_bucket, src_key = _split_s3_uri(source_s3_uri)
+                ext = Path(src_key).suffix or ".png"
+                source_image_path = temp_dir / f"source{ext}"
+                _s3_download(s3, src_bucket, src_key, source_image_path)
+            except (ClientError, ValueError) as exc:
+                logger.warning(
+                    "source image download failed (OCR/line detection 비활성화됨): %s", exc
+                )
+                source_image_path = None
+
         detections_payload = json.loads(detections_bytes)
         detections = list(detections_payload.get("detections") or [])
 
@@ -382,6 +404,7 @@ class SageMakerInferenceService:
             image_width_px=int(image_info.get("width_px", 0)),
             image_height_px=int(image_info.get("height_px", 0)),
             result_payload=result_payload,
+            source_image_local_path=source_image_path,
         )
 
     # ----- 4. download_failure -----

--- a/backend/app/services/wall_extraction.py
+++ b/backend/app/services/wall_extraction.py
@@ -419,13 +419,28 @@ class WallExtractor:
     def execute(self, image_path: Path, detections: List[Any] = None) -> List[List[float]]:
         return self.execute_from_unet_image(image_path, detections)
 
-    def execute_from_prob_map(self, prob_map_path: Path, threshold: float = None, detections: List[Any] = None) -> List[List[float]]:
+    def execute_from_prob_map(
+        self,
+        prob_map_path: Path,
+        threshold: float = None,
+        detections: List[Any] = None,
+        image_path: Path | None = None,
+    ) -> List[List[float]]:
+        """U-Net wall probability map → wall 선분 리스트.
+
+        threshold 결정 우선순위:
+          1. `threshold` 인자가 명시되면 그 값 사용
+          2. `image_path` 가 있으면 multi-threshold + OCR/선분 정합도 기반 best 선택 (§69)
+          3. 그 외 → Otsu fallback
+        """
         from skimage.filters import threshold_otsu
-        
+
         prob = np.load(str(prob_map_path))
-        
-        # 1. Adaptive threshold
-        thr = threshold if threshold is not None else threshold_otsu(prob)
+
+        # 1. threshold 결정
+        thr = self._pick_threshold(prob, threshold, image_path)
+        if thr is None:
+            thr = float(threshold_otsu(prob))
         mask = (prob > thr).astype(np.uint8) * 255
         
         edges = self._preprocess(mask)
@@ -481,6 +496,62 @@ class WallExtractor:
 
         self._save_debug(skeleton, result, detections or [])
         return result
+
+    def _pick_threshold(
+        self,
+        prob: np.ndarray,
+        explicit: float | None,
+        image_path: Path | None,
+    ) -> float | None:
+        """§69 multi-threshold scoring 으로 best 선택. image_path 없으면 None 반환 (fallback)."""
+        if explicit is not None:
+            return float(explicit)
+        if image_path is None or not image_path.exists():
+            return None
+        try:
+            from app.services.wall_extraction_helpers import (
+                line_detection,
+                ocr,
+                threshold_scoring,
+            )
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "wall_extraction_helpers import 실패 → Otsu fallback: %s", exc
+            )
+            return None
+
+        # prob_map 과 source image 의 해상도가 다를 수 있음 → image 기준으로 prob_map 리사이즈.
+        img = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
+        if img is None:
+            return None
+        h_img, w_img = img.shape
+        h_prob, w_prob = prob.shape
+        if (h_img, w_img) != (h_prob, w_prob):
+            prob_resized = cv2.resize(
+                prob.astype(np.float32), (w_img, h_img), interpolation=cv2.INTER_LINEAR
+            )
+        else:
+            prob_resized = prob
+
+        # OCR + line 추출 (실패해도 둘 다 None 처리해서 진행)
+        try:
+            text_bboxes = ocr.detect_text_bboxes(image_path)
+            text_mask = ocr.build_text_mask(text_bboxes, prob_resized.shape, pad=3)
+        except Exception:
+            text_mask = None
+
+        try:
+            segs = line_detection.detect_line_segments(image_path)
+            line_mask = line_detection.build_line_mask(segs, prob_resized.shape, thickness=3) if len(segs) > 0 else None
+        except Exception:
+            line_mask = None
+
+        best_thr, _scores = threshold_scoring.pick_best_threshold(
+            prob_resized, line_mask=line_mask, text_mask=text_mask
+        )
+        return float(best_thr)
+
 
 wall_extractor = WallExtractor()
 

--- a/backend/app/services/wall_extraction_helpers/line_detection.py
+++ b/backend/app/services/wall_extraction_helpers/line_detection.py
@@ -1,0 +1,63 @@
+"""원본 도면 이미지에서 긴 직선 후보 추출 (Canny + HoughLinesP).
+
+벽 추출 threshold 평가 시 "추출된 선분이 wall mask 와 잘 겹치는가" 측정용.
+도면 벽은 보통 긴 수평/수직 직선이므로, U-Net mask 와 이 선분이 align 되면
+벽일 가능성이 큼 → threshold 가 적절했다는 신호.
+
+LSD (LineSegmentDetector) 가 더 정확하지만 OpenCV 4.x 에서 제거됨
+(SBM-Net 라이선스 이슈). HoughLinesP 로 충분히 실용적.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def detect_line_segments(
+    image_path: Path,
+    canny_low: int = 50,
+    canny_high: int = 150,
+    hough_threshold: int = 80,
+    min_line_length_ratio: float = 0.05,
+    max_line_gap: int = 10,
+) -> np.ndarray:
+    """이미지에서 긴 직선 후보 (N, 4) `[x1, y1, x2, y2]` 배열로 반환. 실패 시 빈 배열."""
+    img = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        logger.warning("line detection: 이미지 읽기 실패 %s", image_path)
+        return np.empty((0, 4), dtype=np.int32)
+
+    h, w = img.shape
+    min_length = max(20, int(min(h, w) * min_line_length_ratio))
+
+    edges = cv2.Canny(img, canny_low, canny_high, apertureSize=3)
+    lines = cv2.HoughLinesP(
+        edges,
+        rho=1,
+        theta=np.pi / 180,
+        threshold=hough_threshold,
+        minLineLength=min_length,
+        maxLineGap=max_line_gap,
+    )
+    if lines is None:
+        return np.empty((0, 4), dtype=np.int32)
+
+    segs = lines.reshape(-1, 4)
+    logger.info("line detection: %d segments (min_length=%d)", len(segs), min_length)
+    return segs
+
+
+def build_line_mask(
+    segments: np.ndarray, shape: tuple[int, int], thickness: int = 3
+) -> np.ndarray:
+    """선분들을 픽셀 mask 로 렌더. wall mask 와 정합도 측정용."""
+    h, w = shape
+    mask = np.zeros((h, w), dtype=np.uint8)
+    for x1, y1, x2, y2 in segments:
+        cv2.line(mask, (int(x1), int(y1)), (int(x2), int(y2)), 255, thickness)
+    return mask

--- a/backend/app/services/wall_extraction_helpers/line_detection.py
+++ b/backend/app/services/wall_extraction_helpers/line_detection.py
@@ -23,10 +23,16 @@ def detect_line_segments(
     canny_low: int = 50,
     canny_high: int = 150,
     hough_threshold: int = 80,
-    min_line_length_ratio: float = 0.05,
+    min_line_length_ratio: float = 0.10,
     max_line_gap: int = 10,
+    angle_tolerance_deg: float = 5.0,
 ) -> np.ndarray:
-    """이미지에서 긴 직선 후보 (N, 4) `[x1, y1, x2, y2]` 배열로 반환. 실패 시 빈 배열."""
+    """이미지에서 **벽 후보** 직선 추출 (N, 4) `[x1, y1, x2, y2]`.
+
+    raw Hough → 해칭/치수선/가구까지 다 잡혀서 노이즈 많음. 벽 후보로 좁히기 위해:
+      - `min_line_length_ratio` 0.10 (도면 짧은 변의 10% 이상) — 짧은 가구/디테일 제거
+      - 수평/수직만 (`angle_tolerance_deg` 이내) — 대각선/해칭 제거
+    """
     img = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
     if img is None:
         logger.warning("line detection: 이미지 읽기 실패 %s", image_path)
@@ -48,7 +54,22 @@ def detect_line_segments(
         return np.empty((0, 4), dtype=np.int32)
 
     segs = lines.reshape(-1, 4)
-    logger.info("line detection: %d segments (min_length=%d)", len(segs), min_length)
+    raw_count = len(segs)
+
+    # 수평/수직 필터: 각도가 0° 또는 90° 근처인 것만.
+    if angle_tolerance_deg > 0 and raw_count > 0:
+        dx = segs[:, 2] - segs[:, 0]
+        dy = segs[:, 3] - segs[:, 1]
+        # arctan2 결과를 0~90° 로 fold (수평/수직 모두 0 또는 90 근처가 됨)
+        angle = np.degrees(np.arctan2(np.abs(dy), np.abs(dx)))  # 0~90
+        horiz = angle <= angle_tolerance_deg
+        vert = angle >= (90.0 - angle_tolerance_deg)
+        segs = segs[horiz | vert]
+
+    logger.info(
+        "line detection: %d → %d segments (min_length=%d, ±%.1f° H/V)",
+        raw_count, len(segs), min_length, angle_tolerance_deg,
+    )
     return segs
 
 

--- a/backend/app/services/wall_extraction_helpers/ocr.py
+++ b/backend/app/services/wall_extraction_helpers/ocr.py
@@ -1,0 +1,82 @@
+"""원본 도면 이미지에서 텍스트 bbox 추출 (EasyOCR).
+
+벽 추출 threshold 평가 시 "텍스트 영역에 벽 mask 가 잡혔으면 페널티" 로 활용.
+도면의 글자/치수 라벨 (방 이름, 숫자) 위치를 알면 그 부분이 벽으로 오탐되는 걸
+줄일 수 있음.
+
+EasyOCR 모델은 최초 호출 시 ~64MB 다운로드 (한국어 + 영어). 캐싱됨.
+"""
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _get_reader():
+    """프로세스당 한 번만 reader 인스턴스 생성 (모델 로드 비싸서)."""
+    import easyocr
+    # gpu=False — 백엔드는 보통 CPU. 추론 한 번 정도라 그렇게 느리지 않음.
+    # 한국어 + 영어. 도면에 한글 라벨 (방, 주방 등) 또는 영문 (Bedroom, Kitchen) 둘 다 가능.
+    return easyocr.Reader(["ko", "en"], gpu=False, verbose=False)
+
+
+def detect_text_bboxes(image_path: Path) -> list[tuple[int, int, int, int]]:
+    """이미지에서 OCR 로 텍스트 영역만 추출. 결과는 (x1, y1, x2, y2) 리스트.
+
+    인식한 문자열 자체는 버림 (위치만 필요). 인식 실패한 영역도 무시.
+    실패 시 빈 리스트 반환 (벽 추출 흐름 계속 진행).
+    """
+    try:
+        reader = _get_reader()
+    except Exception as exc:
+        logger.warning("EasyOCR reader 초기화 실패 → OCR 페널티 비활성화: %s", exc)
+        return []
+
+    try:
+        # detail=1 → bbox + text + confidence
+        # paragraph=False → 각 단어 단위
+        results = reader.readtext(str(image_path), detail=1, paragraph=False)
+    except Exception as exc:
+        logger.warning("OCR 실행 실패: %s", exc)
+        return []
+
+    bboxes: list[tuple[int, int, int, int]] = []
+    for entry in results:
+        # entry = (bbox_4_points, text, confidence)
+        bbox_pts = entry[0]
+        try:
+            xs = [int(p[0]) for p in bbox_pts]
+            ys = [int(p[1]) for p in bbox_pts]
+            bboxes.append((min(xs), min(ys), max(xs), max(ys)))
+        except (TypeError, IndexError):
+            continue
+
+    logger.info("OCR detected %d text bboxes from %s", len(bboxes), image_path.name)
+    return bboxes
+
+
+def build_text_mask(
+    bboxes: list[tuple[int, int, int, int]],
+    shape: tuple[int, int],
+    pad: int = 2,
+) -> np.ndarray:
+    """OCR bbox 영역 = 1, 나머지 = 0 인 bool mask 생성.
+
+    pad: bbox 주변 약간 확장해서 글자 획 인근까지 포함 (벽으로 오탐 자주 됨).
+    """
+    h, w = shape
+    mask = np.zeros((h, w), dtype=bool)
+    for x1, y1, x2, y2 in bboxes:
+        x1c = max(0, x1 - pad)
+        y1c = max(0, y1 - pad)
+        x2c = min(w, x2 + pad)
+        y2c = min(h, y2 + pad)
+        if x2c > x1c and y2c > y1c:
+            mask[y1c:y2c, x1c:x2c] = True
+    return mask

--- a/backend/app/services/wall_extraction_helpers/threshold_scoring.py
+++ b/backend/app/services/wall_extraction_helpers/threshold_scoring.py
@@ -1,0 +1,152 @@
+"""여러 threshold 후보 중 best 선택.
+
+각 threshold 마다 wall mask 만들고, 5가지 점수로 평가:
+  + line_alignment_score : 추출된 직선 (Hough) 과 wall mask 의 겹침
+  + connectivity_score   : mask 연결성 (큰 연결 컴포넌트 위주, 작은 노이즈 적을수록 ↑)
+  + orthogonal_score     : 수평/수직 픽셀 비율 (대각선 노이즈 ↓)
+  - ocr_penalty          : OCR 텍스트 bbox 안에 wall 픽셀이 얼마나 들어갔는지
+  - noise_penalty        : 작은 isolated 컴포넌트 개수 (정규화)
+
+가중치는 디폴트 1.0 으로 시작. 실데이터 보면서 조정 가능.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_THRESHOLDS = (0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60)
+
+
+@dataclass
+class ThresholdScore:
+    threshold: float
+    line_alignment: float
+    connectivity: float
+    orthogonal: float
+    ocr_penalty: float
+    noise_penalty: float
+    total: float
+
+
+def _line_alignment_score(wall_mask: np.ndarray, line_mask: np.ndarray) -> float:
+    """추출 선분과 wall mask 의 IoU 비스무리 (선분 픽셀 중 wall 영역에 들어간 비율)."""
+    if line_mask.sum() == 0 or wall_mask.sum() == 0:
+        return 0.0
+    line_pix = (line_mask > 0)
+    wall_pix = (wall_mask > 0)
+    inter = (line_pix & wall_pix).sum()
+    return float(inter / line_pix.sum())
+
+
+def _connectivity_score(wall_mask: np.ndarray) -> float:
+    """큰 connected component 위주면 1 에 가깝, 작은 조각 많으면 0 에 가깝."""
+    if wall_mask.sum() == 0:
+        return 0.0
+    num_labels, _labels, stats, _ = cv2.connectedComponentsWithStats(
+        (wall_mask > 0).astype(np.uint8), connectivity=8
+    )
+    if num_labels <= 1:  # 배경만
+        return 0.0
+    # 가장 큰 컴포넌트가 차지하는 비율 (배경 제외)
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    if len(areas) == 0:
+        return 0.0
+    return float(areas.max() / areas.sum())
+
+
+def _orthogonal_score(wall_mask: np.ndarray) -> float:
+    """수평/수직 픽셀 비율. Sobel 응답으로 근사."""
+    if wall_mask.sum() == 0:
+        return 0.0
+    mask8 = (wall_mask > 0).astype(np.uint8) * 255
+    sx = cv2.Sobel(mask8, cv2.CV_32F, 1, 0, ksize=3)
+    sy = cv2.Sobel(mask8, cv2.CV_32F, 0, 1, ksize=3)
+    mag = np.sqrt(sx * sx + sy * sy)
+    edge_pix = mag > 50
+    total = int(edge_pix.sum())
+    if total == 0:
+        return 0.0
+    # |gx| 또는 |gy| 가 압도적이면 수평/수직 픽셀로 카운트
+    asx = np.abs(sx)
+    asy = np.abs(sy)
+    horiz = ((asy > asx * 3) & edge_pix).sum()
+    vert = ((asx > asy * 3) & edge_pix).sum()
+    return float((horiz + vert) / total)
+
+
+def _ocr_penalty(wall_mask: np.ndarray, text_mask: np.ndarray) -> float:
+    """텍스트 영역 안에 들어간 wall 픽셀 비율. 높을수록 나쁨."""
+    if text_mask.sum() == 0 or wall_mask.sum() == 0:
+        return 0.0
+    overlap = ((wall_mask > 0) & text_mask).sum()
+    return float(overlap / wall_mask.sum())
+
+
+def _noise_penalty(wall_mask: np.ndarray, min_area_ratio: float = 0.001) -> float:
+    """작은 컴포넌트 개수 비율. 0~1 정규화 (10개 이상이면 1)."""
+    if wall_mask.sum() == 0:
+        return 0.0
+    h, w = wall_mask.shape
+    min_area = max(5, int(h * w * min_area_ratio))
+    num_labels, _labels, stats, _ = cv2.connectedComponentsWithStats(
+        (wall_mask > 0).astype(np.uint8), connectivity=8
+    )
+    small = sum(
+        1 for i in range(1, num_labels) if stats[i, cv2.CC_STAT_AREA] < min_area
+    )
+    return float(min(1.0, small / 10.0))
+
+
+def score_threshold(
+    prob_map: np.ndarray,
+    threshold: float,
+    line_mask: np.ndarray | None,
+    text_mask: np.ndarray | None,
+    weights: tuple[float, float, float, float, float] = (1.0, 1.0, 1.0, 1.0, 0.5),
+) -> ThresholdScore:
+    """단일 threshold 평가."""
+    wall_mask = (prob_map > threshold).astype(np.uint8) * 255
+
+    la = _line_alignment_score(wall_mask, line_mask) if line_mask is not None else 0.0
+    cc = _connectivity_score(wall_mask)
+    orth = _orthogonal_score(wall_mask)
+    ocr_p = _ocr_penalty(wall_mask, text_mask) if text_mask is not None else 0.0
+    np_pen = _noise_penalty(wall_mask)
+
+    w_la, w_cc, w_orth, w_ocr, w_np = weights
+    total = w_la * la + w_cc * cc + w_orth * orth - w_ocr * ocr_p - w_np * np_pen
+
+    return ThresholdScore(
+        threshold=float(threshold),
+        line_alignment=la,
+        connectivity=cc,
+        orthogonal=orth,
+        ocr_penalty=ocr_p,
+        noise_penalty=np_pen,
+        total=total,
+    )
+
+
+def pick_best_threshold(
+    prob_map: np.ndarray,
+    line_mask: np.ndarray | None,
+    text_mask: np.ndarray | None,
+    candidates: tuple[float, ...] = DEFAULT_THRESHOLDS,
+) -> tuple[float, list[ThresholdScore]]:
+    """모든 후보 평가 후 best (threshold, scores 전체 리스트) 반환."""
+    scores = [
+        score_threshold(prob_map, t, line_mask, text_mask) for t in candidates
+    ]
+    best = max(scores, key=lambda s: s.total)
+    logger.info(
+        "threshold scoring: best=%.2f total=%.3f (la=%.3f, cc=%.3f, orth=%.3f, ocr_p=%.3f, np=%.3f)",
+        best.threshold, best.total, best.line_alignment, best.connectivity,
+        best.orthogonal, best.ocr_penalty, best.noise_penalty,
+    )
+    return best.threshold, scores

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,3 +40,6 @@ python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 email-validator==2.2.0
+# RF/Wall extraction OCR (#69)
+easyocr==1.7.2
+

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -673,14 +673,19 @@ function parseMetrics(
     toNum(rssDbm?.['mean']) ??
     pickNumber('avg_rssi_dbm', 'avg_dbm', 'rssi_avg', 'avg_rssi');
 
-  // 커버리지: 신규 구조 coverage_summary["ge_-67"] (0~1 비율) 우선 → 100 곱해 %.
-  // 없으면 옛 키들 (이미 % 단위로 가정).
+  // 면적 커버리지: 전체 셀 중 양호 (≥-67dBm) 신호가 잡힌 비율.
+  //   coverage_summary["ge_-67"]      = 데이터 있는 셀 중 양호 비율 (분모: valid_cell_count)
+  //   coverage_summary["valid_cell_ratio"] = 전체 셀 중 데이터 있는 비율 (분모: total_cell_count)
+  // → 둘을 곱해야 "전체 면적 중 양호 비율" 이 됨.
   const coverage = merged['coverage_summary'] as Record<string, unknown> | undefined;
   const ge67 = toNum(coverage?.['ge_-67']);
+  const validRatio = toNum(coverage?.['valid_cell_ratio']);
   const coveragePercent =
-    ge67 !== null
-      ? ge67 * 100
-      : pickNumber('coverage_percent', 'coverage', 'coverage_pct');
+    ge67 !== null && validRatio !== null
+      ? ge67 * validRatio * 100
+      : ge67 !== null
+        ? ge67 * 100 // valid_cell_ratio 없으면 옛 동작 (단순 양호 셀 비율)
+        : pickNumber('coverage_percent', 'coverage', 'coverage_pct');
 
   return { avgRssiDbm, coveragePercent };
 }


### PR DESCRIPTION
## 요약
U-Net 벽 segmentation 의 단일 threshold 대신 OCR + Hough 선분 기반 multi-threshold scoring 으로 적응적 best 선택. 시각화 / 커버리지 계산 자잘한 수정 포함.

Closes #69

## 변경 사항

### 벽 추출 (메인)
- 신규 `app/services/wall_extraction_helpers/`
  - `ocr.py` — EasyOCR (한국어+영어), 텍스트 bbox 추출
  - `line_detection.py` — Canny + HoughLinesP, H/V 직선 후보 필터 (각도/길이)
  - `threshold_scoring.py` — 5점수 (line_alignment, connectivity, orthogonal, ocr_penalty, noise_penalty) 로 best threshold 선택
- `wall_extraction.execute_from_prob_map` — `image_path` 받으면 multi-threshold scoring, 없으면 Otsu fallback (하위 호환)
- `sagemaker_inference_service.download_result` — `source_s3_uri` 받아 원본 도면 이미지도 다운
- `fusion_service` — `source_image_local_path` 를 wall_extractor 로 전달

### 부수 수정
- `scene_version_export.py` — Sionna 1.0.2 ITURadioMaterial 이 받는 raw enum (`concrete`, `plasterboard` 등 소문자, prefix 없음) 으로 매핑
- `SimulationPage.tsx` — 면적 커버리지 계산을 `ge_-67 × valid_cell_ratio` 로 (전체 셀 기준)

### 의존성
- `easyocr==1.7.2` (~1GB, torch 포함). 첫 호출 시 ~64MB 모델 자동 다운

## 테스트
- import 검증 ✓
- 합성 prob_map 으로 scoring 동작 확인 ✓
- 실제 도면 이미지에서 OCR / line detection 결과 시각적 확인 (58 텍스트 bbox + 305 H/V 선분)
- frontend tsc --noEmit ✓
