### PR TITLE
Feat/68

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -67,6 +67,9 @@ class ErrorCode(StrEnum):
 
     AP_LAYOUT_NOT_FOUND = "AP_LAYOUT_NOT_FOUND"
 
+    CALIBRATION_RUN_NOT_FOUND = "CALIBRATION_RUN_NOT_FOUND"
+    INVALID_CALIBRATION_STATUS = "INVALID_CALIBRATION_STATUS"
+
 
 class AppError(Exception):
     def __init__(self, code: ErrorCode, message: str, status_code: int):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,7 @@
 from app.models.ap_layout import ApLayout
 from app.models.asset import Asset
+from app.models.calibration_run import CalibrationRun
+from app.models.parameter_update import ParameterUpdate
 from app.models.draft_object import DraftObject
 from app.models.draft_opening import DraftOpening
 from app.models.draft_room import DraftRoom
@@ -50,5 +52,7 @@ __all__ = [
     "MeasurementSession",
     "MeasurementPoint",
     "ApLayout",
+    "CalibrationRun",
+    "ParameterUpdate",
 ]
 

--- a/backend/app/models/calibration_run.py
+++ b/backend/app/models/calibration_run.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class CalibrationRun(Base):
+    __tablename__ = "calibration_runs"
+    __table_args__ = (
+        Index("idx_calibration_runs_scene_version", "scene_version_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    project_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    floor_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("floors.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    rf_run_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("rf_runs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    measurement_session_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("measurement_sessions.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'queued'")
+    )
+    metrics_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    error_message: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    parameter_updates = relationship(
+        "ParameterUpdate",
+        back_populates="calibration_run",
+        cascade="all, delete",
+        passive_deletes=True,
+    )

--- a/backend/app/models/parameter_update.py
+++ b/backend/app/models/parameter_update.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ParameterUpdate(Base):
+    __tablename__ = "parameter_updates"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    calibration_run_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("calibration_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    target_id: Mapped[str] = mapped_column(UUID(as_uuid=False), nullable=False)
+    parameter_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    old_value_json: Mapped[Any | None] = mapped_column(JSONB, nullable=True)
+    new_value_json: Mapped[Any | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    calibration_run = relationship(
+        "CalibrationRun", back_populates="parameter_updates"
+    )

--- a/backend/app/routers/calibration_runs.py
+++ b/backend/app/routers/calibration_runs.py
@@ -1,0 +1,104 @@
+"""§11 Calibration 라우터"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, verify_internal_api_key
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.calibration_run import (
+    CalibrationRunCreate,
+    CalibrationRunResponse,
+    CalibrationRunUpdate,
+    ParameterUpdateCreate,
+    ParameterUpdateResponse,
+)
+from app.services import calibration_run_service
+
+
+router = APIRouter(prefix="/calibration-runs", tags=["calibration"])
+
+
+@router.post(
+    "",
+    response_model=CalibrationRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="캘리브레이션 실행 (§11.1). RF 결과 vs 실측 비교 Job 큐 등록.",
+)
+def create_calibration_run(
+    payload: CalibrationRunCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalibrationRunResponse:
+    return calibration_run_service.create_calibration_run(
+        db, payload=payload, user=current_user
+    )
+
+
+@router.get(
+    "/{run_id}",
+    response_model=CalibrationRunResponse,
+    summary="캘리브레이션 결과 조회 (§11.2)",
+)
+def get_calibration_run(
+    run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalibrationRunResponse:
+    return calibration_run_service.get_calibration_run(
+        db, run_id=run_id, user=current_user
+    )
+
+
+@router.get(
+    "/{run_id}/parameter-updates",
+    response_model=list[ParameterUpdateResponse],
+    summary="파라미터 변경 이력 (§11.3)",
+)
+def list_parameter_updates(
+    run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[ParameterUpdateResponse]:
+    return calibration_run_service.list_parameter_updates(
+        db, run_id=run_id, user=current_user
+    )
+
+
+# ---------------------------------------------------------------------------
+# 시스템 호출용 (AI 워커 → 백엔드)
+# ---------------------------------------------------------------------------
+@router.patch(
+    "/{run_id}",
+    response_model=CalibrationRunResponse,
+    summary="[시스템] 캘리브레이션 상태/메트릭 갱신",
+    dependencies=[Depends(verify_internal_api_key)],
+)
+def update_calibration_run(
+    payload: CalibrationRunUpdate,
+    run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+) -> CalibrationRunResponse:
+    return calibration_run_service.update_calibration_run(
+        db, run_id=run_id, payload=payload
+    )
+
+
+@router.post(
+    "/{run_id}/parameter-updates",
+    response_model=ParameterUpdateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="[시스템] 파라미터 변경 기록 추가",
+    dependencies=[Depends(verify_internal_api_key)],
+)
+def create_parameter_update(
+    payload: ParameterUpdateCreate,
+    run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+) -> ParameterUpdateResponse:
+    return calibration_run_service.create_parameter_update(
+        db, run_id=run_id, payload=payload
+    )

--- a/backend/app/schemas/calibration_run.py
+++ b/backend/app/schemas/calibration_run.py
@@ -1,0 +1,76 @@
+"""§11 Calibration DTO"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class CalibrationRunCreate(BaseModel):
+    """POST /calibration-runs — 명세 §11.1"""
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: UUID
+    rf_run_id: UUID
+    version_id: UUID
+
+
+class CalibrationRunResponse(BaseModel):
+    """GET /calibration-runs/{id} 응답 — 명세 §11.2
+
+    모델 컬럼명과 명세 필드명이 다른 부분은 service 의 _to_response 에서 alias 매핑.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    status: str
+    session_id: Optional[UUID] = None
+    rf_run_id: Optional[UUID] = None
+    version_id: UUID
+    error_metrics_json: dict[str, Any] = Field(default_factory=dict)
+    error_heatmap_url: Optional[str] = None
+    created_at: datetime
+    finished_at: Optional[datetime] = None
+
+
+class CalibrationRunUpdate(BaseModel):
+    """[시스템] PATCH /calibration-runs/{id} — AI 워커가 진행 상태 갱신."""
+    model_config = ConfigDict(extra="forbid")
+
+    status: Optional[str] = None
+    metrics_json: Optional[dict[str, Any]] = None
+    error_message: Optional[str] = None
+
+
+class ParameterUpdateCreate(BaseModel):
+    """[시스템] POST /calibration-runs/{id}/parameter-updates"""
+    model_config = ConfigDict(extra="forbid")
+
+    target_type: str = Field(..., min_length=1, max_length=20)
+    target_id: UUID
+    param_name: str = Field(..., min_length=1, max_length=80)
+    old_value_json: Any | None = None
+    new_value_json: Any | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_value(self):
+        # 새 값 정도는 있어야 의미 있음 (old 만 있으면 정보 부족).
+        if self.new_value_json is None and self.old_value_json is None:
+            raise ValueError("at least one of old_value_json/new_value_json required")
+        return self
+
+
+class ParameterUpdateResponse(BaseModel):
+    """§11.3 응답 항목. DB 컬럼 parameter_name 을 param_name 으로 노출."""
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    calibration_run_id: UUID
+    target_type: str
+    target_id: UUID
+    param_name: str
+    old_value_json: Any | None = None
+    new_value_json: Any | None = None
+    created_at: datetime

--- a/backend/app/services/calibration_run_service.py
+++ b/backend/app/services/calibration_run_service.py
@@ -1,0 +1,317 @@
+"""§11 Calibration: 실행 / 조회 / 파라미터 변경 이력 / 시스템 갱신"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.models.calibration_run import CalibrationRun
+from app.models.job import Job
+from app.models.measurement_session import MeasurementSession
+from app.models.parameter_update import ParameterUpdate
+from app.models.project import Project
+from app.models.rf_run import RfRun
+from app.models.scene_version import SceneVersion
+from app.models.user import User
+from app.schemas.calibration_run import (
+    CalibrationRunCreate,
+    CalibrationRunResponse,
+    CalibrationRunUpdate,
+    ParameterUpdateCreate,
+    ParameterUpdateResponse,
+)
+
+
+JOB_TYPE_CALIBRATION = "calibration"
+ALLOWED_CALIBRATION_STATUS = {"queued", "running", "completed", "failed"}
+
+
+# ---------------------------------------------------------------------------
+# 권한 + 검증
+# ---------------------------------------------------------------------------
+def _get_owned_scene_version(
+    db: Session, version_id: UUID, user: User
+) -> SceneVersion:
+    sv = db.execute(
+        select(SceneVersion)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            SceneVersion.id == str(version_id),
+            Project.owner_user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if sv is None:
+        raise AppError(
+            ErrorCode.SCENE_VERSION_NOT_FOUND,
+            "Scene version not found.",
+            status_code=404,
+        )
+    return sv
+
+
+def _get_owned_rf_run(db: Session, rf_run_id: UUID, user: User) -> RfRun:
+    rr = db.execute(
+        select(RfRun)
+        .join(Project, RfRun.project_id == Project.id)
+        .where(
+            RfRun.id == str(rf_run_id),
+            Project.owner_user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if rr is None:
+        raise AppError(
+            ErrorCode.RF_RUN_NOT_FOUND,
+            "RF run not found.",
+            status_code=404,
+        )
+    return rr
+
+
+def _get_owned_session(
+    db: Session, session_id: UUID, user: User
+) -> MeasurementSession:
+    s = db.execute(
+        select(MeasurementSession)
+        .join(Project, MeasurementSession.project_id == Project.id)
+        .where(
+            MeasurementSession.id == str(session_id),
+            Project.owner_user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if s is None:
+        raise AppError(
+            ErrorCode.MEASUREMENT_SESSION_NOT_FOUND,
+            "Measurement session not found.",
+            status_code=404,
+        )
+    return s
+
+
+def _get_owned_calibration_run(
+    db: Session, run_id: UUID, user: User
+) -> CalibrationRun:
+    cr = db.execute(
+        select(CalibrationRun)
+        .join(Project, CalibrationRun.project_id == Project.id)
+        .where(
+            CalibrationRun.id == str(run_id),
+            Project.owner_user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if cr is None:
+        raise AppError(
+            ErrorCode.CALIBRATION_RUN_NOT_FOUND,
+            "Calibration run not found.",
+            status_code=404,
+        )
+    return cr
+
+
+def _get_calibration_run_or_404(db: Session, run_id: UUID) -> CalibrationRun:
+    """[시스템 호출용] owner 체크 없이 단순 조회."""
+    cr = db.execute(
+        select(CalibrationRun).where(CalibrationRun.id == str(run_id))
+    ).scalar_one_or_none()
+    if cr is None:
+        raise AppError(
+            ErrorCode.CALIBRATION_RUN_NOT_FOUND,
+            "Calibration run not found.",
+            status_code=404,
+        )
+    return cr
+
+
+# ---------------------------------------------------------------------------
+# alias 매핑 (모델 → 명세 응답)
+# ---------------------------------------------------------------------------
+def _to_response(cr: CalibrationRun) -> CalibrationRunResponse:
+    metrics = cr.metrics_json or {}
+    # error_heatmap_url 은 명세상 top-level. 모델엔 별도 컬럼이 없어 metrics_json 안에 담는 규약.
+    heatmap_url = metrics.get("error_heatmap_url")
+    return CalibrationRunResponse(
+        id=cr.id,
+        status=cr.status,
+        session_id=cr.measurement_session_id,
+        rf_run_id=cr.rf_run_id,
+        version_id=cr.scene_version_id,
+        error_metrics_json=metrics,
+        error_heatmap_url=heatmap_url,
+        created_at=cr.created_at,
+        finished_at=cr.finished_at,
+    )
+
+
+def _pu_to_response(pu: ParameterUpdate) -> ParameterUpdateResponse:
+    return ParameterUpdateResponse(
+        id=pu.id,
+        calibration_run_id=pu.calibration_run_id,
+        target_type=pu.target_type,
+        target_id=pu.target_id,
+        param_name=pu.parameter_name,
+        old_value_json=pu.old_value_json,
+        new_value_json=pu.new_value_json,
+        created_at=pu.created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# §11.1 실행
+# ---------------------------------------------------------------------------
+def create_calibration_run(
+    db: Session, payload: CalibrationRunCreate, user: User
+) -> CalibrationRunResponse:
+    sv = _get_owned_scene_version(db, payload.version_id, user)
+    rr = _get_owned_rf_run(db, payload.rf_run_id, user)
+    ms = _get_owned_session(db, payload.session_id, user)
+
+    # 동일 floor 에 속해야 의미있는 비교. 다르면 거부.
+    if not (sv.floor_id == rr.floor_id == ms.floor_id):
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "scene_version / rf_run / measurement_session must belong to the same floor.",
+            status_code=400,
+        )
+
+    cr = CalibrationRun(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        scene_version_id=sv.id,
+        rf_run_id=rr.id,
+        measurement_session_id=ms.id,
+        status="queued",
+    )
+    db.add(cr)
+    db.flush()
+
+    # AI 워커 등록용 Job. 워커가 아직 없어도 큐에 쌓임 (poller 가 type 모르면 skip).
+    job = Job(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        job_type=JOB_TYPE_CALIBRATION,
+        status="queued",
+        input_json={
+            "calibration_run_id": cr.id,
+            "scene_version_id": sv.id,
+            "rf_run_id": rr.id,
+            "measurement_session_id": ms.id,
+        },
+    )
+    db.add(job)
+
+    try:
+        db.commit()
+        db.refresh(cr)
+    except Exception:
+        db.rollback()
+        raise
+    return _to_response(cr)
+
+
+# ---------------------------------------------------------------------------
+# §11.2 결과 조회
+# ---------------------------------------------------------------------------
+def get_calibration_run(
+    db: Session, run_id: UUID, user: User
+) -> CalibrationRunResponse:
+    return _to_response(_get_owned_calibration_run(db, run_id, user))
+
+
+# ---------------------------------------------------------------------------
+# §11.3 파라미터 변경 이력
+# ---------------------------------------------------------------------------
+def list_parameter_updates(
+    db: Session, run_id: UUID, user: User
+) -> list[ParameterUpdateResponse]:
+    cr = _get_owned_calibration_run(db, run_id, user)
+    rows = (
+        db.execute(
+            select(ParameterUpdate)
+            .where(ParameterUpdate.calibration_run_id == cr.id)
+            .order_by(ParameterUpdate.created_at.asc())
+        )
+        .scalars()
+        .all()
+    )
+    return [_pu_to_response(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# 시스템 호출 (AI 워커 → 백엔드)
+# ---------------------------------------------------------------------------
+def _find_associated_job(db: Session, calibration_run_id: str) -> Job | None:
+    return db.execute(
+        select(Job).where(
+            Job.job_type == JOB_TYPE_CALIBRATION,
+            Job.input_json["calibration_run_id"].astext == calibration_run_id,
+        )
+    ).scalar_one_or_none()
+
+
+def update_calibration_run(
+    db: Session, run_id: UUID, payload: CalibrationRunUpdate
+) -> CalibrationRunResponse:
+    cr = _get_calibration_run_or_404(db, run_id)
+    data = payload.model_dump(exclude_unset=True)
+
+    new_status = data.get("status")
+    if new_status is not None and new_status not in ALLOWED_CALIBRATION_STATUS:
+        raise AppError(
+            ErrorCode.INVALID_CALIBRATION_STATUS,
+            f"Invalid status: {new_status}. Allowed: {sorted(ALLOWED_CALIBRATION_STATUS)}",
+            status_code=400,
+        )
+
+    now = datetime.now(timezone.utc)
+    if new_status is not None:
+        cr.status = new_status
+        if new_status in {"completed", "failed"} and cr.finished_at is None:
+            cr.finished_at = now
+    if "metrics_json" in data and data["metrics_json"] is not None:
+        cr.metrics_json = data["metrics_json"]
+    if "error_message" in data:
+        cr.error_message = data["error_message"]
+
+    job = _find_associated_job(db, cr.id)
+    if job is not None:
+        if new_status is not None:
+            job.status = new_status
+            if new_status == "running" and job.started_at is None:
+                job.started_at = now
+            if new_status in {"completed", "failed"}:
+                job.finished_at = now
+        if "error_message" in data:
+            job.error_message = data["error_message"]
+
+    try:
+        db.commit()
+        db.refresh(cr)
+    except Exception:
+        db.rollback()
+        raise
+    return _to_response(cr)
+
+
+def create_parameter_update(
+    db: Session, run_id: UUID, payload: ParameterUpdateCreate
+) -> ParameterUpdateResponse:
+    cr = _get_calibration_run_or_404(db, run_id)
+    pu = ParameterUpdate(
+        calibration_run_id=cr.id,
+        target_type=payload.target_type,
+        target_id=str(payload.target_id),
+        parameter_name=payload.param_name,
+        old_value_json=payload.old_value_json,
+        new_value_json=payload.new_value_json,
+    )
+    db.add(pu)
+    try:
+        db.commit()
+        db.refresh(pu)
+    except Exception:
+        db.rollback()
+        raise
+    return _pu_to_response(pu)

--- a/backend/app/services/calibration_run_service.py
+++ b/backend/app/services/calibration_run_service.py
@@ -187,18 +187,21 @@ def create_calibration_run(
     db.add(cr)
     db.flush()
 
-    # AI 워커 등록용 Job. 워커가 아직 없어도 큐에 쌓임 (poller 가 type 모르면 skip).
+    # 백그라운드 워커 (job_poller) 가 픽업하도록 running 으로 시작.
+    # poller 는 status=running 만 본다.
+    now = datetime.now(timezone.utc)
     job = Job(
         project_id=sv.project_id,
         floor_id=sv.floor_id,
         job_type=JOB_TYPE_CALIBRATION,
-        status="queued",
+        status="running",
         input_json={
             "calibration_run_id": cr.id,
             "scene_version_id": sv.id,
             "rf_run_id": rr.id,
             "measurement_session_id": ms.id,
         },
+        started_at=now,
     )
     db.add(job)
 

--- a/backend/app/services/calibration_worker.py
+++ b/backend/app/services/calibration_worker.py
@@ -1,0 +1,138 @@
+"""§11 캘리브레이션 백그라운드 워커 (스켈레톤).
+
+`job_poller` 가 `JOB_TYPE_CALIBRATION` 인 Job (status=running) 을 매 사이클
+픽업해서 호출. 같은 프로세스 안이므로 HTTP/internal key 없이 service 함수 직접 호출.
+
+**현재는 스켈레톤**: 측정 데이터 기본 통계 계산 + completed 마킹까지.
+진짜 보정 알고리즘은 RF 시뮬 결과 (RfMap heatmap) 가 들어오기 시작하면
+`_compute_real_error_metrics` 를 채우는 식으로 확장.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.calibration_run import CalibrationRun
+from app.models.job import Job
+from app.models.measurement_point import MeasurementPoint
+from app.models.user import User
+
+
+logger = logging.getLogger(__name__)
+
+JOB_TYPE_CALIBRATION = "calibration"
+
+
+def _fail(db: Session, cr: CalibrationRun, job: Job | None, message: str) -> None:
+    now = datetime.now(timezone.utc)
+    cr.status = "failed"
+    cr.error_message = message
+    cr.finished_at = now
+    if job is not None:
+        job.status = "failed"
+        job.error_message = message
+        job.finished_at = now
+    db.commit()
+    logger.warning("Calibration %s failed: %s", cr.id, message)
+
+
+def _summarize_measurements(points: list[MeasurementPoint]) -> dict[str, Any]:
+    """RSSI 값이 있는 측정 지점만 모아서 간단 통계."""
+    rssi_values: list[float] = []
+    for p in points:
+        if p.rssi_dbm is None:
+            continue
+        rssi_values.append(float(p.rssi_dbm))
+    if not rssi_values:
+        return {"point_count": len(points), "rssi_count": 0}
+    return {
+        "point_count": len(points),
+        "rssi_count": len(rssi_values),
+        "rssi_mean_dbm": round(sum(rssi_values) / len(rssi_values), 2),
+        "rssi_min_dbm": min(rssi_values),
+        "rssi_max_dbm": max(rssi_values),
+    }
+
+
+async def poll_calibration_job(
+    db: Session, *, job_id: str, current_user: User
+) -> Job:
+    """job_poller 가 매 사이클 호출. 같은 시그니처 (job_id, current_user)."""
+    job = db.execute(select(Job).where(Job.id == job_id)).scalar_one_or_none()
+    if job is None:
+        logger.warning("Calibration job %s not found", job_id)
+        return None  # type: ignore[return-value]
+    if job.status != "running":
+        # 이미 다른 사이클에서 완료 처리됨 — idempotent.
+        return job
+
+    calibration_run_id = (job.input_json or {}).get("calibration_run_id")
+    if not calibration_run_id:
+        _fail(db, _stub_cr(), job, "Job.input_json.calibration_run_id missing")
+        return job
+
+    cr = db.execute(
+        select(CalibrationRun).where(CalibrationRun.id == calibration_run_id)
+    ).scalar_one_or_none()
+    if cr is None:
+        job.status = "failed"
+        job.error_message = "CalibrationRun not found"
+        job.finished_at = datetime.now(timezone.utc)
+        db.commit()
+        return job
+
+    # ── 1) 측정 데이터 로드 ──────────────────────────────────────────
+    points = list(
+        db.execute(
+            select(MeasurementPoint).where(
+                MeasurementPoint.session_id == cr.measurement_session_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not points:
+        _fail(db, cr, job, "No measurement points found for the session.")
+        return job
+
+    # ── 2) 기본 통계 (스켈레톤 — 진짜 error metric 은 RfMap 비교 필요) ──
+    stats = _summarize_measurements(points)
+    cr.metrics_json = {
+        **stats,
+        "note": (
+            "Skeleton worker: real error metrics (rmse, mae) require comparing "
+            "with predicted RSSI from RfMap. Not implemented yet."
+        ),
+    }
+
+    # ── 3) 완료 처리 ────────────────────────────────────────────────
+    now = datetime.now(timezone.utc)
+    cr.status = "completed"
+    cr.finished_at = now
+    job.status = "completed"
+    job.finished_at = now
+
+    try:
+        db.commit()
+        db.refresh(cr)
+        db.refresh(job)
+    except Exception:
+        db.rollback()
+        raise
+
+    logger.info(
+        "Calibration %s completed (skeleton): %d points, %d rssi",
+        cr.id, stats.get("point_count", 0), stats.get("rssi_count", 0),
+    )
+    return job
+
+
+def _stub_cr() -> CalibrationRun:
+    """타입 체크용 더미. 실제로 _fail 호출 전에 cr 있는 경로에서만 쓰임."""
+    return CalibrationRun()  # type: ignore[call-arg]

--- a/backend/app/services/job_poller.py
+++ b/backend/app/services/job_poller.py
@@ -77,6 +77,10 @@ async def run_job_poller_forever() -> None:
 async def _poll_once() -> None:
     """한 사이클: running job 조회 → 오래된 건 스킵 → 상한만큼만 폴링."""
     # 임포트는 lazy — 순환 import 회피
+    from app.services.calibration_worker import (
+        JOB_TYPE_CALIBRATION,
+        poll_calibration_job,
+    )
     from app.services.floorplan_job_service import (
         JOB_TYPE_FLOORPLAN_ANALYZE,
         poll_floorplan_job,
@@ -95,7 +99,9 @@ async def _poll_once() -> None:
             .join(Project, Job.project_id == Project.id)
             .where(
                 Job.status == "running",
-                Job.job_type.in_([JOB_TYPE_FLOORPLAN_ANALYZE, JOB_TYPE_RF_SIMULATE]),
+                Job.job_type.in_(
+                    [JOB_TYPE_FLOORPLAN_ANALYZE, JOB_TYPE_RF_SIMULATE, JOB_TYPE_CALIBRATION]
+                ),
                 Job.created_at >= min_created,
             )
             .order_by(Job.created_at.asc())
@@ -119,6 +125,7 @@ async def _poll_once() -> None:
             owner_user_id=str(owner_user_id),
             floorplan_poll=poll_floorplan_job,
             rf_poll=poll_rf_job,
+            calibration_poll=poll_calibration_job,
         )
 
 
@@ -129,6 +136,7 @@ async def _poll_single(
     owner_user_id: str,
     floorplan_poll: Any,
     rf_poll: Any,
+    calibration_poll: Any,
 ) -> None:
     """단일 Job 폴링. 각 호출마다 새 세션. 권한 체크용 owner User 객체 재구성."""
     db: Session = SessionLocal()
@@ -142,6 +150,8 @@ async def _poll_single(
             await floorplan_poll(db, job_id=job_id, current_user=owner)
         elif job_type == "rf_simulate":
             await rf_poll(db, job_id=job_id, current_user=owner)
+        elif job_type == "calibration":
+            await calibration_poll(db, job_id=job_id, current_user=owner)
         else:
             logger.warning("Job %s: unknown job_type=%s, skip", job_id, job_type)
     except Exception:

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,7 @@ from app.routers.ap_layouts import (
     router as ap_layouts_router,
     rf_run_router as rf_run_ap_layouts_router,
 )
+from app.routers.calibration_runs import router as calibration_runs_router
 from app.routers.jobs import router as jobs_router
 from app.routers.floorplan_jobs import router as floorplan_jobs_router
 from app.services.job_poller import job_poller_lifespan
@@ -123,5 +124,6 @@ app.include_router(rf_runs_router)
 app.include_router(rf_jobs_router)
 app.include_router(ap_layouts_router)
 app.include_router(rf_run_ap_layouts_router)
+app.include_router(calibration_runs_router)
 app.include_router(jobs_router)
 app.include_router(floorplan_jobs_router)

--- a/backend/migrations/versions/20260516_0008_calibration_columns.py
+++ b/backend/migrations/versions/20260516_0008_calibration_columns.py
@@ -1,0 +1,54 @@
+"""calibration_runs 보강: measurement_session_id + finished_at + error_message (§11)
+
+기존 initial_schema 의 calibration_runs 는 measurement 연결이 없었고 Job 표준
+컬럼(finished_at / error_message) 도 부족 → §11 API 구현 위해 추가.
+
+Revision ID: 20260516_0008
+Revises: 20260516_0007
+Create Date: 2026-05-16 00:00:00
+
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260516_0008"
+down_revision: Union[str, Sequence[str], None] = "20260516_0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "calibration_runs",
+        sa.Column(
+            "measurement_session_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("measurement_sessions.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "calibration_runs",
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "calibration_runs",
+        sa.Column("error_message", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "idx_calibration_runs_scene_version",
+        "calibration_runs",
+        ["scene_version_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_calibration_runs_scene_version", table_name="calibration_runs")
+    op.drop_column("calibration_runs", "error_message")
+    op.drop_column("calibration_runs", "finished_at")
+    op.drop_column("calibration_runs", "measurement_session_id")


### PR DESCRIPTION
## 요약
명세 §11.1/11.2/11.3 캘리브레이션 API + 백그라운드 워커 (스켈레톤) 구현. RF 시뮬과 실측 측정 비교로 재질 파라미터 보정하는 비동기 Job 흐름.

Closes #68

## 변경 사항

### 신규 엔드포인트 (5개)

**사용자 호출 (JWT)**
- `POST /calibration-runs` (§11.1) — 202, Job 큐 등록 + CalibrationRun 생성
- `GET /calibration-runs/{run_id}` (§11.2) — 결과 조회
- `GET /calibration-runs/{run_id}/parameter-updates` (§11.3) — 파라미터 변경 이력

**AI 워커 호출 (`X-Internal-API-Key`)**
- `PATCH /calibration-runs/{run_id}` — 상태/메트릭 갱신
- `POST /calibration-runs/{run_id}/parameter-updates` — 파라미터 변경 기록

### 백그라운드 워커 (스켈레톤)
- `app/services/calibration_worker.py` — `job_poller` 가 픽업
- 같은 프로세스 안에서 service 함수 직접 호출 (HTTP/internal key 불필요)
- 현재 동작: 측정 포인트 통계 (count/mean/min/max RSSI) + completed 마킹
- 진짜 보정 알고리즘 (실측 vs 예측 RMSE) 은 RfMap 들어오면 추가

### DB 변경 (`calibration_runs` 보강)
- `measurement_session_id` UUID FK 추가
- `finished_at` TIMESTAMP nullable
- `error_message` TEXT nullable
- 마이그레이션: `20260516_0008_calibration_columns`

### 명세 ↔ 모델 alias 매핑
| 명세 | 모델 | 위치 |
|---|---|---|
| `session_id` | `measurement_session_id` | response |
| `version_id` | `scene_version_id` | response |
| `error_metrics_json` | `metrics_json` | response |
| `error_heatmap_url` | `metrics_json.error_heatmap_url` | top-level 노출 |
| `param_name` | `parameter_name` | response |

## 테스트 (로컬 종단)
- [x] POST → 202, queued → 워커 픽업 → completed + metrics_json 채움
- [x] GET alias 매핑 동작
- [x] PATCH running/completed → finished_at 자동 설정
- [x] POST parameter-update → param_name 으로 응답
- [x] 권한: 타 유저 토큰 → 404, 인증 없음 → 401, internal key 없이 PATCH → 401

## 한계 / 후속
- 워커는 스켈레톤 — 실제 RMSE 계산은 RfMap 들어오면 추가
- main 머지로 코드 최신 상태