### PR TITLE
feat: §10.4/10.5 측정 세션·포인트·발견 AP 조회 API (#77)

### DIFF
--- a/backend/app/routers/measurements.py
+++ b/backend/app/routers/measurements.py
@@ -1,17 +1,22 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
+from app.api.deps import get_current_user
 from app.db.session import get_db
+from app.models.user import User
 from app.schemas.measurement import (
+    DetectedApResponseDTO,
     MeasurementLinkContextResponseDTO,
     MeasurementLinkCreateResponseDTO,
     MeasurementPointBatchRequestDTO,
     MeasurementPointBatchResponseDTO,
+    MeasurementPointResponseDTO,
     MeasurementSessionCompleteRequestDTO,
     MeasurementSessionCompleteResponseDTO,
     MeasurementSessionCreateRequestDTO,
     MeasurementSessionResponseDTO,
 )
+from app.schemas.pagination import PaginatedResponse
 from app.services import measurement_service
 
 router = APIRouter(tags=["measurement"])
@@ -72,3 +77,67 @@ def complete_measurement_session(
     db: Session = Depends(get_db),
 ) -> MeasurementSessionCompleteResponseDTO:
     return measurement_service.complete_measurement_session(db, session_id, body)
+
+
+# ============================================================
+# §10.4 / §10.5 — 웹에서 조회 (JWT, owner check)
+# ============================================================
+@router.get(
+    "/measurement-sessions/{session_id}",
+    response_model=MeasurementSessionResponseDTO,
+    summary="측정 세션 단건 조회 (§10.4)",
+)
+def get_measurement_session(
+    session_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> MeasurementSessionResponseDTO:
+    return measurement_service.get_session(db, session_id, current_user)
+
+
+@router.get(
+    "/measurement-sessions/{session_id}/points",
+    response_model=PaginatedResponse[MeasurementPointResponseDTO],
+    summary="세션 내 측정 포인트 목록 (§10.4, 페이지네이션)",
+)
+def list_measurement_points(
+    session_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=100, ge=1, le=500),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[MeasurementPointResponseDTO]:
+    return measurement_service.list_points(
+        db, session_id, current_user, page=page, page_size=page_size
+    )
+
+
+@router.get(
+    "/floors/{floor_id}/measurement-sessions",
+    response_model=PaginatedResponse[MeasurementSessionResponseDTO],
+    summary="층의 측정 세션 목록 (§10.4)",
+)
+def list_floor_measurement_sessions(
+    floor_id: str,
+    status: str | None = Query(default=None, description="in_progress|completed 등 필터"),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[MeasurementSessionResponseDTO]:
+    return measurement_service.list_sessions_by_floor(
+        db, floor_id, current_user, page=page, page_size=page_size, status=status
+    )
+
+
+@router.get(
+    "/measurement-sessions/{session_id}/detected-aps",
+    response_model=list[DetectedApResponseDTO],
+    summary="세션 내 발견된 AP 목록 (§10.5)",
+)
+def list_detected_aps(
+    session_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[DetectedApResponseDTO]:
+    return measurement_service.list_detected_aps(db, session_id, current_user)

--- a/backend/app/schemas/measurement.py
+++ b/backend/app/schemas/measurement.py
@@ -144,3 +144,42 @@ class MeasurementSessionCompleteResponseDTO(BaseModel):
     duration_seconds: int
     ap_count: int
     rssi_range: RssiRangeDTO
+
+
+# ============================================================
+# §10.4 / §10.5 조회 응답 DTO
+# ============================================================
+class MeasurementPointResponseDTO(BaseModel):
+    """§10.4 — 측정 포인트 단건 조회 응답."""
+    id: str
+    session_id: str
+    client_point_id: str | None = None
+    batch_id: str | None = None
+    floor_position: FloorPositionDTO
+    rssi_dbm: float | None = None
+    ap_bssid: str | None = None
+    ap_ssid: str | None = None
+    channel: int | None = None
+    frequency_mhz: int | None = None
+    timestamp_at_point: datetime | None = None
+    ar_tracking_state: str | None = None
+    ar_confidence: float | None = None
+    step_index: int | None = None
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+
+    @field_serializer("timestamp_at_point", "created_at", when_used="unless-none")
+    def _serialize_dt(self, value: datetime) -> str:
+        return _utc_iso_z(value)
+
+
+class DetectedApResponseDTO(BaseModel):
+    """§10.5 — 세션 내에서 측정된 고유 AP 집계."""
+    ap_bssid: str
+    ap_ssid: str | None = None
+    channel: int | None = None
+    frequency_mhz: int | None = None
+    point_count: int
+    rssi_avg: float | None = None
+    rssi_min: float | None = None
+    rssi_max: float | None = None

--- a/backend/app/services/measurement_service.py
+++ b/backend/app/services/measurement_service.py
@@ -15,26 +15,33 @@ from app.core.settings import (
     MEASUREMENT_LINK_TTL_SECONDS,
     MEASUREMENT_WEB_FALLBACK_BASE_URL,
 )
+from app.core.geom import wkb_to_geojson
 from app.models.asset import Asset
 from app.models.floor import Floor
 from app.models.measurement_link import MeasurementLink
 from app.models.measurement_point import MeasurementPoint
 from app.models.measurement_session import MeasurementSession
+from app.models.project import Project
 from app.models.scene_version import SceneVersion
+from app.models.user import User
 from app.schemas.measurement import (
     CoordinateSystemDTO,
+    DetectedApResponseDTO,
     FloorBoundsDTO,
+    FloorPositionDTO,
     FloorplanInfoDTO,
     MeasurementLinkContextResponseDTO,
     MeasurementLinkCreateResponseDTO,
     MeasurementPointBatchRequestDTO,
     MeasurementPointBatchResponseDTO,
+    MeasurementPointResponseDTO,
     MeasurementSessionCompleteRequestDTO,
     MeasurementSessionCompleteResponseDTO,
     MeasurementSessionCreateRequestDTO,
     MeasurementSessionResponseDTO,
     RssiRangeDTO,
 )
+from app.schemas.pagination import PaginatedResponse
 
 FLOORPLAN_ASSET_TYPE = "floorplan_image"
 
@@ -395,3 +402,200 @@ def complete_measurement_session(
             avg=float(rssi_avg) if rssi_avg is not None else None,
         ),
     )
+
+
+# ============================================================
+# §10.4 / §10.5 조회 API (JWT — 본인 소유 floor 의 데이터만)
+# ============================================================
+def _load_owned_session(
+    db: Session, session_id: str, user: User
+) -> MeasurementSession:
+    _validate_uuid(session_id, "session_id")
+    row = (
+        db.query(MeasurementSession)
+        .join(Project, MeasurementSession.project_id == Project.id)
+        .filter(
+            MeasurementSession.id == session_id,
+            Project.owner_user_id == user.id,
+        )
+        .one_or_none()
+    )
+    if row is None:
+        raise AppError(
+            ErrorCode.MEASUREMENT_SESSION_NOT_FOUND,
+            f"Measurement session not found: {session_id}",
+            404,
+        )
+    return row
+
+
+def _validate_owned_floor(db: Session, floor_id: str, user: User) -> None:
+    _validate_uuid(floor_id, "floor_id")
+    floor = (
+        db.query(Floor)
+        .join(Project, Floor.project_id == Project.id)
+        .filter(Floor.id == floor_id, Project.owner_user_id == user.id)
+        .one_or_none()
+    )
+    if floor is None:
+        raise AppError(
+            ErrorCode.FLOOR_NOT_FOUND,
+            f"Floor not found: {floor_id}",
+            404,
+        )
+
+
+def _session_to_response(row: MeasurementSession) -> MeasurementSessionResponseDTO:
+    # MeasurementSession 자체엔 asset_id/scene_version_id 가 없음 (link 가 가짐).
+    # 호환을 위해 None 으로 둠 — 필요시 link 통해 조회 가능.
+    return MeasurementSessionResponseDTO(
+        id=row.id,
+        project_id=row.project_id,
+        floor_id=row.floor_id,
+        scene_version_id=None,
+        asset_id=None,
+        measurement_type=row.measurement_type,
+        status=row.status,
+        created_at=row.created_at,
+    )
+
+
+def get_session(
+    db: Session, session_id: str, user: User
+) -> MeasurementSessionResponseDTO:
+    """§10.4 — 측정 세션 단건 조회."""
+    return _session_to_response(_load_owned_session(db, session_id, user))
+
+
+def _point_to_response(row: MeasurementPoint) -> MeasurementPointResponseDTO:
+    gj = wkb_to_geojson(row.point_geom)
+    coords = (gj or {}).get("coordinates") or [0.0, 0.0]
+    z = float(row.z_m) if row.z_m is not None else 0.0
+    return MeasurementPointResponseDTO(
+        id=row.id,
+        session_id=row.session_id,
+        client_point_id=row.client_point_id,
+        batch_id=row.batch_id,
+        floor_position=FloorPositionDTO(
+            x=float(coords[0]), y=float(coords[1]), z=z
+        ),
+        rssi_dbm=float(row.rssi_dbm) if row.rssi_dbm is not None else None,
+        ap_bssid=row.ap_bssid,
+        ap_ssid=row.ap_ssid,
+        channel=row.channel,
+        frequency_mhz=row.frequency_mhz,
+        timestamp_at_point=row.timestamp_at_point,
+        ar_tracking_state=row.ar_tracking_state,
+        ar_confidence=float(row.ar_confidence) if row.ar_confidence is not None else None,
+        step_index=row.step_index,
+        metadata_json=row.metadata_json or {},
+        created_at=row.created_at,
+    )
+
+
+def list_points(
+    db: Session,
+    session_id: str,
+    user: User,
+    page: int,
+    page_size: int,
+) -> PaginatedResponse[MeasurementPointResponseDTO]:
+    """§10.4 — 세션 내 측정 포인트 페이지네이션 조회."""
+    _load_owned_session(db, session_id, user)
+
+    total = db.execute(
+        select(func.count(MeasurementPoint.id)).where(
+            MeasurementPoint.session_id == session_id
+        )
+    ).scalar() or 0
+
+    rows = (
+        db.execute(
+            select(MeasurementPoint)
+            .where(MeasurementPoint.session_id == session_id)
+            .order_by(MeasurementPoint.step_index.asc().nullslast(), MeasurementPoint.created_at.asc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        .scalars()
+        .all()
+    )
+    return PaginatedResponse[MeasurementPointResponseDTO](
+        items=[_point_to_response(r) for r in rows],
+        page=page,
+        page_size=page_size,
+        total=int(total),
+    )
+
+
+def list_sessions_by_floor(
+    db: Session,
+    floor_id: str,
+    user: User,
+    page: int,
+    page_size: int,
+    status: str | None = None,
+) -> PaginatedResponse[MeasurementSessionResponseDTO]:
+    """§10.4 — 층의 모든 측정 세션 목록 (페이지네이션 + status 필터)."""
+    _validate_owned_floor(db, floor_id, user)
+
+    base = (
+        db.query(MeasurementSession)
+        .filter(MeasurementSession.floor_id == floor_id)
+    )
+    if status is not None:
+        base = base.filter(MeasurementSession.status == status)
+
+    total = base.count()
+    rows = (
+        base.order_by(MeasurementSession.created_at.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return PaginatedResponse[MeasurementSessionResponseDTO](
+        items=[_session_to_response(r) for r in rows],
+        page=page,
+        page_size=page_size,
+        total=int(total),
+    )
+
+
+def list_detected_aps(
+    db: Session, session_id: str, user: User
+) -> list[DetectedApResponseDTO]:
+    """§10.5 — 세션 내 ap_bssid 별 집계."""
+    _load_owned_session(db, session_id, user)
+
+    rows = db.execute(
+        select(
+            MeasurementPoint.ap_bssid,
+            func.max(MeasurementPoint.ap_ssid).label("ap_ssid"),
+            func.max(MeasurementPoint.channel).label("channel"),
+            func.max(MeasurementPoint.frequency_mhz).label("frequency_mhz"),
+            func.count(MeasurementPoint.id).label("point_count"),
+            func.avg(MeasurementPoint.rssi_dbm).label("rssi_avg"),
+            func.min(MeasurementPoint.rssi_dbm).label("rssi_min"),
+            func.max(MeasurementPoint.rssi_dbm).label("rssi_max"),
+        )
+        .where(
+            MeasurementPoint.session_id == session_id,
+            MeasurementPoint.ap_bssid.isnot(None),
+        )
+        .group_by(MeasurementPoint.ap_bssid)
+        .order_by(func.count(MeasurementPoint.id).desc())
+    ).all()
+
+    return [
+        DetectedApResponseDTO(
+            ap_bssid=r.ap_bssid,
+            ap_ssid=r.ap_ssid,
+            channel=r.channel,
+            frequency_mhz=r.frequency_mhz,
+            point_count=int(r.point_count),
+            rssi_avg=float(r.rssi_avg) if r.rssi_avg is not None else None,
+            rssi_min=float(r.rssi_min) if r.rssi_min is not None else None,
+            rssi_max=float(r.rssi_max) if r.rssi_max is not None else None,
+        )
+        for r in rows
+    ]


### PR DESCRIPTION
## 요약
명세 §10.4 (세션/포인트 조회), §10.5 (발견 AP 집계) 구현. 측정 도메인은 그동안 쓰기만 가능 → 웹에서 측정 결과 보기 + 캘리브레이션 워커가 측정 데이터 활용 가능.

모바일 (wifi_mobile 레포) 의 쓰기 흐름 (POST 4개) 과 무관한 추가 — 기존 동작 영향 없음.

Closes #77

## 신규 엔드포인트 4개 (모두 JWT)

### §10.4 세션 / 포인트 조회
- `GET /measurement-sessions/{session_id}` — 세션 단건
- `GET /measurement-sessions/{session_id}/points?page=1&page_size=100` — 포인트 페이지네이션
- `GET /floors/{floor_id}/measurement-sessions?status=completed&page=1` — 층의 세션 목록

### §10.5 발견 AP 집계
- `GET /measurement-sessions/{session_id}/detected-aps` — ap_bssid 별 GROUP BY (point_count, rssi_avg/min/max)

## 권한
- 본인 소유 project 의 floor/session 만 접근 (404 if not owned)
- `_load_owned_session` / `_validate_owned_floor` 헬퍼 추가

## 파일 변경
- `app/schemas/measurement.py` — `MeasurementPointResponseDTO`, `DetectedApResponseDTO` 신규
- `app/services/measurement_service.py` — `get_session`, `list_points`, `list_sessions_by_floor`, `list_detected_aps` 신규
- `app/routers/measurements.py` — GET 4개 핸들러
- DB 변경 없음

## 한계 (별도 이슈)
세션 응답의 `scene_version_id`, `asset_id` 는 현재 None — MeasurementSession 모델에 해당 컬럼 없음. 명세 §10.0-10.3 의 다른 필드 미스매치도 추후 정리 예정 (현재 모바일 앱 구현과는 일치 확인됨).

## 테스트 (로컬)
- [x] 4개 GET 정상 동작
- [x] 페이지네이션 (total/page/page_size) 응답
- [x] 권한: 타 유저 토큰 → 404
- [x] 인증 없음 → 401
- [x] 없는 session → 404
