### PR TITLE
feat: 빈 SceneDraft 생성 API 추가 (#75)

### DIFF
--- a/backend/app/routers/scene_drafts.py
+++ b/backend/app/routers/scene_drafts.py
@@ -3,17 +3,44 @@ Scene Draft 라우터
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, status
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.pagination import PaginatedResponse
-from app.schemas.scene_draft import SceneDraftDetailResponse, SceneDraftSummaryResponse
+from app.schemas.scene_draft import (
+    SceneDraftCreateRequest,
+    SceneDraftDetailResponse,
+    SceneDraftSummaryResponse,
+)
 from app.services import scene_draft_service
 
 router = APIRouter(prefix="/scene-drafts", tags=["scene-drafts"])
+floor_scene_drafts_router = APIRouter(prefix="/floors", tags=["scene-drafts"])
+
+
+@floor_scene_drafts_router.post(
+    "/{floor_id}/scene-drafts",
+    response_model=SceneDraftDetailResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="빈 Scene Draft 생성 (수동 도면 작성용 — AI 분석 안 함)",
+)
+def create_empty_scene_draft(
+    payload: SceneDraftCreateRequest,
+    floor_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SceneDraftDetailResponse:
+    return scene_draft_service.create_empty_draft(
+        db,
+        floor_id=floor_id,
+        source_mode=payload.source_mode,
+        current_user=current_user,
+    )
 
 
 @router.get(

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -6,9 +6,9 @@ from app.schemas.scene import SceneSchema
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 
 class UploadStorageMetadataDTO(BaseModel):
@@ -38,6 +38,17 @@ class AnalyzeFromAssetRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     real_width_m: float = 10.0
+
+
+class SceneDraftCreateRequest(BaseModel):
+    """POST /floors/{floor_id}/scene-drafts — 빈 Draft 생성.
+
+    AI 분석 없이 사용자가 도면을 처음부터 그릴 때 사용.
+    현재는 "manual" 만 허용. 추후 다른 source_mode 추가 시 enum 확장.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    source_mode: Literal["manual"] = Field(default="manual")
 
 
 class SubmitFloorplanJobResponse(BaseModel):

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -443,6 +443,68 @@ def _draft_object_to_response(o: DraftObject) -> DraftObjectResponse:
         created_at=o.created_at,
     )
 
+def create_empty_draft(
+    db: Session,
+    floor_id: UUID,
+    source_mode: str,
+    current_user: User,
+) -> SceneDraftDetailResponse:
+    """이미지/AI 분석 없이 빈 SceneDraft 생성. 사용자가 직접 도면 그릴 때 사용."""
+    floor = (
+        db.query(Floor)
+        .join(Project, Floor.project_id == Project.id)
+        .filter(
+            Floor.id == str(floor_id),
+            Project.owner_user_id == current_user.id,
+        )
+        .first()
+    )
+    if floor is None:
+        raise AppError(
+            ErrorCode.FLOOR_NOT_FOUND,
+            "Floor not found.",
+            status_code=404,
+        )
+
+    scene_draft = SceneDraft(
+        project_id=floor.project_id,
+        floor_id=floor.id,
+        source_mode=source_mode,
+        source_method=source_mode,
+        summary_json={},
+        status="draft",
+        created_by=current_user.email,
+    )
+    try:
+        db.add(scene_draft)
+        db.commit()
+        db.refresh(scene_draft)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise AppError(
+            ErrorCode.SCENE_DRAFT_SAVE_FAILED,
+            f"Failed to create empty scene draft: {exc}",
+            500,
+        ) from exc
+
+    return SceneDraftDetailResponse(
+        id=scene_draft.id,
+        project_id=scene_draft.project_id,
+        floor_id=scene_draft.floor_id,
+        source_mode=scene_draft.source_mode,
+        source_asset_id=scene_draft.source_asset_id,
+        source_method=scene_draft.source_method,
+        summary_json=scene_draft.summary_json,
+        status=scene_draft.status,
+        rooms=[],
+        walls=[],
+        openings=[],
+        objects=[],
+        created_at=scene_draft.created_at,
+        updated_at=scene_draft.updated_at,
+    )
+
+
 def delete_scene_draft(
     db: Session, scene_draft_id: str, current_user: User
 ) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,10 @@ from app.routers.measurements import router as measurements_router
 from app.routers.auth import router as auth_router
 from app.routers.projects import router as projects_router
 from app.routers.floors import router as floors_router
-from app.routers.scene_drafts import router as scene_drafts_router
+from app.routers.scene_drafts import (
+    router as scene_drafts_router,
+    floor_scene_drafts_router,
+)
 from app.core.errors import AppError, ErrorCode
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -99,6 +102,7 @@ app.include_router(auth_router)
 app.include_router(projects_router)
 app.include_router(floors_router)
 app.include_router(scene_drafts_router)
+app.include_router(floor_scene_drafts_router)
 app.include_router(floor_assets_router)
 app.include_router(assets_router)
 app.include_router(scene_draft_rooms_router)


### PR DESCRIPTION
## 요약
이미지 업로드/AI 분석 없이 빈 SceneDraft 를 생성하는 엔드포인트 추가. 사용자가 도면을 처음부터 직접 그릴 수 있게 함.

Closes #75

## 변경 사항

### 신규 엔드포인트
- `POST /floors/{floor_id}/scene-drafts`
  - Request: `{ "source_mode": "manual" }` (Literal — 현재 "manual" 만 허용)
  - Response 201: `SceneDraftDetailResponse`
    - `source_mode`: "manual"
    - `source_method`: "manual"
    - `source_asset_id`: null
    - `summary_json`: {}
    - `status`: "draft"
    - `rooms / walls / openings / objects`: []
  - 권한: 본인 소유 floor 만 (404 if not owned)

이후 흐름은 기존과 동일:
- `POST /scene-drafts/{id}/draft-walls|rooms|openings|objects` 로 entity 추가
- `POST /scene-drafts/{id}/promote` 로 확정본 승격

## 파일
- `app/schemas/scene_draft.py` — `SceneDraftCreateRequest` 신규
- `app/services/scene_draft_service.py` — `create_empty_draft(...)` 신규
- `app/routers/scene_drafts.py` — `floor_scene_drafts_router` 신규 + POST 핸들러
- `main.py` — 라우터 등록

## DB
- 모델/마이그 변경 없음 (`source_mode` 컬럼 이미 존재)

## 테스트 (로컬)
- [x] POST 201, body 그대로 응답 (children 모두 [])
- [x] GET /scene-drafts/{id} 로 재조회 일치
- [x] 권한: 타 유저 토큰 → 404
- [x] `source_mode: "floorplan_image"` 등 → 422 (Literal 검증)
- [x] 인증 없음 → 401
- [x] 없는 floor → 404