### PR TITLE
feat: GP regression 기반 측정 dense coverage 추정 API (#81)

### DIFF
--- a/backend/app/routers/measurements.py
+++ b/backend/app/routers/measurements.py
@@ -6,6 +6,7 @@ from app.db.session import get_db
 from app.models.user import User
 from app.schemas.measurement import (
     DetectedApResponseDTO,
+    EstimatedCoverageResponseDTO,
     MeasurementLinkContextResponseDTO,
     MeasurementLinkCreateResponseDTO,
     MeasurementPointBatchRequestDTO,
@@ -141,3 +142,19 @@ def list_detected_aps(
     current_user: User = Depends(get_current_user),
 ) -> list[DetectedApResponseDTO]:
     return measurement_service.list_detected_aps(db, session_id, current_user)
+
+
+@router.get(
+    "/measurement-sessions/{session_id}/estimated-coverage",
+    response_model=EstimatedCoverageResponseDTO,
+    summary="GP regression 으로 측정점 → dense RSSI 맵 추정 (#81)",
+)
+def estimate_session_coverage(
+    session_id: str,
+    resolution_m: float = Query(default=0.5, gt=0.1, le=2.0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> EstimatedCoverageResponseDTO:
+    return measurement_service.estimate_session_coverage(
+        db, session_id, current_user, grid_resolution_m=resolution_m
+    )

--- a/backend/app/schemas/measurement.py
+++ b/backend/app/schemas/measurement.py
@@ -183,3 +183,25 @@ class DetectedApResponseDTO(BaseModel):
     rssi_avg: float | None = None
     rssi_min: float | None = None
     rssi_max: float | None = None
+
+
+# ============================================================
+# GP 보간 응답 (#81)
+# ============================================================
+class EstimatedRssiRangeDTO(BaseModel):
+    min: float
+    max: float
+    mean: float
+
+
+class EstimatedCoverageResponseDTO(BaseModel):
+    """GP regression 결과. mean/uncertainty heatmap presigned URL + 메타."""
+    heatmap_url: str           # 평균 RSSI heatmap (presigned)
+    uncertainty_url: str       # 불확실성 (std) heatmap (presigned)
+    bounds: FloorBoundsDTO     # 도면 좌표 영역
+    grid_shape: list[int]      # [H, W]
+    grid_resolution_m: float
+    rssi_range: EstimatedRssiRangeDTO  # 추정 grid 의 min/max/mean (dBm)
+    uncertainty_max_db: float
+    input_point_count: int     # GP 학습에 쓴 측정점 개수
+    kernel_repr: str           # 학습된 kernel 정보 (디버깅)

--- a/backend/app/services/measurement_estimation/gp_estimator.py
+++ b/backend/app/services/measurement_estimation/gp_estimator.py
@@ -1,0 +1,113 @@
+"""측정 sparse N개 점 → Gaussian Process Regression → 도면 dense RSSI map 추정.
+
+기술적 접근:
+  - scikit-learn `GaussianProcessRegressor` 사용 — 핵심 수학 (kernel posterior,
+    hyperparameter MLE) 은 라이브러리가 처리. 본 모듈은 wrapper.
+  - 커널: ConstantKernel × RBF + WhiteKernel
+      * RBF length_scale = 공간 상관관계 거리 (3m default — 일반 실내 환경)
+      * WhiteKernel = 측정 노이즈 (±2dB default — Wi-Fi RSSI 전형값)
+  - 결과: 각 grid 셀에 (mean, std) 동시 제공 — uncertainty quantification
+
+length_scale / noise_level 은 initial value 이고, `n_restarts_optimizer` 가
+MLE 로 자동 튜닝함. 실데이터에 맞춰지므로 초기값에 크게 민감하지 않음.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import RBF, ConstantKernel, WhiteKernel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CoverageEstimate:
+    """GP 보간 결과."""
+
+    mean_grid: np.ndarray   # (H, W) RSSI 평균 예측 (dBm)
+    std_grid: np.ndarray    # (H, W) 불확실성 표준편차 (dB)
+    xs: np.ndarray          # (W,) grid x 좌표 (m)
+    ys: np.ndarray          # (H,) grid y 좌표 (m)
+    input_point_count: int  # 입력 측정점 개수
+    kernel_repr: str        # 학습 후 kernel string (디버깅)
+
+
+def estimate_coverage(
+    points: list[tuple[float, float, float]],
+    bounds: tuple[float, float, float, float],
+    grid_resolution_m: float = 0.5,
+    initial_length_scale_m: float = 3.0,
+    initial_noise_db: float = 2.0,
+) -> CoverageEstimate:
+    """측정점 → GP fit → dense grid 예측.
+
+    Args:
+        points: (x_m, y_m, rssi_dbm) 리스트. 최소 3개 필요.
+        bounds: (min_x, min_y, max_x, max_y) 도면 영역 (m).
+        grid_resolution_m: 출력 grid 셀 크기 (m). 작을수록 정밀, 비쌈.
+        initial_length_scale_m: RBF kernel length scale 초기값. 자동 튜닝됨.
+        initial_noise_db: 측정 노이즈 초기값. 자동 튜닝됨.
+
+    Returns:
+        CoverageEstimate (mean_grid, std_grid, xs, ys, ...).
+
+    Raises:
+        ValueError: 측정점이 3개 미만이면 GP 학습 불안정 → 거부.
+    """
+    if len(points) < 3:
+        raise ValueError(
+            f"At least 3 measurement points required for GP estimation (got {len(points)})"
+        )
+
+    # 1. 데이터 분리
+    arr = np.asarray(points, dtype=np.float64)
+    X = arr[:, :2]          # (N, 2)
+    y = arr[:, 2]           # (N,)
+
+    # 2. GP 정의
+    # ConstantKernel: 신호 분산 (자동 튜닝)
+    # RBF: 공간 상관관계 (length_scale 자동 튜닝)
+    # WhiteKernel: 측정 노이즈 (noise_level 자동 튜닝)
+    kernel = (
+        ConstantKernel(constant_value=1.0, constant_value_bounds=(1e-2, 1e3))
+        * RBF(length_scale=initial_length_scale_m, length_scale_bounds=(0.5, 50.0))
+        + WhiteKernel(
+            noise_level=initial_noise_db, noise_level_bounds=(0.1, 50.0)
+        )
+    )
+    gp = GaussianProcessRegressor(
+        kernel=kernel,
+        n_restarts_optimizer=5,
+        normalize_y=True,
+        random_state=42,
+    )
+
+    # 3. 학습 (N 작아도 빠름. 200점 기준 1초 이내)
+    gp.fit(X, y)
+    logger.info(
+        "GP fitted: N=%d, kernel=%s, log_marginal_likelihood=%.2f",
+        len(points), gp.kernel_, gp.log_marginal_likelihood_value_,
+    )
+
+    # 4. 도면 grid 생성
+    min_x, min_y, max_x, max_y = bounds
+    xs = np.arange(min_x, max_x + 1e-9, grid_resolution_m)
+    ys = np.arange(min_y, max_y + 1e-9, grid_resolution_m)
+    grid_X, grid_Y = np.meshgrid(xs, ys)
+    grid_points = np.column_stack([grid_X.ravel(), grid_Y.ravel()])
+
+    # 5. 예측 (mean + std)
+    mean, std = gp.predict(grid_points, return_std=True)
+
+    H, W = len(ys), len(xs)
+    return CoverageEstimate(
+        mean_grid=mean.reshape(H, W),
+        std_grid=std.reshape(H, W),
+        xs=xs,
+        ys=ys,
+        input_point_count=len(points),
+        kernel_repr=str(gp.kernel_),
+    )

--- a/backend/app/services/measurement_estimation/heatmap.py
+++ b/backend/app/services/measurement_estimation/heatmap.py
@@ -1,0 +1,128 @@
+"""GP 보간 결과 → matplotlib heatmap PNG → S3 업로드.
+
+mean heatmap (예측 RSSI) 과 uncertainty heatmap (표준편차) 두 개 PNG 생성.
+mean 은 jet/viridis 같은 신호 강도 컬러맵, uncertainty 는 흑백 / hot 컬러맵 사용.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import uuid
+
+import matplotlib
+
+matplotlib.use("Agg")  # 서버 환경 — GUI backend 비활성
+import matplotlib.pyplot as plt
+import numpy as np
+
+from app.services import _s3
+from .gp_estimator import CoverageEstimate
+
+logger = logging.getLogger(__name__)
+
+
+def _render_to_png(
+    grid: np.ndarray,
+    xs: np.ndarray,
+    ys: np.ndarray,
+    *,
+    cmap: str,
+    vmin: float | None,
+    vmax: float | None,
+    title: str,
+    colorbar_label: str,
+    overlay_points: list[tuple[float, float]] | None = None,
+) -> bytes:
+    """grid + 컬러맵 → PNG bytes. 좌표축 = 미터."""
+    H, W = grid.shape
+    # 도면 비율 그대로 (figsize 약간 조정)
+    aspect = (xs[-1] - xs[0]) / max(ys[-1] - ys[0], 1e-6)
+    fig_h = 6
+    fig_w = max(4.0, min(16.0, fig_h * aspect))
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h), dpi=120)
+    im = ax.imshow(
+        grid,
+        extent=(xs[0], xs[-1], ys[-1], ys[0]),  # y 뒤집기 — top_left 원점
+        cmap=cmap,
+        vmin=vmin,
+        vmax=vmax,
+        interpolation="bilinear",
+        aspect="auto",
+    )
+    if overlay_points:
+        pxs = [p[0] for p in overlay_points]
+        pys = [p[1] for p in overlay_points]
+        ax.scatter(pxs, pys, s=8, c="white", edgecolors="black", linewidths=0.5, alpha=0.8)
+    ax.set_xlabel("x (m)")
+    ax.set_ylabel("y (m)")
+    ax.set_title(title)
+    cb = plt.colorbar(im, ax=ax, shrink=0.85)
+    cb.set_label(colorbar_label)
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png")
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def render_and_upload(
+    estimate: CoverageEstimate,
+    session_id: str,
+    measurement_points: list[tuple[float, float, float]] | None = None,
+) -> tuple[str, str]:
+    """mean / uncertainty 두 PNG 생성 + S3 업로드 → (mean_uri, uncertainty_uri).
+
+    Args:
+        estimate: GP 결과.
+        session_id: S3 키 구성용.
+        measurement_points: 측정점 (x, y, rssi). mean 위에 오버레이.
+
+    Returns:
+        (mean_s3_uri, uncertainty_s3_uri) — s3:// 형식.
+    """
+    overlay = (
+        [(p[0], p[1]) for p in measurement_points] if measurement_points else None
+    )
+
+    mean = estimate.mean_grid
+    std = estimate.std_grid
+
+    # mean 색 범위: -100 ~ -30 dBm (Wi-Fi RSSI 일반)
+    mean_png = _render_to_png(
+        mean,
+        estimate.xs,
+        estimate.ys,
+        cmap="jet",
+        vmin=float(np.percentile(mean, 5)),
+        vmax=float(np.percentile(mean, 95)),
+        title=f"Estimated RSSI Coverage (GP, N={estimate.input_point_count})",
+        colorbar_label="RSSI (dBm)",
+        overlay_points=overlay,
+    )
+
+    # uncertainty: 0 ~ max 자동
+    std_png = _render_to_png(
+        std,
+        estimate.xs,
+        estimate.ys,
+        cmap="hot",
+        vmin=0.0,
+        vmax=float(std.max()) if std.size > 0 else 1.0,
+        title="GP Uncertainty (std)",
+        colorbar_label="std (dB)",
+        overlay_points=overlay,
+    )
+
+    # S3 업로드
+    job_uuid = uuid.uuid4().hex
+    mean_key = f"measurement-estimates/{session_id}/{job_uuid}-mean.png"
+    std_key = f"measurement-estimates/{session_id}/{job_uuid}-uncertainty.png"
+    mean_uri = _s3.upload_bytes(mean_key, mean_png, content_type="image/png")
+    std_uri = _s3.upload_bytes(std_key, std_png, content_type="image/png")
+
+    logger.info(
+        "GP coverage PNGs uploaded session=%s mean=%s std=%s",
+        session_id, mean_uri, std_uri,
+    )
+    return mean_uri, std_uri

--- a/backend/app/services/measurement_service.py
+++ b/backend/app/services/measurement_service.py
@@ -566,6 +566,98 @@ def list_sessions_by_floor(
     )
 
 
+def estimate_session_coverage(
+    db: Session,
+    session_id: str,
+    user: User,
+    grid_resolution_m: float = 0.5,
+) -> "EstimatedCoverageResponseDTO":
+    """§81 — 세션의 측정점들을 GP regression 으로 dense map 추정.
+
+    1. 권한 + 세션 로드
+    2. 측정점 (x, y, rssi) 로드 — rssi NULL 인 점은 제외
+    3. floor 의 도면 bounds 계산 (없으면 측정점 bounding box)
+    4. GP fit + predict
+    5. heatmap PNG 생성 + S3 업로드
+    6. presigned URL 응답
+    """
+    # lazy import — 무거운 sklearn / matplotlib 을 모듈 import 단에서 끌어오지 않음
+    from app.schemas.measurement import (
+        EstimatedCoverageResponseDTO,
+        EstimatedRssiRangeDTO,
+    )
+    from app.services._s3 import presigned_get_url
+    from app.services.measurement_estimation.gp_estimator import estimate_coverage
+    from app.services.measurement_estimation.heatmap import render_and_upload
+
+    session_row = _load_owned_session(db, session_id, user)
+
+    # 측정점 (rssi 있는 것만) 로드
+    rows = (
+        db.execute(
+            select(MeasurementPoint).where(
+                MeasurementPoint.session_id == session_row.id,
+                MeasurementPoint.rssi_dbm.isnot(None),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    points: list[tuple[float, float, float]] = []
+    for r in rows:
+        gj = wkb_to_geojson(r.point_geom)
+        coords = (gj or {}).get("coordinates") or [0.0, 0.0]
+        points.append((float(coords[0]), float(coords[1]), float(r.rssi_dbm)))
+
+    if len(points) < 3:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            f"Need at least 3 measurement points with RSSI for estimation (got {len(points)})",
+            400,
+        )
+
+    # bounds — floor 의 floorplan 메타데이터 → 없으면 측정점 bbox
+    asset = _latest_floorplan_asset(db, str(session_row.floor_id))
+    floorplan = _floorplan_info_from_asset(db, asset.id if asset else None)
+    bounds_dto = _bounds_from_floorplan(floorplan)
+    if bounds_dto.max_x <= 0 or bounds_dto.max_y <= 0:
+        # fallback: 측정점 bbox + 1m 마진
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        bounds_dto = FloorBoundsDTO(
+            min_x=min(xs) - 1.0,
+            min_y=min(ys) - 1.0,
+            max_x=max(xs) + 1.0,
+            max_y=max(ys) + 1.0,
+        )
+    bounds_tuple = (bounds_dto.min_x, bounds_dto.min_y, bounds_dto.max_x, bounds_dto.max_y)
+
+    # GP 학습 + 예측
+    estimate = estimate_coverage(
+        points, bounds=bounds_tuple, grid_resolution_m=grid_resolution_m
+    )
+
+    # heatmap 생성 + S3
+    mean_uri, std_uri = render_and_upload(estimate, str(session_row.id), points)
+
+    return EstimatedCoverageResponseDTO(
+        heatmap_url=presigned_get_url(mean_uri),
+        uncertainty_url=presigned_get_url(std_uri),
+        bounds=bounds_dto,
+        grid_shape=list(estimate.mean_grid.shape),
+        grid_resolution_m=grid_resolution_m,
+        rssi_range=EstimatedRssiRangeDTO(
+            min=float(estimate.mean_grid.min()),
+            max=float(estimate.mean_grid.max()),
+            mean=float(estimate.mean_grid.mean()),
+        ),
+        uncertainty_max_db=float(estimate.std_grid.max()),
+        input_point_count=estimate.input_point_count,
+        kernel_repr=estimate.kernel_repr,
+    )
+
+
 def list_detected_aps(
     db: Session, session_id: str, user: User
 ) -> list[DetectedApResponseDTO]:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,4 +42,6 @@ bcrypt==4.0.1
 email-validator==2.2.0
 # RF/Wall extraction OCR (#69)
 easyocr==1.7.2
+# GP regression for measurement coverage estimation (#81)
+scikit-learn>=1.6
 


### PR DESCRIPTION
## 요약
모바일 측정 데이터 (sparse N개 점) → **Gaussian Process Regression** → 도면 전체 dense RSSI 맵 (mean + uncertainty) 추정. 측정 안 한 영역도 통계적으로 추정 + 불확실성 정량화.

웹에서 측정 결과 시각화 + 캘리브레이션 (#82) 의 입력으로 사용.

Closes #81

## 핵심 알고리즘
- **scikit-learn `GaussianProcessRegressor`**
- 커널: `ConstantKernel × RBF(length_scale=3.0) + WhiteKernel(noise_level=2.0)`
  - RBF: 공간 상관관계 (자동 튜닝)
  - WhiteKernel: 측정 노이즈 흡수 (Wi-Fi RSSI 본질적 ±2dB)
- `n_restarts_optimizer=5` 로 MLE 자동 튜닝
- 각 grid 셀 = (mean RSSI, std) → Bayesian uncertainty quantification

## 신규 모듈
- `app/services/measurement_estimation/gp_estimator.py` — `estimate_coverage(...)` → CoverageEstimate
- `app/services/measurement_estimation/heatmap.py` — matplotlib heatmap PNG + S3 업로드 + presigned URL

## 신규 엔드포인트
- `GET /measurement-sessions/{id}/estimated-coverage?resolution_m=0.5`
  - 응답:
    ```json
    {
      "heatmap_url": "https://...presigned mean heatmap",
      "uncertainty_url": "https://...presigned std heatmap",
      "bounds": { "min_x": 0, "min_y": 0, "max_x": 6, "max_y": 6 },
      "grid_shape": [13, 13],
      "grid_resolution_m": 0.5,
      "rssi_range": { "min": -75.3, "max": -53.8, "mean": -66.2 },
      "uncertainty_max_db": 8.8,
      "input_point_count": 5,
      "kernel_repr": "1.46**2 * RBF(length_scale=4.14) + WhiteKernel(noise_level=0.1)"
    }
    ```
  - 권한: 본인 소유 세션만 (#77 의 `_load_owned_session` 재사용)

## 의존성
- `scikit-learn>=1.6` (이미 easyocr 와 함께 설치돼있었으나 requirements.txt 에 명시 추가)
- `matplotlib` (기존 의존)

## 파일 변경
- `app/services/measurement_estimation/__init__.py`, `gp_estimator.py`, `heatmap.py` 신규
- `app/schemas/measurement.py` — `EstimatedCoverageResponseDTO`, `EstimatedRssiRangeDTO` 추가
- `app/services/measurement_service.py` — `estimate_session_coverage(...)` 추가
- `app/routers/measurements.py` — GET 핸들러 추가
- `requirements.txt` — scikit-learn 명시
- DB 변경 없음

## 테스트 (로컬)
- [x] 합성 측정점 50개 (가우시안 형태 RSSI) 로 GP fit 동작 확인
- [x] 실제 DB 의 5개 측정점으로 endpoint 종단 호출 → PNG 2개 생성 + S3 업로드
- [x] mean heatmap: 측정점 기반 자연스러운 그라데이션 추정 (-75 ~ -54 dBm)
- [x] uncertainty: 측정점 근처는 std 낮음 (~2), 먼 곳은 높음 (~8) — Active Learning 근거
- [x] 권한: 타 유저 → 404, 인증 없음 → 401, 없는 session → 404
- [x] invalid resolution_m → 422

## 후속 (이번 PR 범위 외)
- `GET /measurement-sessions/{id}/next-measurement-point` — uncertainty 최대 셀을 다음 측정 추천 (Active Learning)
- 캘리브레이션 워커 (#82) — 이 GP 결과를 dense map 으로 사용해 시뮬 비교