### PR TITLE
[Fix] 도면 분석 결과를 Asset metadata에 반영하고 확정 SceneVersion 기준으로 context 조회

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -38,7 +38,10 @@ assets_router = APIRouter(prefix="/assets", tags=["assets"])
 def upload_asset(
     floor_id: UUID = Path(..., description="자산을 추가할 층 ID"),
     file: UploadFile = File(..., description="png/jpg/jpeg/pdf"),
-    asset_type: str = Form(..., description="floorplan / photo / document"),
+    asset_type: str = Form(
+        ...,
+        description="허용된 AssetType 값. 현재 'floorplan_image' 만 지원.",
+    ),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> AssetResponse:
@@ -60,7 +63,7 @@ def upload_asset(
 def list_assets(
     floor_id: UUID = Path(...),
     asset_type: Optional[str] = Query(
-        None, description="필터: floorplan/photo/document"
+        None, description="필터: AssetType 값 (예: floorplan_image)"
     ),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -9,6 +9,7 @@ from fastapi import UploadFile
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.enums import AssetType
 from app.core.errors import AppError, ErrorCode
 from app.core.settings import RF_PRESIGNED_URL_EXPIRES_SECONDS
 from app.models.asset import Asset
@@ -24,7 +25,10 @@ ALLOWED_EXTENSIONS: dict[str, str] = {
     "pdf": "application/pdf",
 }
 
-ALLOWED_ASSET_TYPES: set[str] = {"floorplan", "photo", "document"}
+# AssetType enum 과 1:1 매칭. measurement_service._latest_floorplan_asset 가
+# Asset.asset_type == "floorplan_image" 로 검색하므로 같은 문자열을 강제한다.
+# 새 종류(photo/document 등)는 먼저 AssetType enum 에 추가해야 함.
+ALLOWED_ASSET_TYPES: set[str] = {t.value for t in AssetType}
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +169,51 @@ def create_asset(
         _s3.delete_object(s3_uri)
         raise
 
+    return asset
+
+
+def create_floorplan_asset_from_bytes(
+    db: Session,
+    *,
+    project_id: str,
+    floor_id: str,
+    content: bytes,
+    filename: str,
+    content_type: Optional[str],
+    uploaded_by: str,
+) -> Asset:
+    """이미 byte 로 읽어둔 도면 이미지를 S3 + assets 에 저장.
+
+    /upload/floorplan/analyze 흐름처럼 UploadFile 을 한 번 read 한 뒤 같은 byte 를
+    SageMaker 와 asset 양쪽에 써야 할 때 사용한다. commit 은 호출자에게 위임
+    (보통 같은 트랜잭션에서 Job row 도 같이 commit).
+    """
+    asset_type = AssetType.FLOORPLAN_IMAGE.value
+    ext = _resolve_extension(filename)
+    asset_id = uuid4()
+    key = _build_s3_key(project_id, floor_id, asset_id, ext)
+    mime_type = content_type or ALLOWED_EXTENSIONS[ext]
+    s3_uri = _s3.upload_bytes(key, content, content_type=mime_type)
+
+    asset = Asset(
+        id=str(asset_id),
+        project_id=project_id,
+        floor_id=floor_id,
+        uploaded_by=uploaded_by,
+        asset_type=asset_type,
+        source_format=ext,
+        storage_url=s3_uri,
+        mime_type=mime_type,
+        file_size_bytes=len(content),
+        metadata_json={},
+    )
+    try:
+        db.add(asset)
+        db.flush()
+    except Exception:
+        db.rollback()
+        _s3.delete_object(s3_uri)
+        raise
     return asset
 
 

--- a/backend/app/services/floorplan_job_service.py
+++ b/backend/app/services/floorplan_job_service.py
@@ -17,12 +17,15 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
+from sqlalchemy.orm.attributes import flag_modified
+
 from app.core.errors import AppError, ErrorCode
-from app.models import Floor, Job, Project, User
+from app.models import Asset, Floor, Job, Project, User
 from app.schemas.scene_draft import (
     SaveSceneDraftRequestDTO,
     UploadStorageMetadataDTO,
 )
+from app.services.asset_service import create_floorplan_asset_from_bytes
 from app.services.fusion_service import fusion_service
 from app.services.sagemaker_inference_service import (
     SageMakerInferenceFailure,
@@ -54,11 +57,45 @@ async def submit_floorplan_analysis(
     current_user: User,
     upload_metadata: UploadStorageMetadataDTO,
     created_by: str | None = None,
+    source_asset_id: str | None = None,
 ) -> Job:
-    """SageMaker submit + Job row 생성. 1~3초 안에 반환."""
+    """SageMaker submit + Job row 생성. 1~3초 안에 반환.
+
+    source_asset_id 가 None 이면 이 Job 이 분석할 원본 도면을 assets 테이블에 자동
+    등록한다 (raw upload 흐름). analyze_from_asset 처럼 이미 asset 이 있는 경우는
+    호출자가 그 id 를 명시적으로 넘겨야 중복 생성을 막을 수 있다.
+
+    저장된 source_asset_id 는 Job.input_json 에 보관되어 _complete_floorplan_job
+    에서 asset.metadata_json 백필 + SceneDraft.source_asset_id 전파에 쓰인다.
+    """
     resolved_project_id, resolved_floor_id = _resolve_project_floor(
         db, project_id, floor_id, current_user
     )
+
+    # raw upload 경로면 여기서 asset row 를 만들어 둔다. floor 단위 도면 자산이
+    # 항상 존재해야 measurement_link 가 그걸 가리킬 수 있다.
+    if source_asset_id is None:
+        new_asset = create_floorplan_asset_from_bytes(
+            db,
+            project_id=resolved_project_id,
+            floor_id=resolved_floor_id,
+            content=image_bytes,
+            filename=filename,
+            content_type=content_type,
+            uploaded_by=current_user.id,
+        )
+        source_asset_id = new_asset.id
+        # upload_metadata 에 실제 S3 좌표도 같이 보관 (참조 용이)
+        if not upload_metadata.s3_uri:
+            try:
+                upload_metadata = upload_metadata.model_copy(
+                    update={
+                        "provider": upload_metadata.provider or "s3",
+                        "s3_uri": new_asset.storage_url,
+                    }
+                )
+            except Exception:
+                pass
 
     submit_result = await sagemaker_inference_service.submit(
         image_bytes=image_bytes,
@@ -73,6 +110,7 @@ async def submit_floorplan_analysis(
         "content_type": content_type,
         "real_width_m": real_width_m,
         "created_by": created_by or current_user.email,
+        "source_asset_id": source_asset_id,
         "upload": upload_metadata.model_dump(),
         "sagemaker": {
             "inference_id": submit_result.sagemaker_inference_id,
@@ -222,6 +260,13 @@ async def _complete_floorplan_job(
         if locked.status != JOB_STATUS_RUNNING:
             return locked
 
+        source_asset_id = (locked.input_json or {}).get("source_asset_id")
+
+        # 측정 흐름이 asset.metadata_json 에서 width/height/scale 을 읽기 때문에
+        # 분석 결과가 나오는 이 시점에 같이 채워둬야 모바일 context 의 bounds 가 정상.
+        if source_asset_id:
+            _backfill_asset_spatial_metadata(db, source_asset_id, scene)
+
         request_dto = SaveSceneDraftRequestDTO(
             scene=scene,
             upload=UploadStorageMetadataDTO(**upload_meta) if upload_meta else UploadStorageMetadataDTO(),
@@ -229,7 +274,9 @@ async def _complete_floorplan_job(
             floor_id=locked.floor_id,
             created_by=created_by,
         )
-        save_result = save_scene_draft(db, request_dto, current_user)
+        save_result = save_scene_draft(
+            db, request_dto, current_user, source_asset_id=source_asset_id
+        )
     except SageMakerInferenceFailure as failure:
         # build 중에 발생할 일은 거의 없지만 방어적으로
         return _claim_and_finalize(
@@ -355,6 +402,51 @@ def _mark_job_failed(
 # ============================================================
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _backfill_asset_spatial_metadata(db: Session, asset_id: str, scene: Any) -> None:
+    """분석 결과에서 얻은 도면 픽셀 차원/스케일을 asset.metadata_json 에 머지.
+
+    measurement_service._bounds_from_floorplan 이 width_px/height_px/scale_m_per_px
+    중 하나라도 None 이면 빈 bounds 를 반환하기 때문에 이 백필이 누락되면 모바일
+    measurement context 가 도면 url 만 있고 좌표 frame 이 없는 상태가 된다.
+
+    JSONB 컬럼은 dict 내부 변경을 SQLAlchemy 가 감지하지 못해 flag_modified 가 필요.
+    """
+    asset = db.get(Asset, asset_id)
+    if asset is None:
+        logger.warning("backfill skipped: asset %s not found", asset_id)
+        return
+
+    image_meta = getattr(scene, "inference_metadata", None) or {}
+    if not isinstance(image_meta, dict):
+        image_meta = {}
+    image = image_meta.get("image") or {}
+    width = image.get("width_px")
+    height = image.get("height_px")
+    scale = getattr(scene, "scale_ratio", None)
+
+    md: dict[str, Any] = dict(asset.metadata_json or {})
+    changed = False
+    if width is not None and md.get("width_px") != width:
+        md["width_px"] = int(width)
+        changed = True
+    if height is not None and md.get("height_px") != height:
+        md["height_px"] = int(height)
+        changed = True
+    if scale is not None:
+        scale_f = float(scale)
+        if md.get("scale_m_per_px") != scale_f:
+            md["scale_m_per_px"] = scale_f
+            changed = True
+
+    if changed:
+        asset.metadata_json = md
+        flag_modified(asset, "metadata_json")
+        logger.info(
+            "asset %s spatial metadata backfilled: w=%s h=%s scale=%s",
+            asset_id, md.get("width_px"), md.get("height_px"), md.get("scale_m_per_px"),
+        )
 
 
 def _get_owned_floorplan_job_or_404(

--- a/backend/app/services/measurement_service.py
+++ b/backend/app/services/measurement_service.py
@@ -125,13 +125,18 @@ def _resolve_scene_and_asset(
 ) -> tuple[str | None, str | None]:
     """Pick the scene_version + asset that this measurement link should anchor to.
 
-    Preference: latest scene_version for the floor (and its source_asset_id);
-    fall back to the latest floorplan_image asset on the floor when no scene
-    version exists yet.
+    Preference: latest **confirmed** scene_version for the floor (and its
+    source_asset_id); fall back to the latest floorplan_image asset on the
+    floor when no confirmed scene version exists yet. Draft (is_confirmed=False)
+    versions are ignored — measurement links must anchor to a stable, user-
+    approved scene so that downstream coordinates stay consistent.
     """
     scene = db.execute(
         select(SceneVersion)
-        .where(SceneVersion.floor_id == floor_id)
+        .where(
+            SceneVersion.floor_id == floor_id,
+            SceneVersion.is_confirmed.is_(True),
+        )
         .order_by(SceneVersion.version_no.desc())
         .limit(1)
     ).scalar_one_or_none()

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -320,6 +320,7 @@ async def analyze_from_asset(
         current_user=current_user,
         upload_metadata=upload_metadata,
         created_by=current_user.email,
+        source_asset_id=str(asset.id),
     )
 
     return AnalyzeFromAssetResponse(


### PR DESCRIPTION
## 개요
모바일 측정 context에서 도면 bounds가 비정상적으로 내려오는 문제를 해결하기 위해, 도면 분석 job과 원본 floorplan Asset의 연결을 보강
- `/upload/floorplan/analyze` 흐름에서도 floorplan Asset row를 생성하고, 분석 job input에 `source_asset_id`를 저장
- SageMaker 분석 완료 후에는 이미지 크기와 scale 정보를 `Asset.metadata_json`으로 적어두어 measurement context가 정상적인 bounds를 계산할 수 있도록 수정

또한 measurement context는 draft scene이 아니라 `is_confirmed=True`인 확정 SceneVersion만 기준으로 선택하도록 수정

핵심 흐름
```
도면 업로드
→ floorplan Asset 생성
→ Job.input_json.source_asset_id 저장
→ SageMaker 분석 완료
→ Asset.metadata_json에 width/height/scale 백필
→ SceneDraft 저장 시 source_asset_id 전달
→ 사용자가 draft 확정
→ confirmed SceneVersion 생성
→ measurement context가 confirmed SceneVersion + Asset metadata 기준으로 bounds 생성
```

## 변경 내용
### 1. AssetType 기준 통일
- 기존 `floorplan`, `photo`, `document` 문자열 기반 허용 목록을 `AssetType` enum 기반으로 변경

### 2. Raw upload 분석 흐름에서도 Asset 생성
- `/upload/floorplan/analyze`처럼 UploadFile bytes를 바로 SageMaker 분석에 넘기는 흐름에서도 floorplan Asset row를 생성하도록 변경
- `create_floorplan_asset_from_bytes()`를 추가하여 이미 읽어둔 image bytes를 S3에 저장하고 assets row를 생성할 수 있게 변경
- 생성된 asset id는 `source_asset_id`로 사용

### 3. 분석 Job과 원본 Asset 연결
- `submit_floorplan_analysis()`에 `source_asset_id` 파라미터를 추가
- 분석 job 생성 시 `Job.input_json.source_asset_id`에 분석 대상 asset id를 저장
- `/assets/{asset_id}/analyze` 흐름에서는 기존 asset id를 `source_asset_id`로 전달하여 중복 asset 생성을 방지

### 4. 분석 완료 후 Asset metadata 저장
```json
{
  "width_px": 1234,
  "height_px": 987,
  "scale_m_per_px": 0.02
}
```
### 5. SceneDraft 저장 시 source_asset_id 전달
- 분석 완료 후 save_scene_draft() 호출 시 source_asset_id를 전달하도록 수정
이후 draft publish 과정에서 confirmed SceneVersion이 원본 Asset을 추적할 수 있는 기반을 마련

### 6. Measurement context 기준을 확정본으로 제한
- measurement_service._resolve_scene_and_asset()에서 SceneVersion.is_confirmed == True인 version만 조회하도록 수정
- 측정 링크는 draft가 아니라 사용자가 확정한 stable scene을 기준으로 동작하도록 수정

## Test
aseet_id 받아오기 성공
<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/61aea699-cd8d-4232-b0b3-002f88a65096" />

모바일에서 원본 이미지 받아오는지 테스트 성공
<img width="1200" height="2000" alt="image" src="https://github.com/user-attachments/assets/ff122167-a02b-4a1d-ad21-27ce53a7004c" />

## 주의할 점
- 현재 도면이 두 번 저장되어 한 번 저장 후 재사용으로 수정 필요!! 
- (submit()이 source_s3_uri를 받고 자체 PUT은 스킵하도록 )
