### PR TITLE
[Feat] 로컬 추론 모드 및 OCR/Line 기반 wall 후보정 파이프라인 연동

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -90,7 +90,7 @@ def get_asset(
 @assets_router.get(
     "/{asset_id}/download-url",
     response_model=AssetDownloadUrlResponse,
-    summary="자산 파일 presigned GET URL 발급 (S3)",
+    summary="자산 파일 다운로드 URL 발급 (S3 presigned 또는 로컬 스트리밍)",
 )
 def get_asset_download_url(
     asset_id: UUID = Path(...),
@@ -101,6 +101,22 @@ def get_asset_download_url(
         db=db, asset_id=asset_id, user=current_user
     )
     return AssetDownloadUrlResponse(url=url, expires_in=expires_in)
+
+
+@assets_router.get(
+    "/{asset_id}/raw",
+    summary="로컬 자산 파일 스트리밍 (file:// storage 전용)",
+)
+def stream_asset_raw(
+    asset_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    from fastapi.responses import FileResponse
+    path, mime = asset_service.open_asset_local_file(
+        db=db, asset_id=asset_id, user=current_user
+    )
+    return FileResponse(str(path), media_type=mime, filename=path.name)
 
 
 @assets_router.delete(
@@ -124,14 +140,14 @@ def delete_asset(
     summary="Asset 도면 분석 Job 등록 (비동기). job_id 받아서 GET /floorplan-jobs/{job_id} 폴링.",
 )
 async def analyze_asset(
-    payload: AnalyzeFromAssetRequest,
     asset_id: UUID = Path(...),
+    payload: AnalyzeFromAssetRequest = AnalyzeFromAssetRequest(),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> AnalyzeFromAssetResponse:
     return await scene_draft_service.analyze_from_asset(
         db=db,
         asset_id=asset_id,
-        real_width_m=payload.real_width_m,
         current_user=current_user,
+        inference_mode=payload.inference_mode,
     )

--- a/backend/app/routers/experiments.py
+++ b/backend/app/routers/experiments.py
@@ -1,12 +1,15 @@
 from pathlib import Path
 import mimetypes
+import shutil
+import tempfile
+import uuid
 
 import requests
-from fastapi import APIRouter
+from fastapi import APIRouter, File, Form, UploadFile
 
 from app.core.errors import AppError, ErrorCode
-from app.core.settings import UPLOAD_DIR, ai_service_url, rf_server_url
-from app.services.wall_extraction import run_rule_based_wall_extraction
+from app.core.settings import MASK_DIR, UPLOAD_DIR, ai_service_url, rf_server_url
+from app.services.wall_extraction import run_rule_based_wall_extraction, wall_extractor
 
 router = APIRouter(prefix="/experiments", tags=["experiments"])
 
@@ -74,6 +77,65 @@ def objects_yolo(file_id: str) -> dict:
         image_path=image_path,
         timeout=120,
     )
+
+
+@router.post("/wall/postprocess/{file_id}")
+async def wall_postprocess(
+    file_id: str,
+    prob_map: UploadFile = File(..., description="U-Net wall probability map (.npy)"),
+    threshold: float | None = Form(
+        None,
+        description="명시하면 adaptive scoring 건너뛰고 그 값 사용 (디버깅용).",
+    ),
+) -> dict:
+    """§69 wall postprocess 디버깅 — adaptive threshold scoring 결과를 그대로 dump.
+
+    `file_id` 의 업로드된 원본 도면 이미지를 OCR/선분 검출 입력으로 쓰고,
+    multipart 로 받은 prob_map .npy 를 후처리 파이프라인에 통과시킴.
+    응답에 후보별 점수와 디버그 이미지 디렉토리가 포함되어 전/후 비교 가능.
+    """
+    image_path = _find_uploaded_file(file_id)
+    if image_path is None:
+        raise AppError(ErrorCode.UPLOADED_FILE_NOT_FOUND, "Uploaded file not found.", 404)
+
+    # multipart .npy → temp 파일로 저장 (numpy.load 가 파일 경로 필요).
+    tmp_dir = Path(tempfile.mkdtemp(prefix="wall_pp_"))
+    tmp_npy = tmp_dir / "prob_map.npy"
+    try:
+        with tmp_npy.open("wb") as f:
+            shutil.copyfileobj(prob_map.file, f)
+
+        run_id = uuid.uuid4().hex[:12]
+        debug_dir = MASK_DIR / "wall_postprocess" / f"debug_{file_id}_{run_id}"
+
+        try:
+            result = wall_extractor.execute_from_prob_map(
+                tmp_npy,
+                threshold=threshold,
+                detections=None,
+                image_path=image_path,
+                debug_dir=debug_dir,
+            )
+        except Exception as exc:
+            raise AppError(
+                ErrorCode.WALL_EXTRACTION_FAILED,
+                f"Wall postprocess failed: {exc}",
+                500,
+            ) from exc
+
+        return {
+            "status": "ok",
+            "fileId": file_id,
+            "walls": result.walls,
+            "postprocess_metadata": result.postprocess.to_dict(),
+        }
+    finally:
+        # .npy 파일만 정리. 디버그 이미지 (debug_dir) 는 의도적으로 남김.
+        try:
+            tmp_npy.unlink(missing_ok=True)
+            tmp_dir.rmdir()
+        except OSError:
+            pass
 
 
 @router.post("/rf/sionna/smoke")

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -68,10 +68,10 @@ async def upload_floorplan(file: UploadFile = File(...)) -> dict:
 )
 async def upload_and_analyze_floorplan(
     file: UploadFile = File(...),
-    real_width_m: float = Form(10.0),
     project_id: str | None = Form(None),
     floor_id: str | None = Form(None),
     created_by: str | None = Form(None),
+    inference_mode: str = Form("sagemaker"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> UploadAndAnalyzeFloorplanResponse:
@@ -91,12 +91,12 @@ async def upload_and_analyze_floorplan(
         image_bytes=content,
         filename=file.filename or f"{file_id}",
         content_type=file.content_type or "application/octet-stream",
-        real_width_m=real_width_m,
         project_id=project_id,
         floor_id=floor_id,
         current_user=current_user,
         upload_metadata=upload_metadata,
         created_by=created_by,
+        inference_mode=inference_mode,
     )
 
     return UploadAndAnalyzeFloorplanResponse(

--- a/backend/app/schemas/scene.py
+++ b/backend/app/schemas/scene.py
@@ -55,3 +55,6 @@ class SceneSchema(BaseModel):
     # AI inference run metadata — fusion_service 가 SageMaker InferenceResult 에서 채움.
     # summary_json 으로 영속됨 (감사/디버깅용). 선택적이라 기존 caller 깨지지 않음.
     inference_metadata: Optional[dict] = None
+    # §69 wall postprocess metadata — adaptive threshold / OCR / line scoring 결과.
+    # WallExtractor.PostprocessMetadata.to_dict() 형태. summary_json["wall_postprocess"] 로 영속.
+    postprocess_metadata: Optional[dict] = None

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -35,9 +35,14 @@ class SaveSceneDraftResultDTO(BaseModel):
 
 
 class AnalyzeFromAssetRequest(BaseModel):
+    """POST /assets/{asset_id}/analyze 본문.
+
+    real_width_m 은 제거됨 (백엔드의 OCR 치수 자동 추정으로 대체).
+    inference_mode 만 옵션으로 노출.
+    """
     model_config = ConfigDict(extra="forbid")
 
-    real_width_m: float = 10.0
+    inference_mode: Literal["sagemaker", "local"] = "sagemaker"
 
 
 class SceneDraftCreateRequest(BaseModel):

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -217,6 +217,56 @@ def create_floorplan_asset_from_bytes(
     return asset
 
 
+def create_floorplan_asset_from_local_path(
+    db: Session,
+    *,
+    project_id: str,
+    floor_id: str,
+    local_path: str,
+    filename: str,
+    content_type: Optional[str],
+    file_size_bytes: int,
+    uploaded_by: str,
+) -> Asset:
+    """로컬 FS 에 이미 저장된 도면 이미지를 assets 에 등록 (S3 업로드 없음).
+
+    로컬 추론 모드(`/upload/floorplan/analyze?inference_mode=local`) 전용. router 의
+    `_validate_and_save_file` 가 이미 UPLOAD_DIR 에 파일을 저장했으므로, 그 경로를
+    그대로 `storage_url = file:///abs/path` 로 보관해서 DB row 만든다.
+
+    `/assets/{id}/download-url` 은 `file://` 스킴을 감지해 백엔드 자체 스트리밍
+    엔드포인트(`/assets/{id}/raw`) URL 을 반환한다 (S3 presigned 우회).
+    """
+    asset_type = AssetType.FLOORPLAN_IMAGE.value
+    ext = _resolve_extension(filename)
+    mime_type = content_type or ALLOWED_EXTENSIONS[ext]
+    asset_id = uuid4()
+
+    # 경로 정규화 + file:// URI 로 보관 (드라이브 표기 윈도우 호환).
+    abs_path = Path(local_path).resolve()
+    storage_url = abs_path.as_uri()  # 예: file:///C:/capstone2/.../uploads/xxx.jpg
+
+    asset = Asset(
+        id=str(asset_id),
+        project_id=project_id,
+        floor_id=floor_id,
+        uploaded_by=uploaded_by,
+        asset_type=asset_type,
+        source_format=ext,
+        storage_url=storage_url,
+        mime_type=mime_type,
+        file_size_bytes=file_size_bytes,
+        metadata_json={},
+    )
+    try:
+        db.add(asset)
+        db.flush()
+    except Exception:
+        db.rollback()
+        raise
+    return asset
+
+
 def list_assets(
     db: Session,
     floor_id: UUID,
@@ -242,18 +292,58 @@ def get_asset(db: Session, asset_id: UUID, user: User) -> Asset:
 def get_asset_download_url(
     db: Session, asset_id: UUID, user: User
 ) -> tuple[str, int]:
-    """presigned GET URL + 만료 초 반환."""
+    """asset 다운로드 URL + 만료 초 반환.
+
+    - `s3://` 자산: S3 presigned GET URL
+    - `file://` 자산 (로컬 추론 모드): 백엔드 자체 스트리밍 엔드포인트 상대 경로
+    """
     asset, _floor, _project = _get_owned_asset_or_404(db, asset_id, user)
-    if not asset.storage_url or not asset.storage_url.startswith("s3://"):
+    url_value = asset.storage_url or ""
+    if url_value.startswith("s3://"):
+        url = _s3.presigned_get_url(
+            url_value, expires_seconds=RF_PRESIGNED_URL_EXPIRES_SECONDS
+        )
+        return url, RF_PRESIGNED_URL_EXPIRES_SECONDS
+    if url_value.startswith("file://"):
+        # 백엔드가 자체 스트리밍 — 만료 개념 없지만 client 호환성을 위해 0 으로.
+        return f"/assets/{asset.id}/raw", 0
+    raise AppError(
+        ErrorCode.UPLOADED_FILE_NOT_FOUND,
+        f"Asset has unsupported storage scheme: {url_value[:40]}",
+        status_code=404,
+    )
+
+
+def open_asset_local_file(
+    db: Session, asset_id: UUID, user: User
+) -> tuple[Path, str]:
+    """`file://` 자산의 로컬 파일 경로 + mime_type 반환. 스트리밍 endpoint 가 사용.
+
+    권한 체크(_get_owned_asset_or_404) 포함. S3 자산이면 404.
+    """
+    asset, _floor, _project = _get_owned_asset_or_404(db, asset_id, user)
+    url_value = asset.storage_url or ""
+    if not url_value.startswith("file://"):
         raise AppError(
             ErrorCode.UPLOADED_FILE_NOT_FOUND,
-            "Asset is not on S3 (legacy local path).",
+            "Asset is not a local file.",
             status_code=404,
         )
-    url = _s3.presigned_get_url(
-        asset.storage_url, expires_seconds=RF_PRESIGNED_URL_EXPIRES_SECONDS
-    )
-    return url, RF_PRESIGNED_URL_EXPIRES_SECONDS
+    # file:///C:/path → Path 추출. Path.from_uri 는 3.13+, urlparse 로 호환.
+    from urllib.parse import urlparse, unquote
+    parsed = urlparse(url_value)
+    raw_path = unquote(parsed.path)
+    # 윈도우: '/C:/x/y' 형태 → 앞의 '/' 제거
+    if len(raw_path) >= 3 and raw_path[0] == "/" and raw_path[2] == ":":
+        raw_path = raw_path[1:]
+    path = Path(raw_path)
+    if not path.exists() or not path.is_file():
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            f"Local asset file missing on disk: {path}",
+            status_code=404,
+        )
+    return path, asset.mime_type or "application/octet-stream"
 
 
 def delete_asset(db: Session, asset_id: UUID, user: User) -> None:

--- a/backend/app/services/floorplan_job_service.py
+++ b/backend/app/services/floorplan_job_service.py
@@ -8,6 +8,7 @@
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -20,14 +21,21 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.errors import AppError, ErrorCode
+from app.db.session import SessionLocal
 from app.models import Asset, Floor, Job, Project, User
 from app.schemas.scene_draft import (
     SaveSceneDraftRequestDTO,
     UploadStorageMetadataDTO,
 )
-from app.services.asset_service import create_floorplan_asset_from_bytes
+from app.core.settings import ai_service_url
+from app.services.asset_service import (
+    create_floorplan_asset_from_bytes,
+    create_floorplan_asset_from_local_path,
+)
 from app.services.fusion_service import fusion_service
+from app.services.local_inference_service import run_local_inference
 from app.services.sagemaker_inference_service import (
+    InferenceResult,
     SageMakerInferenceFailure,
     map_failure_to_app_error,
     sagemaker_inference_service,
@@ -41,6 +49,9 @@ JOB_STATUS_RUNNING = "running"
 JOB_STATUS_DONE = "done"
 JOB_STATUS_FAILED = "failed"
 
+INFERENCE_MODE_SAGEMAKER = "sagemaker"
+INFERENCE_MODE_LOCAL = "local"
+
 
 # ============================================================
 # Submit
@@ -51,13 +62,13 @@ async def submit_floorplan_analysis(
     image_bytes: bytes,
     filename: str,
     content_type: str,
-    real_width_m: float,
     project_id: str | None,
     floor_id: str | None,
     current_user: User,
     upload_metadata: UploadStorageMetadataDTO,
     created_by: str | None = None,
     source_asset_id: str | None = None,
+    inference_mode: str = INFERENCE_MODE_SAGEMAKER,
 ) -> Job:
     """SageMaker submit + Job row 생성. 1~3초 안에 반환.
 
@@ -67,36 +78,120 @@ async def submit_floorplan_analysis(
 
     저장된 source_asset_id 는 Job.input_json 에 보관되어 _complete_floorplan_job
     에서 asset.metadata_json 백필 + SceneDraft.source_asset_id 전파에 쓰인다.
+
+    inference_mode:
+      - "sagemaker" (기본): S3 + async invocation + 폴링
+      - "local": `AI_SERVICE_URL` 동기 호출 → 즉시 fusion+save → done 으로 반환
     """
+    if inference_mode not in (INFERENCE_MODE_SAGEMAKER, INFERENCE_MODE_LOCAL):
+        raise AppError(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unknown inference_mode: {inference_mode}",
+            400,
+        )
+
     resolved_project_id, resolved_floor_id = _resolve_project_floor(
         db, project_id, floor_id, current_user
     )
 
     # raw upload 경로면 여기서 asset row 를 만들어 둔다. floor 단위 도면 자산이
     # 항상 존재해야 measurement_link 가 그걸 가리킬 수 있다.
+    # SageMaker 모드: S3 PUT + storage_url=s3://...
+    # 로컬 모드 (개발용): S3 우회 + storage_url=file:///local/path (router 가 이미 저장한 파일)
     if source_asset_id is None:
-        new_asset = create_floorplan_asset_from_bytes(
-            db,
+        if inference_mode == INFERENCE_MODE_SAGEMAKER:
+            new_asset = create_floorplan_asset_from_bytes(
+                db,
+                project_id=resolved_project_id,
+                floor_id=resolved_floor_id,
+                content=image_bytes,
+                filename=filename,
+                content_type=content_type,
+                uploaded_by=current_user.id,
+            )
+            source_asset_id = new_asset.id
+            # upload_metadata 에 실제 S3 좌표도 같이 보관 (참조 용이)
+            if not upload_metadata.s3_uri:
+                try:
+                    upload_metadata = upload_metadata.model_copy(
+                        update={
+                            "provider": upload_metadata.provider or "s3",
+                            "s3_uri": new_asset.storage_url,
+                        }
+                    )
+                except Exception:
+                    pass
+        elif inference_mode == INFERENCE_MODE_LOCAL:
+            # router(_validate_and_save_file) 가 이미 UPLOAD_DIR 에 저장 → 그 경로 사용.
+            local_path = upload_metadata.local_saved_path
+            if not local_path:
+                raise AppError(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "Local inference mode requires upload.local_saved_path",
+                    500,
+                )
+            new_asset = create_floorplan_asset_from_local_path(
+                db,
+                project_id=resolved_project_id,
+                floor_id=resolved_floor_id,
+                local_path=local_path,
+                filename=filename,
+                content_type=content_type,
+                file_size_bytes=upload_metadata.size_bytes or len(image_bytes),
+                uploaded_by=current_user.id,
+            )
+            source_asset_id = new_asset.id
+
+    # ── 로컬 모드: Job 생성 + 백그라운드 task 등록 → 202 즉시 반환 ─────────────
+    # SageMaker 흐름과 동일하게 프론트는 폴링으로 완료 확인.
+    if inference_mode == INFERENCE_MODE_LOCAL:
+        input_json_local: dict[str, Any] = {
+            "filename": filename,
+            "content_type": content_type,
+            "created_by": created_by or current_user.email,
+            "source_asset_id": source_asset_id,
+            "upload": upload_metadata.model_dump(),
+            "inference_mode": INFERENCE_MODE_LOCAL,
+            "ai_service_url": ai_service_url(),
+        }
+        job = Job(
             project_id=resolved_project_id,
             floor_id=resolved_floor_id,
-            content=image_bytes,
-            filename=filename,
-            content_type=content_type,
-            uploaded_by=current_user.id,
+            job_type=JOB_TYPE_FLOORPLAN_ANALYZE,
+            status=JOB_STATUS_RUNNING,
+            input_json=input_json_local,
+            result_json={},
+            started_at=_now_utc(),
         )
-        source_asset_id = new_asset.id
-        # upload_metadata 에 실제 S3 좌표도 같이 보관 (참조 용이)
-        if not upload_metadata.s3_uri:
-            try:
-                upload_metadata = upload_metadata.model_copy(
-                    update={
-                        "provider": upload_metadata.provider or "s3",
-                        "s3_uri": new_asset.storage_url,
-                    }
-                )
-            except Exception:
-                pass
+        try:
+            db.add(job)
+            db.commit()
+            db.refresh(job)
+        except SQLAlchemyError as exc:
+            db.rollback()
+            raise AppError(
+                ErrorCode.INTERNAL_SERVER_ERROR,
+                f"Failed to persist floorplan analysis job (local): {exc}",
+                500,
+            ) from exc
 
+        logger.info("Floorplan job (local) submitted job_id=%s", job.id)
+
+        # 백그라운드에서 inference + finalize. 요청 핸들러는 즉시 반환 (job=running).
+        # asyncio.create_task 는 핸들러 반환 후에도 살아 있음 — 자체 DB 세션 사용 필수.
+        asyncio.create_task(
+            _run_local_in_background(
+                job_id=str(job.id),
+                owner_user_id=current_user.id,
+                image_bytes=image_bytes,
+                filename=filename,
+                content_type=content_type,
+            ),
+            name=f"local-inference-{job.id}",
+        )
+        return job
+
+    # ── SageMaker 모드 (기본) ────────────────────────────────────────────────
     submit_result = await sagemaker_inference_service.submit(
         image_bytes=image_bytes,
         filename=filename,
@@ -108,10 +203,10 @@ async def submit_floorplan_analysis(
     input_json: dict[str, Any] = {
         "filename": filename,
         "content_type": content_type,
-        "real_width_m": real_width_m,
         "created_by": created_by or current_user.email,
         "source_asset_id": source_asset_id,
         "upload": upload_metadata.model_dump(),
+        "inference_mode": INFERENCE_MODE_SAGEMAKER,
         "sagemaker": {
             "inference_id": submit_result.sagemaker_inference_id,
             "source_s3_uri": submit_result.source_s3_uri,
@@ -173,7 +268,14 @@ async def poll_floorplan_job(
     if job.status != JOB_STATUS_RUNNING:
         return job
 
-    sagemaker_meta = (job.input_json or {}).get("sagemaker") or {}
+    # 로컬 모드 Job 은 `submit_floorplan_analysis` 가 동기적으로 finalize 함.
+    # 폴링 시점에 아직 running 이면 (a) submit 핸들러가 진행 중 또는 (b) submit 중간에
+    # 죽어 stale 상태. 어느 쪽이든 poller 가 할 일 없음 — 현재 상태 그대로 반환.
+    input_meta = job.input_json or {}
+    if input_meta.get("inference_mode") == INFERENCE_MODE_LOCAL:
+        return job
+
+    sagemaker_meta = input_meta.get("sagemaker") or {}
     output_prefix = sagemaker_meta.get("output_prefix")
     sagemaker_failure_location = sagemaker_meta.get("sagemaker_failure_location") or ""
     if not output_prefix:
@@ -241,9 +343,92 @@ async def _complete_floorplan_job(
         output_prefix,
         source_s3_uri,
     )
+    return await _finalize_with_inference(db, job, current_user, inference)
 
+
+async def _run_local_in_background(
+    *,
+    job_id: str,
+    owner_user_id: str,
+    image_bytes: bytes,
+    filename: str,
+    content_type: str,
+) -> None:
+    """로컬 inference + finalize 를 백그라운드 task 로 실행.
+
+    submit 핸들러는 Job row 만들고 즉시 반환했으므로 여기서 자체 DB 세션을 새로
+    열어 finalize. 실패하면 Job 을 failed 로 마크.
+    """
+    logger.info("local bg task: ENTER job_id=%s", job_id)
+    db: Session = SessionLocal()
+    try:
+        owner = db.get(User, owner_user_id)
+        job = db.get(Job, job_id)
+        if owner is None or job is None:
+            logger.warning(
+                "local bg task: missing owner(%s) or job(%s), skip",
+                owner_user_id, job_id,
+            )
+            return
+
+        # 1) 로컬 AI 호출 (blocking HTTP) — threadpool 로 이벤트 루프 보호
+        try:
+            inference = await run_in_threadpool(
+                run_local_inference,
+                image_bytes=image_bytes,
+                filename=filename,
+                content_type=content_type,
+                ai_service_url=ai_service_url(),
+            )
+        except AppError as exc:
+            logger.warning(
+                "local bg task: inference failed job_id=%s code=%s msg=%s",
+                job_id, exc.code, exc.message,
+            )
+            _claim_and_finalize(
+                db, job_id, owner,
+                finalize=lambda l: _mark_job_failed(
+                    db, l, code=exc.code, stage="local_inference", message=exc.message,
+                ),
+            )
+            return
+        except Exception as exc:
+            logger.exception("local bg task: unexpected inference error job_id=%s", job_id)
+            _claim_and_finalize(
+                db, job_id, owner,
+                finalize=lambda l: _mark_job_failed(
+                    db, l,
+                    code=ErrorCode.INTERNAL_SERVER_ERROR,
+                    stage="local_inference",
+                    message=f"unexpected error: {exc}",
+                ),
+            )
+            return
+
+        logger.info("local bg task: inference done, starting finalize job_id=%s", job_id)
+
+        # 2) fusion + save + Job done — SageMaker 완료 경로와 100% 공유
+        try:
+            await _finalize_with_inference(db, job, owner, inference)
+            logger.info("local bg task: finalize done job_id=%s", job_id)
+        except Exception:
+            logger.exception("local bg task: finalize failed job_id=%s", job_id)
+    finally:
+        db.close()
+        logger.info("local bg task: EXIT job_id=%s", job_id)
+
+
+async def _finalize_with_inference(
+    db: Session,
+    job: Job,
+    current_user: User,
+    inference: InferenceResult,
+) -> Job:
+    """다운로드된 InferenceResult 를 받아 fusion + save_scene_draft + Job done 마무리.
+
+    SageMaker (다운로드 후) 와 로컬 모드 (즉시 호출 후) 양쪽에서 공유.
+    """
     input_meta = job.input_json or {}
-    real_width_m = float(input_meta.get("real_width_m", 10.0))
     filename = str(input_meta.get("filename") or "floorplan.png")
     upload_meta = input_meta.get("upload") or {}
     created_by = input_meta.get("created_by")
@@ -252,7 +437,6 @@ async def _complete_floorplan_job(
         scene = await fusion_service.build_scene_from_inference(
             result=inference,
             filename=filename,
-            real_width_m=real_width_m,
         )
 
         # race-safe: row lock 잡고 status 재확인. 다른 poller 가 이미 done/failed 라면 그대로 반환.

--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -151,25 +151,20 @@ class FusionService:
                 det.id = f"furniture_{len(furniture_objects)}"
                 furniture_objects.append(det)
 
-        # 같은 문/창을 여러 번 탐지한 중복 제거 (NMS). score 높은 박스 유지.
-        # type 별로 따로 NMS — 가까이 겹친 door 와 window 가 서로를 제거하지 않도록.
+        # 중복 detection 제거 (NMS) — type 무관 단일 pass.
+        # 같은 위치에 door 와 window 가 동시 감지되면 score 1 등만 유지.
+        # (이전엔 type 별로 따로 NMS 였지만 사용자가 한 개만 보이길 원해 변경.)
         if opening_dets:
             before = len(opening_dets)
-            kept_set: set[int] = set()
-            for cls in ("door", "window"):
-                group = [i for i, d in enumerate(opening_dets) if d.class_name == cls]
-                if not group:
-                    continue
-                g_boxes = [
-                    tuple(float(v) for v in opening_dets[i].bbox_xyxy) for i in group
-                ]
-                g_scores = [float(opening_dets[i].score) for i in group]
-                for k in nms_filter_indices(g_boxes, g_scores):
-                    kept_set.add(group[k])
-            opening_dets = [d for i, d in enumerate(opening_dets) if i in kept_set]
+            all_boxes = [
+                tuple(float(v) for v in d.bbox_xyxy) for d in opening_dets
+            ]
+            all_scores = [float(d.score) for d in opening_dets]
+            kept_indices = nms_filter_indices(all_boxes, all_scores)
+            opening_dets = [opening_dets[i] for i in kept_indices]
             if len(opening_dets) < before:
                 logger.info(
-                    "opening NMS (per-type): %d → %d (removed %d duplicates)",
+                    "opening NMS (cross-type): %d → %d (removed %d duplicates)",
                     before, len(opening_dets), before - len(opening_dets),
                 )
 

--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from starlette.concurrency import run_in_threadpool
 
+from app.core.settings import MASK_DIR
 from app.geometry import (
     assign_wall_refs,
     bridge_collinear_walls,
@@ -43,7 +44,6 @@ class FusionService:
         *,
         result: InferenceResult,
         filename: str,
-        real_width_m: float,
     ) -> SceneSchema:
         """SageMaker raw outputs (download 완료된 상태) → SceneSchema.
 
@@ -52,40 +52,64 @@ class FusionService:
         """
         ml_output = _build_ml_output_from_inference(result, filename)
         sagemaker_meta = _build_sagemaker_meta(result)
+        # per-job 디버그 이미지 격리 (멀티잡 동시 실행 시 덮어쓰기 방지).
+        debug_dir = MASK_DIR / "wall_postprocess" / str(result.job_id)
         scene = await run_in_threadpool(
             self._run_wi_twin_pipeline,
             ml_output,
-            real_width_m,
             result.prob_map_local_path,
             sagemaker_meta,
             result.source_image_local_path,
+            debug_dir,
         )
         return scene
 
     def _run_wi_twin_pipeline(
         self,
         ml_output: MlOutputDTO,
-        real_width_m: float,
         prob_map_local_path,
         sagemaker_meta: dict[str, Any] | None = None,
         source_image_local_path=None,
+        debug_dir=None,
     ) -> SceneSchema:
-        geo_service = GeometryService(
-            pixel_width=ml_output.meta.original_width,
-            pixel_height=ml_output.meta.original_height,
-            real_width_m=real_width_m,
-        )
-        topo_service = TopologyService()
-        scale_ratio = geo_service.scale_ratio
-
         # wall_extraction 은 .npy 파일 경로를 받아 prob_map 로딩.
-        # source_image 있으면 §69 multi-threshold + OCR scoring 흐름 활성화.
-        raw_coords = wall_extractor.execute_from_prob_map(
+        # source_image 있으면 §69 multi-threshold + OCR scoring + 치수 매칭 흐름 활성화.
+        # GeometryService 보다 먼저 호출 — OCR 치수 기반 scale 추정을 받아 scale 결정.
+        wall_result = wall_extractor.execute_from_prob_map(
             prob_map_local_path,
             threshold=None,
             detections=ml_output.detections,
             image_path=source_image_local_path,
+            debug_dir=debug_dir,
         )
+        raw_coords = wall_result.walls
+        postprocess_meta_dict = wall_result.postprocess.to_dict()
+
+        # OCR 치수 추정 scale 이 있으면 그걸로, 없으면 default fallback (사용자가
+        # PropertiesPanel 에서 벽별 실측 입력해 후속 보정).
+        scale_ratio_override: float | None = None
+        scale_source = "default_fallback"
+        scale_est = wall_result.postprocess.scale_estimate
+        if scale_est and scale_est.get("scale_m_per_px", 0) > 0:
+            scale_ratio_override = float(scale_est["scale_m_per_px"])
+            scale_source = "ocr_dimension"
+            logger.info(
+                "scale source: OCR dimension matching (%.6f m/px, %d pairs)",
+                scale_ratio_override, scale_est.get("pair_count", 0),
+            )
+        else:
+            logger.info(
+                "scale source: default fallback — OCR dim 매칭 부족, 사용자 보정 필요"
+            )
+        postprocess_meta_dict["scale_source"] = scale_source
+
+        geo_service = GeometryService(
+            pixel_width=ml_output.meta.original_width,
+            pixel_height=ml_output.meta.original_height,
+            scale_ratio=scale_ratio_override,
+        )
+        topo_service = TopologyService()
+        scale_ratio = geo_service.scale_ratio
 
         raw_walls: list[Wall] = []
         for i, coord in enumerate(raw_coords):
@@ -183,6 +207,7 @@ class FusionService:
             topology=topology_result.model_dump(),
             objects=[obj.model_dump() for obj in furniture_objects],
             inference_metadata=sagemaker_meta,
+            postprocess_metadata=postprocess_meta_dict,
         )
 
 

--- a/backend/app/services/geometry_service.py
+++ b/backend/app/services/geometry_service.py
@@ -9,10 +9,24 @@ from app.schemas.scene import Wall, Room
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_FALLBACK_SCALE_M_PER_PX = 0.01  # OCR 치수 추정 실패 시 임시값 (1px = 1cm).
+# 명백히 잘못된 추정 가능성 있음 — 사용자가 PropertiesPanel 에서 벽별 실측값 입력해
+# 보정하도록 유도. summary_json["wall_postprocess"]["scale_source"]="default_fallback".
+
+
 class GeometryService:
-    def __init__(self, pixel_width: int, pixel_height: int, real_width_m: float):
-        # 픽셀 당 미터 비율 계산
-        self.scale_ratio = real_width_m / pixel_width if pixel_width > 0 else 0.1
+    def __init__(
+        self,
+        pixel_width: int,
+        pixel_height: int,
+        scale_ratio: float | None = None,
+    ):
+        # scale_ratio 결정 (m/px): 호출자가 명시한 값 우선, 없으면 default fallback.
+        # real_width_m 입력 흐름은 제거됨 — OCR 치수 자동 추정이 primary source.
+        if scale_ratio is not None and scale_ratio > 0:
+            self.scale_ratio = float(scale_ratio)
+        else:
+            self.scale_ratio = DEFAULT_FALLBACK_SCALE_M_PER_PX
         self.pixel_height = pixel_height
         self.pixel_width = pixel_width
 

--- a/backend/app/services/local_inference_service.py
+++ b/backend/app/services/local_inference_service.py
@@ -1,0 +1,324 @@
+"""로컬 AI 서버 (`AI_SERVICE_URL`) 기반 동기 추론 클라이언트.
+
+SageMaker async 흐름과 동일한 `InferenceResult` dataclass 를 만들어 fusion_service
+에 넘기는 것이 목적. 로컬 모드 토글이 켜진 분석 호출이 들어오면
+`floorplan_job_service._run_local_in_background` 가 이 모듈을 호출.
+
+AI 서버 계약 (rf-service/packages/contracts/inference.py):
+  - `POST {AI_SERVICE_URL}/inference/unet` (multipart `file` + form `file_id`)
+    응답: `{ status, task, fileId, output: { wallProbNpyPath, wallProbOverlayPath },
+            metrics: { shape, dtype, minProb, maxProb, ... } }`
+  - `POST {AI_SERVICE_URL}/inference/yolo` (multipart `file` + form `file_id`)
+    응답: `{ status, task, fileId,
+            output: { detections: [{class_id, class_name, confidence, bbox}], previewPath },
+            metrics: { detectionCount, ... } }`
+
+`*Path` 필드들은 AI 서버 로컬 FS 경로 (같은 머신이라 백엔드가 직접 np.load/read_bytes).
+HTTP 환경으로 분리되면 `_load_npy_from_path_or_url` 가 URL fallback 도 처리.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import mimetypes
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import requests
+
+from app.core.errors import AppError, ErrorCode
+from app.services.sagemaker_inference_service import InferenceResult
+
+logger = logging.getLogger(__name__)
+
+
+def run_local_inference(
+    *,
+    image_bytes: bytes,
+    filename: str,
+    content_type: str,
+    ai_service_url: str,
+    request_timeout_s: float = 120.0,
+) -> InferenceResult:
+    """이미지 바이트 → 로컬 AI 두 endpoint 호출 → SageMaker 와 같은 `InferenceResult`.
+
+    호출자가 결과의 `temp_dir` cleanup 책임.
+    """
+    if not ai_service_url:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            "AI_SERVICE_URL not configured for local inference.",
+            503,
+        )
+
+    base = ai_service_url.rstrip("/")
+    job_id = uuid.uuid4().hex
+    temp_dir = Path(tempfile.mkdtemp(prefix=f"local-{job_id}-"))
+    logger.info("local inference start job_id=%s base=%s filename=%s", job_id, base, filename)
+
+    try:
+        # 1) source 이미지 — temp 보관 (OCR/선분 검출 입력용)
+        suffix = Path(filename).suffix.lower() or ".png"
+        source_image_path = temp_dir / f"source{suffix}"
+        source_image_path.write_bytes(image_bytes)
+
+        ctype = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+        # 2) unet 호출
+        logger.info("local inference: POST /inference/unet job_id=%s", job_id)
+        unet_payload = _post_inference(
+            f"{base}/inference/unet",
+            file_id=job_id,
+            filename=filename,
+            image_bytes=image_bytes,
+            content_type=ctype,
+            timeout=request_timeout_s,
+        )
+        unet_out = _require_output(unet_payload, task="unet")
+        unet_metrics = unet_payload.get("metrics") or {}
+        logger.info(
+            "local inference: unet ok job_id=%s shape=%s",
+            job_id, unet_metrics.get("shape"),
+        )
+
+        # 3) prob_map 로드 (계약: output.wallProbNpyPath)
+        prob_map = _load_npy_from_path_or_url(
+            _require_str(unet_out, "wallProbNpyPath"),
+            base_url=base,
+            timeout=request_timeout_s,
+        )
+        prob_map = _validate_prob_map_shape(prob_map)
+        prob_map_path = temp_dir / "wall_prob_map.npy"
+        np.save(str(prob_map_path), prob_map)
+
+        # 4) overlay PNG 저장 (계약: output.wallProbOverlayPath, optional FS copy)
+        mask_local_path = temp_dir / "wall_mask.png"
+        _copy_overlay_or_fallback(
+            unet_out.get("wallProbOverlayPath"), mask_local_path, prob_map,
+        )
+
+        # 5) yolo 호출 (detections 는 inline list — 계약: output.detections[])
+        logger.info("local inference: POST /inference/yolo job_id=%s", job_id)
+        yolo_payload = _post_inference(
+            f"{base}/inference/yolo",
+            file_id=job_id,
+            filename=filename,
+            image_bytes=image_bytes,
+            content_type=ctype,
+            timeout=request_timeout_s,
+        )
+        yolo_out = _require_output(yolo_payload, task="yolo")
+        detections_raw = yolo_out.get("detections")
+        if not isinstance(detections_raw, list):
+            raise AppError(
+                ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+                f"yolo response output.detections is not a list (got {type(detections_raw).__name__})",
+                502,
+            )
+        # 계약: {class_id, class_name, confidence, bbox: [x1,y1,x2,y2]}
+        # fusion_service._build_ml_output_from_inference 가 동일 키들을 읽음.
+        detections = list(detections_raw)
+        logger.info(
+            "local inference: yolo ok job_id=%s detections=%d",
+            job_id, len(detections),
+        )
+
+        # 6) 이미지 dims — unet metrics.shape = [H, W] 우선, 없으면 prob_map shape.
+        width_px, height_px = _extract_image_dims(unet_metrics, prob_map)
+
+        # fusion_service._build_sagemaker_meta 가 읽는 최소 필드만 채움.
+        now_iso = datetime.now(timezone.utc).isoformat()
+        result_payload: dict[str, Any] = {
+            "inference_id": f"local-{job_id}",
+            "endpoint_name": "local-inference",
+            "started_at": now_iso,
+            "completed_at": now_iso,
+            "image": {"width_px": width_px, "height_px": height_px},
+        }
+
+        return InferenceResult(
+            job_id=job_id,
+            temp_dir=temp_dir,
+            prob_map_local_path=prob_map_path,
+            mask_local_path=mask_local_path,
+            detections=detections,
+            image_width_px=width_px,
+            image_height_px=height_px,
+            result_payload=result_payload,
+            source_image_local_path=source_image_path,
+        )
+    except Exception:
+        # 실패하면 temp 정리하고 예외 다시 던짐 — 성공시엔 호출자 책임.
+        for child in temp_dir.glob("*"):
+            try:
+                child.unlink(missing_ok=True)
+            except OSError:
+                pass
+        try:
+            temp_dir.rmdir()
+        except OSError:
+            pass
+        raise
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# HTTP 호출
+# ───────────────────────────────────────────────────────────────────────────
+def _post_inference(
+    url: str,
+    *,
+    file_id: str,
+    filename: str,
+    image_bytes: bytes,
+    content_type: str,
+    timeout: float,
+) -> dict[str, Any]:
+    """AI 서버 multipart 호출. `file_id` form field + `file` 파일 (계약)."""
+    try:
+        resp = requests.post(
+            url,
+            data={"file_id": file_id},
+            files={"file": (filename, io.BytesIO(image_bytes), content_type)},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"Local AI request failed ({url}): {exc}",
+            502,
+        ) from exc
+
+    if resp.status_code >= 400:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"Local AI {url} returned HTTP {resp.status_code}: {resp.text[:300]}",
+            502,
+        )
+    try:
+        return resp.json()
+    except ValueError as exc:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"Local AI {url} returned non-JSON body: {resp.text[:300]}",
+            502,
+        ) from exc
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# 계약 검증 헬퍼
+# ───────────────────────────────────────────────────────────────────────────
+def _require_output(payload: dict[str, Any], *, task: str) -> dict[str, Any]:
+    """`{status, task, output: {...}}` 형태에서 `output` dict 강제."""
+    if not isinstance(payload, dict):
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"{task} response is not a JSON object",
+            502,
+        )
+    output = payload.get("output")
+    if not isinstance(output, dict):
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"{task} response missing 'output' object. Got fields: {sorted(payload.keys())}",
+            502,
+        )
+    return output
+
+
+def _require_str(d: dict[str, Any], key: str) -> str:
+    v = d.get(key)
+    if not isinstance(v, str) or not v:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"Local AI output missing required field '{key}' (got {type(v).__name__}). "
+            f"Available: {sorted(d.keys())}",
+            502,
+        )
+    return v
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# 파일 로더 (로컬 FS 우선, URL fallback)
+# ───────────────────────────────────────────────────────────────────────────
+def _load_npy_from_path_or_url(value: str, *, base_url: str, timeout: float) -> np.ndarray:
+    """AI 서버가 돌려준 경로/URL 에서 .npy 로드.
+
+    1) `http(s)://...` → HTTP GET
+    2) 로컬 FS 경로로 파일 존재 → `np.load` 직접
+    3) `/...` 절대 경로지만 FS 에 없으면 `base_url + path` 로 GET
+    """
+    if value.startswith(("http://", "https://")):
+        logger.info("npy source: URL %s", value)
+        r = requests.get(value, timeout=timeout)
+        r.raise_for_status()
+        return np.load(io.BytesIO(r.content), allow_pickle=False)
+
+    p = Path(value)
+    if p.exists() and p.is_file():
+        logger.info("npy source: local FS %s", value)
+        return np.load(str(p), allow_pickle=False)
+
+    if value.startswith("/"):
+        url = base_url.rstrip("/") + value
+        logger.info("npy source: server-relative URL %s", url)
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+        return np.load(io.BytesIO(r.content), allow_pickle=False)
+
+    raise AppError(
+        ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+        f"Cannot resolve npy path/url: {value}",
+        502,
+    )
+
+
+def _copy_overlay_or_fallback(
+    overlay_path: Any, dest: Path, prob_map: np.ndarray,
+) -> None:
+    """AI 서버의 overlay PNG 를 mask 자리에 복사. 실패하면 prob_map>0.5 로 2진화."""
+    if isinstance(overlay_path, str) and overlay_path:
+        try:
+            p = Path(overlay_path)
+            if p.exists() and p.is_file():
+                dest.write_bytes(p.read_bytes())
+                return
+            logger.warning("overlay path 존재하지 않음 (%s) → prob_map fallback", overlay_path)
+        except Exception as exc:
+            logger.warning("overlay path copy 실패: %s → prob_map fallback", exc)
+
+    # prob_map>0.5 이진화
+    try:
+        import cv2
+        mask = (prob_map > 0.5).astype(np.uint8) * 255
+        cv2.imwrite(str(dest), mask)
+    except Exception as exc:
+        logger.warning("wall_mask 생성 실패 (무시): %s", exc)
+
+
+def _extract_image_dims(
+    unet_metrics: dict[str, Any], prob_map: np.ndarray
+) -> tuple[int, int]:
+    """unet metrics.shape = [H, W] (계약) 우선, 없으면 prob_map shape (H, W)."""
+    shape = unet_metrics.get("shape")
+    if isinstance(shape, list) and len(shape) >= 2:
+        try:
+            h, w = int(shape[0]), int(shape[1])
+            if h > 0 and w > 0:
+                return w, h
+        except (TypeError, ValueError):
+            pass
+    return int(prob_map.shape[1]), int(prob_map.shape[0])
+
+
+def _validate_prob_map_shape(arr: np.ndarray) -> np.ndarray:
+    if arr.ndim != 2:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            f"prob_map 은 2D 가 필요. got shape={arr.shape}",
+            502,
+        )
+    return arr.astype(np.float32, copy=False)

--- a/backend/app/services/local_inference_service.py
+++ b/backend/app/services/local_inference_service.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import io
 import logging
 import mimetypes
+import os
 import tempfile
 import uuid
 from datetime import datetime, timezone
@@ -35,6 +36,13 @@ from app.services.sagemaker_inference_service import InferenceResult
 
 logger = logging.getLogger(__name__)
 
+# 로컬 AI 추론은 sliding-window U-Net (CPU 기본) 으로, 1654×1169 도면 기준 patch
+# 30개 × 3~10s = 90~300s + 모델 첫 로드 5~10s 가 걸린다. 환경변수로 조정 가능.
+# 첫 호출은 모델 로드 포함이라 더 길게, 이후는 캐시되어 빠름.
+DEFAULT_LOCAL_INFERENCE_TIMEOUT_S = float(
+    os.getenv("LOCAL_INFERENCE_TIMEOUT_SECONDS", "600")
+)
+
 
 def run_local_inference(
     *,
@@ -42,7 +50,7 @@ def run_local_inference(
     filename: str,
     content_type: str,
     ai_service_url: str,
-    request_timeout_s: float = 120.0,
+    request_timeout_s: float = DEFAULT_LOCAL_INFERENCE_TIMEOUT_S,
 ) -> InferenceResult:
     """이미지 바이트 → 로컬 AI 두 endpoint 호출 → SageMaker 와 같은 `InferenceResult`.
 
@@ -185,6 +193,17 @@ def _post_inference(
             files={"file": (filename, io.BytesIO(image_bytes), content_type)},
             timeout=timeout,
         )
+    except requests.exceptions.ReadTimeout as exc:
+        raise AppError(
+            ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,
+            (
+                f"Local AI {url} read timeout after {timeout:.0f}s. "
+                f"Sliding-window U-Net on CPU 은 큰 이미지에서 수 분 걸릴 수 있음. "
+                f"LOCAL_INFERENCE_TIMEOUT_SECONDS env 로 늘리거나, AI 측 "
+                f"configs/unet_inference.yaml 에서 sliding_window: false 로 빠르게 (품질↓)."
+            ),
+            504,
+        ) from exc
     except requests.RequestException as exc:
         raise AppError(
             ErrorCode.EXTERNAL_SERVICE_REQUEST_FAILED,

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -66,6 +66,77 @@ def _positive(value: float | None, fallback: float) -> float:
     return value
 
 
+def _build_wall_dimension_match_map(
+    walls: list[dict],
+    postprocess_metadata: dict | None,
+) -> dict[int, dict]:
+    """SceneSchema.walls (픽셀 좌표) 와 postprocess dimension_matches 를 다시 매칭.
+
+    fusion 후처리(bridge/snap)로 wall idx 가 바뀌었을 수 있어, postprocess 단계의
+    `matched_wall_idx` 를 그대로 못 씀. 대신 OCR entries 와 wall 픽셀 좌표를 받아
+    동일 `match_dimensions_to_walls` 알고리즘으로 재매칭.
+
+    반환: `{wall_index_in_scene: dimension_match_dict}`. 매칭 안 된 wall 은 키 없음.
+    """
+    if not postprocess_metadata or not walls:
+        return {}
+
+    raw_matches = postprocess_metadata.get("dimension_matches") or []
+    if not raw_matches:
+        return {}
+
+    # dimension_matches 자체에 OCR 결과 (bbox + parsed meters) 가 있으므로 OCR 호출
+    # 다시 안 해도 됨. dimension_matching 의 매칭 알고리즘만 재사용.
+    try:
+        from app.services.wall_extraction_helpers import dimension_matching
+        from app.services.wall_extraction_helpers.ocr import OCREntry
+    except Exception:
+        return {}
+
+    # 픽셀 좌표 추출. SceneSchema.Wall 은 model_dump 됐으므로 x1/y1/x2/y2 직접 접근.
+    wall_pixel_coords: list[list[float]] = []
+    for w in walls:
+        try:
+            wall_pixel_coords.append([
+                float(w["x1"]), float(w["y1"]),
+                float(w["x2"]), float(w["y2"]),
+            ])
+        except (KeyError, TypeError, ValueError):
+            wall_pixel_coords.append([0.0, 0.0, 0.0, 0.0])
+
+    # 각 dimension_match → OCREntry 로 복원 (text/bbox 가 필요한 최소 필드).
+    entries = []
+    for m in raw_matches:
+        try:
+            bbox = tuple(int(v) for v in m.get("bbox", []))
+            if len(bbox) != 4:
+                continue
+            entries.append(
+                OCREntry(
+                    bbox=bbox,  # type: ignore[arg-type]
+                    text=str(m.get("text", "")),
+                    confidence=float(m.get("ocr_confidence", 0.0)),
+                )
+            )
+        except Exception:
+            continue
+
+    if not entries:
+        return {}
+
+    rematched = dimension_matching.match_dimensions_to_walls(entries, wall_pixel_coords)
+    result: dict[int, dict] = {}
+    for m in rematched:
+        if m.matched_wall_idx is None:
+            continue
+        # 같은 wall 에 여러 매칭이 잡히면 가장 높은 ocr_confidence 만 유지.
+        existing = result.get(m.matched_wall_idx)
+        if existing and existing.get("ocr_confidence", 0) >= m.ocr_confidence:
+            continue
+        result[m.matched_wall_idx] = m.to_dict()
+    return result
+
+
 def _resolve_project_floor(
     db: Session,
     project_id: str | None,
@@ -167,6 +238,8 @@ def save_scene_draft(
     }
     if request_dto.scene.inference_metadata:
         summary_json["inference_metadata"] = request_dto.scene.inference_metadata
+    if request_dto.scene.postprocess_metadata:
+        summary_json["wall_postprocess"] = request_dto.scene.postprocess_metadata
 
     scene_draft = SceneDraft(
         project_id=resolved_project_id,
@@ -198,8 +271,20 @@ def save_scene_draft(
                 )
             )
 
+        # wall 픽셀 좌표 기준으로 OCR 치수 매칭 재실행 (fusion 후처리로 wall idx 바뀌었을
+        # 가능성 대비). dimension_match 결과는 각 DraftWall.metadata_json 에 첨부.
+        wall_dim_matches = _build_wall_dimension_match_map(
+            request_dto.scene.walls,
+            request_dto.scene.postprocess_metadata,
+        )
+
         wall_id_map: dict[str, str] = {}
-        for wall in request_dto.scene.walls:
+        for idx, wall in enumerate(request_dto.scene.walls):
+            wall_meta: dict[str, Any] = {"raw": wall}
+            dim_match = wall_dim_matches.get(idx)
+            if dim_match is not None:
+                wall_meta["dimension_match"] = dim_match
+
             draft_wall = DraftWall(
                 scene_draft_id=scene_draft.id,
                 wall_role=wall.get("role", "inner"),
@@ -208,7 +293,7 @@ def save_scene_draft(
                 material_label=wall.get("material"),
                 source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
                 centerline_geom=wall_centerline_geom(wall, scale_ratio),
-                metadata_json={"raw": wall},
+                metadata_json=wall_meta,
             )
             db.add(draft_wall)
             db.flush()
@@ -272,8 +357,8 @@ def save_scene_draft(
 async def analyze_from_asset(
     db: Session,
     asset_id: UUID,
-    real_width_m: float,
     current_user: User,
+    inference_mode: str = "sagemaker",
 ) -> AnalyzeFromAssetResponse:
     """이미 등록된 Asset 도면을 분석해서 비동기 Job 등록.
 
@@ -314,13 +399,13 @@ async def analyze_from_asset(
         image_bytes=content,
         filename=filename,
         content_type=asset.mime_type or "application/octet-stream",
-        real_width_m=real_width_m,
         project_id=asset.project_id,
         floor_id=asset.floor_id,
         current_user=current_user,
         upload_metadata=upload_metadata,
         created_by=current_user.email,
         source_asset_id=str(asset.id),
+        inference_mode=inference_mode,
     )
 
     return AnalyzeFromAssetResponse(

--- a/backend/app/services/wall_extraction.py
+++ b/backend/app/services/wall_extraction.py
@@ -1,16 +1,66 @@
 import cv2
 import numpy as np
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Any, Tuple
 from app.core.settings import MASK_DIR
+
+
+@dataclass
+class PostprocessMetadata:
+    """§69 wall postprocess 결과 metadata.
+
+    응답 / `summary_json["wall_postprocess"]` 영속화 / 디버깅 라우터에서 동일하게 사용.
+    `applied=False` 면 threshold scoring 비활성 (image_path 없음, helper import 실패 등).
+    """
+    applied: bool
+    selected_threshold: float | None = None
+    threshold_candidates: list[float] = field(default_factory=list)
+    scores: list[dict] = field(default_factory=list)  # ThresholdScore.to_dict()
+    ocr_regions_count: int = 0
+    line_segments_count: int = 0
+    # 치수 OCR ↔ 벽 매칭 결과 (scoring 단계에서는 dim_entries 만 추출, 매칭은 후처리 후).
+    dimension_entries_count: int = 0     # 치수로 파싱된 OCR 항목 수
+    dimension_matches: list[dict] = field(default_factory=list)  # DimensionMatch.to_dict()
+    scale_estimate: dict | None = None   # ScaleEstimate.to_dict() — OCR 기반 scale (None 이면 fallback 필요)
+    fallback_reason: str | None = None   # applied=False 일 때 사유
+    debug_dir: str | None = None         # per-job 디버그 이미지 디렉토리 (있을 때)
+
+    def to_dict(self) -> dict:
+        return {
+            "applied": self.applied,
+            "selected_threshold": self.selected_threshold,
+            "threshold_candidates": list(self.threshold_candidates),
+            "scores": list(self.scores),
+            "ocr_regions_count": self.ocr_regions_count,
+            "line_segments_count": self.line_segments_count,
+            "dimension_entries_count": self.dimension_entries_count,
+            "dimension_matches": list(self.dimension_matches),
+            "scale_estimate": self.scale_estimate,
+            "fallback_reason": self.fallback_reason,
+            "debug_dir": self.debug_dir,
+        }
+
+
+@dataclass
+class WallExtractionResult:
+    """`execute_from_prob_map` 반환값. walls 좌표 + postprocess metadata 묶음."""
+    walls: list[list[float]]
+    postprocess: PostprocessMetadata
 
 
 class WallExtractor:
     def __init__(self):
         MASK_DIR.mkdir(parents=True, exist_ok=True)
 
+    def _resolve_debug_dir(self, debug_dir: Path | None) -> Path:
+        """디버그 이미지 저장 경로. 명시되면 그 디렉토리, 아니면 MASK_DIR fallback."""
+        target = Path(debug_dir) if debug_dir is not None else MASK_DIR
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
     # ── 1. 전처리 ─────────────────────────────────────────────────────────
-    def _preprocess(self, mask: np.ndarray) -> np.ndarray:
+    def _preprocess(self, mask: np.ndarray, debug_dir: Path | None = None) -> np.ndarray:
         _, binary = cv2.threshold(mask, 127, 255, cv2.THRESH_BINARY)
         h, w = binary.shape
 
@@ -21,11 +71,12 @@ class WallExtractor:
         close_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (k_size * 2, k_size * 2))
         clean = cv2.morphologyEx(clean, cv2.MORPH_CLOSE, close_kernel)
 
-        cv2.imwrite(str(MASK_DIR / "debug_edges.png"), clean)
+        out_dir = self._resolve_debug_dir(debug_dir)
+        cv2.imwrite(str(out_dir / "debug_edges.png"), clean)
         return clean
 
     # ── 2. Skeleton ───────────────────────────────────────────────────────
-    def _skeletonize(self, edges: np.ndarray, prob_map=None) -> np.ndarray:
+    def _skeletonize(self, edges: np.ndarray, prob_map=None, debug_dir: Path | None = None) -> np.ndarray:
         from skimage.morphology import thin
 
         num_labels, labels, stats, _ = cv2.connectedComponentsWithStats(edges)
@@ -44,7 +95,8 @@ class WallExtractor:
             conf_mask = (prob_map > 0.4)
             thinned = ((thinned > 0) & conf_mask).astype(np.uint8) * 255
 
-        cv2.imwrite(str(MASK_DIR / "debug_skeleton.png"), thinned)
+        out_dir = self._resolve_debug_dir(debug_dir)
+        cv2.imwrite(str(out_dir / "debug_skeleton.png"), thinned)
         return thinned
     
     def _filter_by_confidence(self, lines: List, prob_map: np.ndarray, min_conf=0.6) -> List:
@@ -341,7 +393,13 @@ class WallExtractor:
         return float(np.median(samples))
 
     # ── 9. 디버그 이미지 저장 ─────────────────────────────────────────────
-    def _save_debug(self, skeleton: np.ndarray, lines: List, detections: List[Any] = None):
+    def _save_debug(
+        self,
+        skeleton: np.ndarray,
+        lines: List,
+        detections: List[Any] = None,
+        debug_dir: Path | None = None,
+    ):
         debug = cv2.cvtColor(skeleton, cv2.COLOR_GRAY2BGR)
 
         # 벽 선분 (주황색)
@@ -361,16 +419,22 @@ class WallExtractor:
                 color = (0, 255, 0) if det.class_name == "door" else (0, 200, 255)
                 cv2.rectangle(debug, (bx1, by1), (bx2, by2), color, 2)
 
-        cv2.imwrite(str(MASK_DIR / "eee.png"), debug)
+        out_dir = self._resolve_debug_dir(debug_dir)
+        cv2.imwrite(str(out_dir / "walls_overlay.png"), debug)
 
     # ── 10. 메인 실행 ─────────────────────────────────────────────────────
-    def execute_from_mask(self, mask: np.ndarray, detections: List[Any] = None) -> List[List[float]]:
-        edges = self._preprocess(mask)
+    def execute_from_mask(
+        self,
+        mask: np.ndarray,
+        detections: List[Any] = None,
+        debug_dir: Path | None = None,
+    ) -> List[List[float]]:
+        edges = self._preprocess(mask, debug_dir=debug_dir)
         if edges.sum() == 0:
             return []
 
         wall_thickness = self.estimate_wall_thickness(edges, detections or [])
-        skeleton = self._skeletonize(edges)
+        skeleton = self._skeletonize(edges, debug_dir=debug_dir)
 
         raw_lines = self._detect_lines(skeleton)
         hv_lines  = self._filter_hv(raw_lines)           
@@ -406,18 +470,28 @@ class WallExtractor:
         extended = self._snap_intersections(extended, tol=20.0)
 
 
-        self._save_debug(skeleton, extended, detections or [])
+        self._save_debug(skeleton, extended, detections or [], debug_dir=debug_dir)
         return extended
 
-    def execute_from_unet_image(self, image_path: Path, detections: List[Any] = None) -> List[List[float]]:
+    def execute_from_unet_image(
+        self,
+        image_path: Path,
+        detections: List[Any] = None,
+        debug_dir: Path | None = None,
+    ) -> List[List[float]]:
         img = cv2.imread(str(image_path))
         if img is None:
             raise ValueError(f"이미지를 읽을 수 없습니다: {image_path}")
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-        return self.execute_from_mask(gray, detections)
+        return self.execute_from_mask(gray, detections, debug_dir=debug_dir)
 
-    def execute(self, image_path: Path, detections: List[Any] = None) -> List[List[float]]:
-        return self.execute_from_unet_image(image_path, detections)
+    def execute(
+        self,
+        image_path: Path,
+        detections: List[Any] = None,
+        debug_dir: Path | None = None,
+    ) -> List[List[float]]:
+        return self.execute_from_unet_image(image_path, detections, debug_dir=debug_dir)
 
     def execute_from_prob_map(
         self,
@@ -425,32 +499,42 @@ class WallExtractor:
         threshold: float = None,
         detections: List[Any] = None,
         image_path: Path | None = None,
-    ) -> List[List[float]]:
-        """U-Net wall probability map → wall 선분 리스트.
+        debug_dir: Path | None = None,
+    ) -> WallExtractionResult:
+        """U-Net wall probability map → walls + postprocess metadata.
 
         threshold 결정 우선순위:
           1. `threshold` 인자가 명시되면 그 값 사용
           2. `image_path` 가 있으면 multi-threshold + OCR/선분 정합도 기반 best 선택 (§69)
           3. 그 외 → Otsu fallback
+
+        반환: `WallExtractionResult` (walls + PostprocessMetadata). 호출자가 metadata
+        를 `summary_json` 영속화 / 응답 / 디버깅에 활용.
         """
         from skimage.filters import threshold_otsu
 
         prob = np.load(str(prob_map_path))
 
-        # 1. threshold 결정
-        thr = self._pick_threshold(prob, threshold, image_path)
-        if thr is None:
-            thr = float(threshold_otsu(prob))
+        # 1. threshold 결정 (+ metadata 동시 빌드, OCR entries 보존)
+        meta, ocr_entries = self._pick_threshold(prob, threshold, image_path)
+        if meta.debug_dir is None and debug_dir is not None:
+            meta.debug_dir = str(debug_dir)
+        if meta.selected_threshold is None:
+            otsu_thr = float(threshold_otsu(prob))
+            meta.selected_threshold = otsu_thr
+            if meta.fallback_reason is None:
+                meta.fallback_reason = "explicit_threshold_not_provided"
+        thr = meta.selected_threshold
         mask = (prob > thr).astype(np.uint8) * 255
-        
-        edges = self._preprocess(mask)
+
+        edges = self._preprocess(mask, debug_dir=debug_dir)
         if edges.sum() == 0:
-            return []
+            return WallExtractionResult(walls=[], postprocess=meta)
 
         wall_thickness = self.estimate_wall_thickness(edges, detections or [])
-        
+
         # 2. 확률 가중 스켈레톤
-        skeleton = self._skeletonize(edges, prob_map=prob)
+        skeleton = self._skeletonize(edges, prob_map=prob, debug_dir=debug_dir)
 
         raw_lines = self._detect_lines(skeleton)
         hv_lines  = self._filter_hv(raw_lines)
@@ -494,22 +578,63 @@ class WallExtractor:
         # 이미지 가장자리에 잡힌 캔버스 경계 라인 제거
         result = self._filter_border(result, skeleton.shape, margin_ratio=0.01)
 
-        self._save_debug(skeleton, result, detections or [])
-        return result
+        self._save_debug(skeleton, result, detections or [], debug_dir=debug_dir)
+
+        # 4. 치수 OCR ↔ 추출된 벽 매칭 → scale 추정 (real_width_m fallback 용).
+        if ocr_entries and result:
+            try:
+                from app.services.wall_extraction_helpers import dimension_matching
+
+                matches = dimension_matching.match_dimensions_to_walls(
+                    ocr_entries, result,
+                )
+                meta.dimension_matches = [m.to_dict() for m in matches]
+                est = dimension_matching.estimate_scale_from_matches(matches)
+                if est is not None:
+                    meta.scale_estimate = est.to_dict()
+            except Exception as exc:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "dimension matching 실패 (무시하고 진행): %s", exc
+                )
+
+        return WallExtractionResult(walls=result, postprocess=meta)
 
     def _pick_threshold(
         self,
         prob: np.ndarray,
         explicit: float | None,
         image_path: Path | None,
-    ) -> float | None:
-        """§69 multi-threshold scoring 으로 best 선택. image_path 없으면 None 반환 (fallback)."""
+    ) -> tuple[PostprocessMetadata, list]:
+        """§69 multi-threshold scoring 으로 best 선택 + 치수 매칭 입력 자료 보존.
+
+        반환: `(PostprocessMetadata, ocr_entries)` — ocr_entries 는 후속 dimension
+        매칭에 재사용. scoring 비활성이면 빈 리스트.
+
+          - `applied=True` & `selected_threshold` 설정: scoring 완료
+          - `applied=False`: scoring 비활성 — 호출자가 explicit 값 또는 Otsu fallback 사용
+        """
+        from app.services.wall_extraction_helpers.threshold_scoring import (
+            DEFAULT_THRESHOLDS,
+        )
+
+        meta = PostprocessMetadata(
+            applied=False,
+            threshold_candidates=list(DEFAULT_THRESHOLDS),
+        )
+
         if explicit is not None:
-            return float(explicit)
-        if image_path is None or not image_path.exists():
-            return None
+            meta.selected_threshold = float(explicit)
+            meta.fallback_reason = "explicit_threshold_provided"
+            return meta, []
+
+        if image_path is None or not Path(image_path).exists():
+            meta.fallback_reason = "source_image_unavailable"
+            return meta, []
+
         try:
             from app.services.wall_extraction_helpers import (
+                dimension_matching,
                 line_detection,
                 ocr,
                 threshold_scoring,
@@ -519,12 +644,14 @@ class WallExtractor:
             logging.getLogger(__name__).warning(
                 "wall_extraction_helpers import 실패 → Otsu fallback: %s", exc
             )
-            return None
+            meta.fallback_reason = f"helpers_import_failed: {exc}"
+            return meta, []
 
         # prob_map 과 source image 의 해상도가 다를 수 있음 → image 기준으로 prob_map 리사이즈.
         img = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
         if img is None:
-            return None
+            meta.fallback_reason = "source_image_read_failed"
+            return meta, []
         h_img, w_img = img.shape
         h_prob, w_prob = prob.shape
         if (h_img, w_img) != (h_prob, w_prob):
@@ -534,30 +661,54 @@ class WallExtractor:
         else:
             prob_resized = prob
 
-        # OCR + line 추출 (실패해도 둘 다 None 처리해서 진행)
+        # OCR — 텍스트 보존된 entries (치수 매칭 + 페널티 양쪽 쓰임).
+        ocr_entries = []
+        text_mask = None
         try:
-            text_bboxes = ocr.detect_text_bboxes(image_path)
-            text_mask = ocr.build_text_mask(text_bboxes, prob_resized.shape, pad=3)
-        except Exception:
-            text_mask = None
+            ocr_entries = ocr.detect_text_entries(image_path)
+            meta.ocr_regions_count = len(ocr_entries)
+            text_mask = ocr.build_text_mask(
+                [e.bbox for e in ocr_entries], prob_resized.shape, pad=3,
+            )
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning("OCR 추출 실패: %s", exc)
 
+        # 치수로 파싱되는 항목만 분리 — scoring 단계에서 dim_alignment 평가용.
+        dim_entries = [
+            e for e in ocr_entries
+            if dimension_matching.parse_dimension_to_meters(e.text) is not None
+        ]
+        meta.dimension_entries_count = len(dim_entries)
+
+        line_mask = None
         try:
             segs = line_detection.detect_line_segments(image_path)
-            line_mask = line_detection.build_line_mask(segs, prob_resized.shape, thickness=3) if len(segs) > 0 else None
-        except Exception:
-            line_mask = None
+            meta.line_segments_count = int(len(segs))
+            line_mask = (
+                line_detection.build_line_mask(segs, prob_resized.shape, thickness=3)
+                if len(segs) > 0 else None
+            )
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning("line detection 실패: %s", exc)
 
-        best_thr, _scores = threshold_scoring.pick_best_threshold(
-            prob_resized, line_mask=line_mask, text_mask=text_mask
+        best_thr, scores = threshold_scoring.pick_best_threshold(
+            prob_resized,
+            line_mask=line_mask,
+            text_mask=text_mask,
+            dim_entries=dim_entries,
         )
-        return float(best_thr)
+        meta.applied = True
+        meta.selected_threshold = float(best_thr)
+        meta.scores = [s.to_dict() for s in scores]
+        meta.fallback_reason = None
+        return meta, ocr_entries
 
 
 wall_extractor = WallExtractor()
 
 
-# def run_rule_based_wall_extraction(image_path: Path, detections: List[Any] = None):
-#     return wall_extractor.execute(image_path, detections)
-
-def run_rule_based_wall_extraction(prob_map_path: Path, detections=None): 
-     return wall_extractor.execute_from_prob_map(prob_map_path, detections=detections)
+def run_rule_based_wall_extraction(prob_map_path: Path, detections=None):
+    """legacy entry point — walls 좌표 리스트만 반환 (metadata 버림)."""
+    return wall_extractor.execute_from_prob_map(prob_map_path, detections=detections).walls

--- a/backend/app/services/wall_extraction.py
+++ b/backend/app/services/wall_extraction.py
@@ -19,6 +19,9 @@ class PostprocessMetadata:
     scores: list[dict] = field(default_factory=list)  # ThresholdScore.to_dict()
     ocr_regions_count: int = 0
     line_segments_count: int = 0
+    # OCR 진단용 원본 entries (각 항목: text/bbox/confidence/parsed_meters/parse_confidence).
+    # "OCR 자체 실패" vs "OCR 성공했지만 parser 가 거부" vs "parse 됐지만 매칭 실패" 분리용.
+    ocr_entries: list[dict] = field(default_factory=list)
     # 치수 OCR ↔ 벽 매칭 결과 (scoring 단계에서는 dim_entries 만 추출, 매칭은 후처리 후).
     dimension_entries_count: int = 0     # 치수로 파싱된 OCR 항목 수
     dimension_matches: list[dict] = field(default_factory=list)  # DimensionMatch.to_dict()
@@ -34,6 +37,7 @@ class PostprocessMetadata:
             "scores": list(self.scores),
             "ocr_regions_count": self.ocr_regions_count,
             "line_segments_count": self.line_segments_count,
+            "ocr_entries": list(self.ocr_entries),
             "dimension_entries_count": self.dimension_entries_count,
             "dimension_matches": list(self.dimension_matches),
             "scale_estimate": self.scale_estimate,
@@ -61,15 +65,29 @@ class WallExtractor:
 
     # ── 1. 전처리 ─────────────────────────────────────────────────────────
     def _preprocess(self, mask: np.ndarray, debug_dir: Path | None = None) -> np.ndarray:
+        """Open(작게)으로 노이즈만 제거 → 수평/수직 Close 따로 적용해 합집합.
+
+        이전엔 큰 정사각형(k*2) Close 로 인접 평행 벽을 뭉치게 했는데, 얇은 내부 벽이
+        사라지는 문제 있어서 H/V 분리:
+          - 수평 close (k_close, 1) → 가로 벽 안의 작은 끊김만 메움
+          - 수직 close (1, k_close) → 세로 벽 안의 작은 끊김만 메움
+          - 두 결과 OR → H/V 벽 모두 보존하되 perpendicular gap bridging 회피
+        """
         _, binary = cv2.threshold(mask, 127, 255, cv2.THRESH_BINARY)
         h, w = binary.shape
 
-        k_size = max(3, int(min(h, w) * 0.01))
-        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (k_size, k_size))
-        clean = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel)
+        # Open: 노이즈 제거용 작은 커널 (이전 0.01 → 0.003 으로 축소).
+        k_open = max(2, int(min(h, w) * 0.003))
+        open_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (k_open, k_open))
+        clean = cv2.morphologyEx(binary, cv2.MORPH_OPEN, open_kernel)
 
-        close_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (k_size * 2, k_size * 2))
-        clean = cv2.morphologyEx(clean, cv2.MORPH_CLOSE, close_kernel)
+        # Close: H/V 분리해서 각자의 끊김만 메움.
+        k_close = max(5, int(min(h, w) * 0.008))
+        h_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (k_close, 1))
+        v_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (1, k_close))
+        h_close = cv2.morphologyEx(clean, cv2.MORPH_CLOSE, h_kernel)
+        v_close = cv2.morphologyEx(clean, cv2.MORPH_CLOSE, v_kernel)
+        clean = cv2.bitwise_or(h_close, v_close)
 
         out_dir = self._resolve_debug_dir(debug_dir)
         cv2.imwrite(str(out_dir / "debug_edges.png"), clean)
@@ -515,7 +533,24 @@ class WallExtractor:
 
         prob = np.load(str(prob_map_path))
 
+        # A. 좌표계 통일 — AI 가 prob_map 을 작은 해상도(예: 512×512)로 뱉으면
+        # OCR bbox(원본 이미지 좌표)와 wall 결과(prob_map 좌표) 가 어긋남.
+        # image_path 가 있으면 prob_map 을 원본 이미지 크기로 미리 resize 해서
+        # 모든 downstream 처리(mask, skeleton, walls, OCR, dimension match)가 동일
+        # 이미지 좌표계에서 동작하도록 보장.
+        if image_path is not None and Path(image_path).exists():
+            img_for_dims = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
+            if img_for_dims is not None:
+                h_img, w_img = img_for_dims.shape
+                h_prob, w_prob = prob.shape
+                if (h_img, w_img) != (h_prob, w_prob):
+                    prob = cv2.resize(
+                        prob.astype(np.float32), (w_img, h_img),
+                        interpolation=cv2.INTER_LINEAR,
+                    )
+
         # 1. threshold 결정 (+ metadata 동시 빌드, OCR entries 보존)
+        # 이 시점의 prob 는 이미 image 좌표계에 정렬되어 있음.
         meta, ocr_entries = self._pick_threshold(prob, threshold, image_path)
         if meta.debug_dir is None and debug_dir is not None:
             meta.debug_dir = str(debug_dir)
@@ -674,11 +709,27 @@ class WallExtractor:
             import logging
             logging.getLogger(__name__).warning("OCR 추출 실패: %s", exc)
 
-        # 치수로 파싱되는 항목만 분리 — scoring 단계에서 dim_alignment 평가용.
-        dim_entries = [
-            e for e in ocr_entries
-            if dimension_matching.parse_dimension_to_meters(e.text) is not None
-        ]
+        # 진단용: 각 OCR entry 의 raw text + bbox + conf + parse 결과를 metadata 에 보관.
+        # "OCR 실패" / "parser 거부" / "parse 됐지만 매칭 실패" 를 분리해 추적 가능.
+        ocr_entries_dump: list[dict] = []
+        dim_entries = []
+        for e in ocr_entries:
+            parsed = dimension_matching.parse_dimension_to_meters(e.text)
+            ocr_entries_dump.append({
+                "text": e.text,
+                "bbox": list(e.bbox),
+                "confidence": round(float(e.confidence), 3),
+                "parsed_meters": (
+                    round(parsed.meters, 4) if parsed is not None else None
+                ),
+                "parse_confidence": (
+                    round(parsed.confidence, 2) if parsed is not None else None
+                ),
+                "unit_hint": parsed.unit_hint if parsed is not None else None,
+            })
+            if parsed is not None:
+                dim_entries.append(e)
+        meta.ocr_entries = ocr_entries_dump
         meta.dimension_entries_count = len(dim_entries)
 
         line_mask = None

--- a/backend/app/services/wall_extraction_helpers/dimension_matching.py
+++ b/backend/app/services/wall_extraction_helpers/dimension_matching.py
@@ -1,0 +1,368 @@
+"""도면 OCR 치수 ↔ 벽 길이 매칭 + scale 자동 추정.
+
+도면에는 보통 벽 옆에 치수 라벨이 적혀 있다 (예: "3,500", "3.5m", "350cm").
+OCR 로 라벨 위치/문자열을 받고, 가장 가까운 평행 벽 선분의 픽셀 길이와 페어링하면
+픽셀↔미터 변환비 (`scale_m_per_px`) 를 도면 자체에서 추정할 수 있다.
+
+흐름:
+  1. `parse_dimension_to_meters(text)` — 텍스트에서 미터값만 뽑는다 (m/mm/cm 인식).
+  2. `match_dimensions_to_walls(entries, walls)` — 각 OCR 항목을 인접 벽과 짝지운다.
+  3. `estimate_scale_from_matches(matches)` — 페어들의 median 으로 scale 결정 (outlier 제외).
+
+사용자에게 도면 가로폭(m)을 묻지 않고도 scale 잡히는 것이 목적. 매칭 신뢰 페어가
+부족하면 `None` 반환 → 호출자(`fusion_service`)가 default fallback scale 사용 후
+사용자가 PropertiesPanel 에서 벽별 실측값으로 보정.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# 단위 명시 패턴 (대소문자 무시). 한국 건축 도면 표기 흔한 순서대로.
+_UNIT_PATTERNS: tuple[tuple[re.Pattern, float], ...] = (
+    (re.compile(r"(\d+(?:[\.,]\d+)?)\s*mm\b", re.IGNORECASE), 0.001),
+    (re.compile(r"(\d+(?:[\.,]\d+)?)\s*cm\b", re.IGNORECASE), 0.01),
+    (re.compile(r"(\d+(?:[\.,]\d+)?)\s*m\b", re.IGNORECASE), 1.0),
+)
+
+# 단위 미명시 — 쉼표 포함 정수 ("3,500"): 한국 건축 mm 표기로 가정.
+_COMMA_INT_PATTERN = re.compile(r"^\s*(\d{1,3}(?:,\d{3})+)\s*$")
+# 단위 미명시 — 소수점 포함 ("3.5"): m 가정.
+_DECIMAL_PATTERN = re.compile(r"^\s*(\d+\.\d+)\s*$")
+
+
+@dataclass(frozen=True)
+class ParsedDimension:
+    meters: float
+    confidence: float  # 단위 명시=1.0, 휴리스틱(comma/decimal)=0.5
+    unit_hint: str     # "m" / "mm" / "cm" / "mm_comma" / "m_decimal"
+
+
+def parse_dimension_to_meters(text: str) -> ParsedDimension | None:
+    """OCR 텍스트에서 미터 단위 길이 추출. 인식 안되면 None.
+
+    인식 규칙:
+      - "3500mm" / "350cm" / "3.5m" → 명시된 단위로 직접 변환 (confidence=1.0)
+      - "3,500" → 한국 도면 mm 표기로 가정 (confidence=0.5)
+      - "3.5" → m 가정 (confidence=0.5)
+      - 단순 정수 (e.g. "350") → 단위 추정 위험 → 거부
+    """
+    if not text or not isinstance(text, str):
+        return None
+
+    # 단위 명시 우선 — 텍스트 전체가 아닌 부분 매칭도 허용 (예: "L=3.5m" 등).
+    for pat, factor in _UNIT_PATTERNS:
+        m = pat.search(text)
+        if m:
+            try:
+                v = float(m.group(1).replace(",", "."))
+            except ValueError:
+                continue
+            meters = v * factor
+            if meters <= 0:
+                continue
+            unit = "mm" if factor == 0.001 else ("cm" if factor == 0.01 else "m")
+            return ParsedDimension(meters=meters, confidence=1.0, unit_hint=unit)
+
+    # 휴리스틱 1: 쉼표 포함 정수 → mm
+    m = _COMMA_INT_PATTERN.match(text)
+    if m:
+        try:
+            v = float(m.group(1).replace(",", ""))
+        except ValueError:
+            return None
+        if v <= 0:
+            return None
+        return ParsedDimension(meters=v * 0.001, confidence=0.5, unit_hint="mm_comma")
+
+    # 휴리스틱 2: 소수점 → m
+    m = _DECIMAL_PATTERN.match(text)
+    if m:
+        try:
+            v = float(m.group(1))
+        except ValueError:
+            return None
+        if v <= 0 or v > 30.0:  # 30m 초과는 도면 단일 치수로 비현실적
+            return None
+        return ParsedDimension(meters=v, confidence=0.5, unit_hint="m_decimal")
+
+    return None
+
+
+@dataclass
+class DimensionMatch:
+    """OCR 치수 라벨 + 매칭된 벽 + implied scale."""
+    text: str
+    parsed_meters: float
+    bbox: tuple[int, int, int, int]
+    orientation: str  # "horizontal" / "vertical"
+    matched_wall_idx: int | None
+    matched_wall_px_len: float | None
+    implied_scale_m_per_px: float | None
+    ocr_confidence: float
+    parse_confidence: float
+
+    def is_valid_for_scale(self) -> bool:
+        return (
+            self.matched_wall_idx is not None
+            and self.implied_scale_m_per_px is not None
+            and self.implied_scale_m_per_px > 0
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "text": self.text,
+            "parsed_meters": round(self.parsed_meters, 4),
+            "bbox": list(self.bbox),
+            "orientation": self.orientation,
+            "matched_wall_idx": self.matched_wall_idx,
+            "matched_wall_px_len": (
+                round(self.matched_wall_px_len, 2)
+                if self.matched_wall_px_len is not None else None
+            ),
+            "implied_scale_m_per_px": (
+                round(self.implied_scale_m_per_px, 6)
+                if self.implied_scale_m_per_px is not None else None
+            ),
+            "ocr_confidence": round(self.ocr_confidence, 3),
+            "parse_confidence": round(self.parse_confidence, 3),
+        }
+
+
+def _bbox_orientation(bbox: tuple[int, int, int, int]) -> str:
+    """bbox 가로/세로 비율로 치수 라벨 방향 추정 (벽도 같은 방향이라 가정)."""
+    x1, y1, x2, y2 = bbox
+    w, h = max(1, x2 - x1), max(1, y2 - y1)
+    return "horizontal" if w >= h else "vertical"
+
+
+def _wall_orientation(wall: Sequence[float]) -> str | None:
+    """벽 선분이 거의 수평/수직인지. 둘 다 아니면 None (대각선 제외)."""
+    x1, y1, x2, y2 = wall
+    dx, dy = abs(x2 - x1), abs(y2 - y1)
+    if dx == 0 and dy == 0:
+        return None
+    if dx >= dy * 3:
+        return "horizontal"
+    if dy >= dx * 3:
+        return "vertical"
+    return None
+
+
+def _wall_length(wall: Sequence[float]) -> float:
+    x1, y1, x2, y2 = wall
+    return float(((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5)
+
+
+def _bbox_to_wall_distance(
+    bbox: tuple[int, int, int, int], wall: Sequence[float], orientation: str
+) -> float:
+    """치수 bbox 중심에서 평행 벽까지의 수직 거리."""
+    bx = (bbox[0] + bbox[2]) / 2
+    by = (bbox[1] + bbox[3]) / 2
+    x1, y1, x2, y2 = wall
+    wall_mid_x = (x1 + x2) / 2
+    wall_mid_y = (y1 + y2) / 2
+    if orientation == "horizontal":
+        # 수평 벽 — y 차이가 수직 거리
+        return abs(by - wall_mid_y)
+    # 수직 벽 — x 차이가 수직 거리
+    return abs(bx - wall_mid_x)
+
+
+def _bbox_along_overlap(
+    bbox: tuple[int, int, int, int], wall: Sequence[float], orientation: str
+) -> float:
+    """치수 bbox 가 벽 선분과 길이 방향으로 얼마나 겹치는지 (0~1)."""
+    if orientation == "horizontal":
+        bx1, bx2 = bbox[0], bbox[2]
+        wx1, wx2 = min(wall[0], wall[2]), max(wall[0], wall[2])
+    else:
+        bx1, bx2 = bbox[1], bbox[3]
+        wx1, wx2 = min(wall[1], wall[3]), max(wall[1], wall[3])
+    inter = max(0.0, min(bx2, wx2) - max(bx1, wx1))
+    span = max(1.0, bx2 - bx1)
+    return float(inter / span)
+
+
+def match_dimensions_to_walls(
+    entries,  # list[OCREntry] (app.services.wall_extraction_helpers.ocr.OCREntry)
+    walls: Sequence[Sequence[float]],
+    max_perpendicular_dist_px: float = 80.0,
+    min_along_overlap: float = 0.2,
+) -> list[DimensionMatch]:
+    """OCR 항목 각각에 가장 가까운 평행 벽을 매칭.
+
+    매칭 규칙:
+      - 라벨 bbox 방향(수평/수직) 추정 → 같은 방향 벽만 후보
+      - bbox 중심에서 벽까지 수직 거리 ≤ `max_perpendicular_dist_px`
+      - bbox 와 벽이 길이 방향으로 일정 비율(`min_along_overlap`) 이상 겹쳐야 함
+      - 위 조건 통과한 후보 중 수직 거리가 가장 작은 벽 1개
+    """
+    matches: list[DimensionMatch] = []
+    if not walls:
+        return matches
+
+    for entry in entries or []:
+        parsed = parse_dimension_to_meters(entry.text)
+        if parsed is None:
+            continue
+
+        orient = _bbox_orientation(entry.bbox)
+
+        best_idx: int | None = None
+        best_dist = float("inf")
+        for i, w in enumerate(walls):
+            if _wall_orientation(w) != orient:
+                continue
+            d = _bbox_to_wall_distance(entry.bbox, w, orient)
+            if d > max_perpendicular_dist_px:
+                continue
+            if _bbox_along_overlap(entry.bbox, w, orient) < min_along_overlap:
+                continue
+            if d < best_dist:
+                best_dist = d
+                best_idx = i
+
+        wall_len = _wall_length(walls[best_idx]) if best_idx is not None else None
+        implied = (
+            (parsed.meters / wall_len) if wall_len and wall_len > 0 else None
+        )
+        matches.append(
+            DimensionMatch(
+                text=entry.text,
+                parsed_meters=parsed.meters,
+                bbox=entry.bbox,
+                orientation=orient,
+                matched_wall_idx=best_idx,
+                matched_wall_px_len=wall_len,
+                implied_scale_m_per_px=implied,
+                ocr_confidence=entry.confidence,
+                parse_confidence=parsed.confidence,
+            )
+        )
+
+    if matches:
+        valid = sum(1 for m in matches if m.is_valid_for_scale())
+        logger.info(
+            "dimension matching: %d parsed, %d wall-matched (of %d walls)",
+            len(matches), valid, len(walls),
+        )
+    return matches
+
+
+@dataclass
+class ScaleEstimate:
+    scale_m_per_px: float
+    pair_count: int
+    median: float
+    mad: float                 # median absolute deviation
+    outliers_dropped: int
+    used_pairs: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "scale_m_per_px": round(self.scale_m_per_px, 6),
+            "pair_count": self.pair_count,
+            "median": round(self.median, 6),
+            "mad": round(self.mad, 6),
+            "outliers_dropped": self.outliers_dropped,
+            "used_pairs": list(self.used_pairs),
+        }
+
+
+def estimate_scale_from_matches(
+    matches: list[DimensionMatch],
+    min_pairs: int = 3,
+    mad_factor: float = 3.0,
+) -> ScaleEstimate | None:
+    """매칭들에서 픽셀↔미터 변환비 추정. min_pairs 미만이면 None.
+
+    median + MAD 기반 outlier 제거 후 median 반환. unit-mismatch (예: "3500" 을
+    잘못 m 로 파싱) 같은 한두 케이스 떨어뜨려 robustness 확보.
+    """
+    valid = [
+        m for m in matches
+        if m.is_valid_for_scale() and m.implied_scale_m_per_px is not None
+    ]
+    if len(valid) < min_pairs:
+        return None
+
+    vals = sorted(m.implied_scale_m_per_px for m in valid)  # type: ignore[misc]
+    n = len(vals)
+    med = vals[n // 2] if n % 2 == 1 else 0.5 * (vals[n // 2 - 1] + vals[n // 2])
+    abs_dev = sorted(abs(v - med) for v in vals)
+    mad = abs_dev[n // 2] if n % 2 == 1 else 0.5 * (abs_dev[n // 2 - 1] + abs_dev[n // 2])
+
+    if mad == 0:
+        kept = valid
+    else:
+        kept = [m for m in valid if abs(m.implied_scale_m_per_px - med) <= mad_factor * mad]  # type: ignore[operator]
+        if len(kept) < min_pairs:
+            kept = valid
+
+    kept_vals = sorted(m.implied_scale_m_per_px for m in kept)  # type: ignore[misc]
+    k = len(kept_vals)
+    final = kept_vals[k // 2] if k % 2 == 1 else 0.5 * (kept_vals[k // 2 - 1] + kept_vals[k // 2])
+
+    return ScaleEstimate(
+        scale_m_per_px=float(final),
+        pair_count=len(kept),
+        median=float(med),
+        mad=float(mad),
+        outliers_dropped=len(valid) - len(kept),
+        used_pairs=[m.to_dict() for m in kept],
+    )
+
+
+def dimension_alignment_score(
+    wall_mask,
+    dim_entries,
+    expand_perpendicular_px: int = 12,
+    expand_along_px: int = 6,
+) -> float:
+    """치수 라벨 bbox 의 "벽 쪽" 인접 영역에 wall 픽셀이 존재하는 비율 (0~1).
+
+    threshold_scoring 단계용 — wall 선분 추출이 끝나기 전이므로 mask 자체로만 평가.
+    라벨 bbox 의 좌/우 (수평 라벨) 또는 상/하 (수직 라벨) 일정 거리 내 wall 픽셀 존재 시
+    "라벨에 대응하는 벽이 있다" 로 카운트. 라벨이 N 개 중 M 개 매칭되면 M/N.
+    """
+    import numpy as np
+
+    if wall_mask is None or wall_mask.sum() == 0 or not dim_entries:
+        return 0.0
+    h, w = wall_mask.shape
+    mask_bool = wall_mask > 0
+
+    parsed_count = 0
+    matched_count = 0
+    for entry in dim_entries:
+        if parse_dimension_to_meters(entry.text) is None:
+            continue
+        parsed_count += 1
+        x1, y1, x2, y2 = entry.bbox
+        orient = _bbox_orientation(entry.bbox)
+
+        if orient == "horizontal":
+            # 수평 라벨 → 위/아래 wall 후보
+            ay1 = max(0, y1 - expand_perpendicular_px)
+            ay2 = min(h, y2 + expand_perpendicular_px)
+            ax1 = max(0, x1 - expand_along_px)
+            ax2 = min(w, x2 + expand_along_px)
+        else:
+            ay1 = max(0, y1 - expand_along_px)
+            ay2 = min(h, y2 + expand_along_px)
+            ax1 = max(0, x1 - expand_perpendicular_px)
+            ax2 = min(w, x2 + expand_perpendicular_px)
+
+        if ax2 > ax1 and ay2 > ay1 and mask_bool[ay1:ay2, ax1:ax2].any():
+            matched_count += 1
+
+    if parsed_count == 0:
+        return 0.0
+    return float(matched_count / parsed_count)

--- a/backend/app/services/wall_extraction_helpers/dimension_matching.py
+++ b/backend/app/services/wall_extraction_helpers/dimension_matching.py
@@ -34,6 +34,11 @@ _UNIT_PATTERNS: tuple[tuple[re.Pattern, float], ...] = (
 _COMMA_INT_PATTERN = re.compile(r"^\s*(\d{1,3}(?:,\d{3})+)\s*$")
 # 단위 미명시 — 소수점 포함 ("3.5"): m 가정.
 _DECIMAL_PATTERN = re.compile(r"^\s*(\d+\.\d+)\s*$")
+# 단위 미명시 — 단순 정수 ("3500", "17500"): 한국 건축 도면은 mm 가 표준이라 mm 가정.
+# 너무 작거나 큰 값은 거부 (방 번호/연도 등 오인 방지). 범위: 300~50000 mm = 0.3~50m.
+_PLAIN_INT_PATTERN = re.compile(r"^\s*(\d{3,5})\s*$")
+_PLAIN_INT_MIN_MM = 300
+_PLAIN_INT_MAX_MM = 50000
 
 
 @dataclass(frozen=True)
@@ -90,6 +95,19 @@ def parse_dimension_to_meters(text: str) -> ParsedDimension | None:
         if v <= 0 or v > 30.0:  # 30m 초과는 도면 단일 치수로 비현실적
             return None
         return ParsedDimension(meters=v, confidence=0.5, unit_hint="m_decimal")
+
+    # 휴리스틱 3: 단순 정수 ("3500", "17500") → mm 가정 (한국 건축 표준).
+    # confidence 0.3 — 단위 추정이 강한 가정이라 가장 낮음. 다른 신호와 같이 쓰일 때
+    # outlier 로 떨어지면 estimate_scale_from_matches 의 MAD 필터가 걸러줌.
+    m = _PLAIN_INT_PATTERN.match(text)
+    if m:
+        try:
+            v = int(m.group(1))
+        except ValueError:
+            return None
+        if v < _PLAIN_INT_MIN_MM or v > _PLAIN_INT_MAX_MM:
+            return None
+        return ParsedDimension(meters=v / 1000.0, confidence=0.3, unit_hint="mm_int")
 
     return None
 

--- a/backend/app/services/wall_extraction_helpers/ocr.py
+++ b/backend/app/services/wall_extraction_helpers/ocr.py
@@ -9,12 +9,21 @@ EasyOCR 모델은 최초 호출 시 ~64MB 다운로드 (한국어 + 영어). 캐
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OCREntry:
+    """OCR 결과 한 항목. room label / 치수 / scale calibration 확장용."""
+    bbox: tuple[int, int, int, int]  # (x1, y1, x2, y2)
+    text: str
+    confidence: float
 
 
 @lru_cache(maxsize=1)
@@ -26,10 +35,13 @@ def _get_reader():
     return easyocr.Reader(["ko", "en"], gpu=False, verbose=False)
 
 
-def detect_text_bboxes(image_path: Path) -> list[tuple[int, int, int, int]]:
-    """이미지에서 OCR 로 텍스트 영역만 추출. 결과는 (x1, y1, x2, y2) 리스트.
+def detect_text_entries(image_path: Path) -> list[OCREntry]:
+    """이미지에서 OCR 로 텍스트 영역 + 문자열 + 신뢰도 추출.
 
-    인식한 문자열 자체는 버림 (위치만 필요). 인식 실패한 영역도 무시.
+    문자열까지 같이 반환 — room label 자동 부여, 치수 OCR, scale calibration 같은
+    후속 기능에서 활용. threshold scoring 만 필요한 호출자는 `detect_text_bboxes`
+    를 쓰면 됨 (위치만 추출).
+
     실패 시 빈 리스트 반환 (벽 추출 흐름 계속 진행).
     """
     try:
@@ -46,19 +58,36 @@ def detect_text_bboxes(image_path: Path) -> list[tuple[int, int, int, int]]:
         logger.warning("OCR 실행 실패: %s", exc)
         return []
 
-    bboxes: list[tuple[int, int, int, int]] = []
+    entries: list[OCREntry] = []
     for entry in results:
         # entry = (bbox_4_points, text, confidence)
-        bbox_pts = entry[0]
+        if len(entry) < 3:
+            continue
+        bbox_pts, text, conf = entry[0], entry[1], entry[2]
         try:
             xs = [int(p[0]) for p in bbox_pts]
             ys = [int(p[1]) for p in bbox_pts]
-            bboxes.append((min(xs), min(ys), max(xs), max(ys)))
+            bbox = (min(xs), min(ys), max(xs), max(ys))
         except (TypeError, IndexError):
             continue
+        try:
+            confidence = float(conf)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        entries.append(OCREntry(bbox=bbox, text=str(text), confidence=confidence))
 
-    logger.info("OCR detected %d text bboxes from %s", len(bboxes), image_path.name)
-    return bboxes
+    logger.info("OCR detected %d text entries from %s", len(entries), image_path.name)
+    return entries
+
+
+def detect_text_bboxes(image_path: Path) -> list[tuple[int, int, int, int]]:
+    """텍스트 위치 bbox 만 추출 (threshold scoring 용 경량 진입점).
+
+    문자열/신뢰도가 필요하면 `detect_text_entries` 를 사용. 둘은 동일한 OCR
+    실행을 거치므로 중복 호출이 필요하면 호출자가 `detect_text_entries` 결과를
+    재사용해서 bbox 만 골라 쓰는 게 효율적.
+    """
+    return [e.bbox for e in detect_text_entries(image_path)]
 
 
 def build_text_mask(

--- a/backend/app/services/wall_extraction_helpers/threshold_scoring.py
+++ b/backend/app/services/wall_extraction_helpers/threshold_scoring.py
@@ -1,9 +1,10 @@
 """여러 threshold 후보 중 best 선택.
 
-각 threshold 마다 wall mask 만들고, 5가지 점수로 평가:
+각 threshold 마다 wall mask 만들고, 6가지 점수로 평가:
   + line_alignment_score : 추출된 직선 (Hough) 과 wall mask 의 겹침
   + connectivity_score   : mask 연결성 (큰 연결 컴포넌트 위주, 작은 노이즈 적을수록 ↑)
   + orthogonal_score     : 수평/수직 픽셀 비율 (대각선 노이즈 ↓)
+  + dimension_alignment  : OCR 치수 라벨 옆에 wall 픽셀 존재 비율 (라벨 ↔ 벽 정합)
   - ocr_penalty          : OCR 텍스트 bbox 안에 wall 픽셀이 얼마나 들어갔는지
   - noise_penalty        : 작은 isolated 컴포넌트 개수 (정규화)
 
@@ -31,7 +32,21 @@ class ThresholdScore:
     orthogonal: float
     ocr_penalty: float
     noise_penalty: float
+    dimension_alignment: float
     total: float
+
+    def to_dict(self) -> dict:
+        """JSON 직렬화용 (응답 / summary_json 영속화)."""
+        return {
+            "threshold": round(self.threshold, 4),
+            "line_alignment": round(self.line_alignment, 4),
+            "connectivity": round(self.connectivity, 4),
+            "orthogonal": round(self.orthogonal, 4),
+            "ocr_penalty": round(self.ocr_penalty, 4),
+            "noise_penalty": round(self.noise_penalty, 4),
+            "dimension_alignment": round(self.dimension_alignment, 4),
+            "total": round(self.total, 4),
+        }
 
 
 def _line_alignment_score(wall_mask: np.ndarray, line_mask: np.ndarray) -> float:
@@ -108,9 +123,14 @@ def score_threshold(
     threshold: float,
     line_mask: np.ndarray | None,
     text_mask: np.ndarray | None,
-    weights: tuple[float, float, float, float, float] = (1.0, 1.0, 1.0, 1.0, 0.5),
+    dim_entries=None,
+    weights: tuple[float, float, float, float, float, float] = (1.0, 1.0, 1.0, 1.0, 0.5, 1.0),
 ) -> ThresholdScore:
-    """단일 threshold 평가."""
+    """단일 threshold 평가.
+
+    weights: (line_alignment, connectivity, orthogonal, ocr_penalty, noise_penalty,
+    dimension_alignment). 디폴트는 dim_alignment 도 line_alignment 와 동급 1.0.
+    """
     wall_mask = (prob_map > threshold).astype(np.uint8) * 255
 
     la = _line_alignment_score(wall_mask, line_mask) if line_mask is not None else 0.0
@@ -118,9 +138,19 @@ def score_threshold(
     orth = _orthogonal_score(wall_mask)
     ocr_p = _ocr_penalty(wall_mask, text_mask) if text_mask is not None else 0.0
     np_pen = _noise_penalty(wall_mask)
+    dim = 0.0
+    if dim_entries:
+        # 지연 import — dimension_matching 이 ocr 모듈을 거치지 않도록.
+        from app.services.wall_extraction_helpers.dimension_matching import (
+            dimension_alignment_score,
+        )
+        dim = dimension_alignment_score(wall_mask, dim_entries)
 
-    w_la, w_cc, w_orth, w_ocr, w_np = weights
-    total = w_la * la + w_cc * cc + w_orth * orth - w_ocr * ocr_p - w_np * np_pen
+    w_la, w_cc, w_orth, w_ocr, w_np, w_dim = weights
+    total = (
+        w_la * la + w_cc * cc + w_orth * orth + w_dim * dim
+        - w_ocr * ocr_p - w_np * np_pen
+    )
 
     return ThresholdScore(
         threshold=float(threshold),
@@ -129,6 +159,7 @@ def score_threshold(
         orthogonal=orth,
         ocr_penalty=ocr_p,
         noise_penalty=np_pen,
+        dimension_alignment=dim,
         total=total,
     )
 
@@ -137,16 +168,19 @@ def pick_best_threshold(
     prob_map: np.ndarray,
     line_mask: np.ndarray | None,
     text_mask: np.ndarray | None,
+    dim_entries=None,
     candidates: tuple[float, ...] = DEFAULT_THRESHOLDS,
 ) -> tuple[float, list[ThresholdScore]]:
     """모든 후보 평가 후 best (threshold, scores 전체 리스트) 반환."""
     scores = [
-        score_threshold(prob_map, t, line_mask, text_mask) for t in candidates
+        score_threshold(prob_map, t, line_mask, text_mask, dim_entries=dim_entries)
+        for t in candidates
     ]
     best = max(scores, key=lambda s: s.total)
     logger.info(
-        "threshold scoring: best=%.2f total=%.3f (la=%.3f, cc=%.3f, orth=%.3f, ocr_p=%.3f, np=%.3f)",
+        "threshold scoring: best=%.2f total=%.3f "
+        "(la=%.3f, cc=%.3f, orth=%.3f, dim=%.3f, ocr_p=%.3f, np=%.3f)",
         best.threshold, best.total, best.line_alignment, best.connectivity,
-        best.orthogonal, best.ocr_penalty, best.noise_penalty,
+        best.orthogonal, best.dimension_alignment, best.ocr_penalty, best.noise_penalty,
     )
     return best.threshold, scores

--- a/backend/app/tests/test_logic.py
+++ b/backend/app/tests/test_logic.py
@@ -53,9 +53,9 @@ def test_wi_twin_logic():
     # 2. GeometryService 단독 테스트 (좌표 변환 확인)
     print("\n[STEP 2] GeometryService 변환 테스트 (2000px -> 10m 가정)")
     geo_service = GeometryService(
-        pixel_width=ai_output.meta.original_width, 
-        pixel_height=ai_output.meta.original_height, 
-        real_width_m=10.0
+        pixel_width=ai_output.meta.original_width,
+        pixel_height=ai_output.meta.original_height,
+        scale_ratio=10.0 / max(1, ai_output.meta.original_width),
     )
     
     # 문(door)의 중심점 좌표 하나만 변환해보기

--- a/backend/app/tests/test_wall.py
+++ b/backend/app/tests/test_wall.py
@@ -27,7 +27,7 @@ def run_opencv_unit_test():
     test_mask_path = backend_dir / "outputs" / "test_wall_mask.png"
     create_test_mask(test_mask_path)
     
-    service = GeometryService(pixel_width=1000, pixel_height=1000, real_width_m=10.0)
+    service = GeometryService(pixel_width=1000, pixel_height=1000, scale_ratio=0.01)
 
     print("\n[단계 1] 이미지 읽기 및 좌표 추출 중...")
     try:

--- a/backend/migrations/versions/20260517_0009_floors_spatial_meta.py
+++ b/backend/migrations/versions/20260517_0009_floors_spatial_meta.py
@@ -1,0 +1,55 @@
+"""floors.spatial_meta JSONB 추가 — 측정 좌표계/스케일을 asset 과 분리
+
+기존: bounds/scale/coordinate_system 은 asset.metadata_json (도면 이미지) 에서 파생.
+   → 도면 asset 이 교체되면 spatial 정의도 같이 흔들리고, asset 이 아예 없으면
+     bounds 가 비어 측정 검증이 무력화됨.
+
+변경: floor 단위에 spatial_meta JSONB 컬럼 추가. 첫 도면 분석 시 자동 seed.
+   → asset 교체에도 spatial 보존, asset 미존재 시에도 spatial 수동 입력 가능.
+
+예시 spatial_meta 형태:
+  {
+    "bounds_m": {"min_x": 0.0, "min_y": 0.0, "max_x": 50.0, "max_y": 30.0},
+    "scale_m_per_px": 0.0234,
+    "coordinate_system": {
+      "unit": "meter",
+      "origin": "top_left",
+      "x_axis": "right",
+      "y_axis": "down",
+      "z_axis": "up",
+      "heading_zero_axis": "x",
+      "heading_positive_direction": "cw"
+    }
+  }
+
+Revision ID: 20260517_0009
+Revises: 20260516_0008
+Create Date: 2026-05-17 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260517_0009"
+down_revision: Union[str, Sequence[str], None] = "20260516_0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "floors",
+        sa.Column(
+            "spatial_meta",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("floors", "spatial_meta")

--- a/frontend/src/api/scene-draft.ts
+++ b/frontend/src/api/scene-draft.ts
@@ -1,4 +1,5 @@
 import { api } from './client';
+import { getInferenceModeOnce } from '@/hooks/use-inference-mode';
 import type { Paginated, UUID } from '@/types/common';
 import type {
   AnalyzeFloorplanResponse,
@@ -18,7 +19,6 @@ import type {
 
 export interface AnalyzeFloorplanParams {
   file: File;
-  real_width_m?: number;
   project_id?: UUID;
   floor_id?: UUID;
   created_by?: string;
@@ -26,7 +26,6 @@ export interface AnalyzeFloorplanParams {
 
 export interface AnalyzeFromAssetParams {
   asset_id: UUID;
-  real_width_m: number;
 }
 
 export interface SceneDraftListParams {
@@ -38,14 +37,16 @@ export interface SceneDraftListParams {
 }
 
 export const sceneDraftApi = {
-  // §6.1 POST /upload/floorplan/analyze — Job 큐 등록, HTTP 202 + job_id 반환
+  // §6.1 POST /upload/floorplan/analyze — Job 큐 등록, HTTP 202 + job_id 반환.
+  // scale_ratio 는 백엔드의 OCR 치수 자동 추정으로 결정. 사용자 입력 m 없음.
+  // inference_mode 는 헤더 토글값(localStorage)을 호출 시점에 1회 조회.
   analyzeFloorplan: ({ file, ...rest }: AnalyzeFloorplanParams) => {
     const fd = new FormData();
     fd.append('file', file);
-    if (rest.real_width_m != null) fd.append('real_width_m', String(rest.real_width_m));
     if (rest.project_id) fd.append('project_id', rest.project_id);
     if (rest.floor_id) fd.append('floor_id', rest.floor_id);
     if (rest.created_by) fd.append('created_by', rest.created_by);
+    fd.append('inference_mode', getInferenceModeOnce());
     return api
       .post<AnalyzeFloorplanResponse>('/upload/floorplan/analyze', fd, {
         headers: { 'Content-Type': 'multipart/form-data' },
@@ -54,9 +55,11 @@ export const sceneDraftApi = {
   },
 
   // §6.1.1 POST /assets/{asset_id}/analyze — Job 큐 등록
-  analyzeFromAsset: ({ asset_id, real_width_m }: AnalyzeFromAssetParams) =>
+  analyzeFromAsset: ({ asset_id }: AnalyzeFromAssetParams) =>
     api
-      .post<AnalyzeFromAssetResponse>(`/assets/${asset_id}/analyze`, { real_width_m })
+      .post<AnalyzeFromAssetResponse>(`/assets/${asset_id}/analyze`, {
+        inference_mode: getInferenceModeOnce(),
+      })
       .then((r) => r.data),
 
   // §6.3 GET /scene-drafts  — 자식 배열 없는 summary 응답

--- a/frontend/src/features/editor/CanvasArea.tsx
+++ b/frontend/src/features/editor/CanvasArea.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import { FilePlus2, Image as ImageIcon, Ruler, Upload } from 'lucide-react';
+import { FilePlus2, Image as ImageIcon, Upload } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const ALLOWED_MIME = ['image/png', 'image/jpeg', 'application/pdf'];
 const ALLOWED_EXT = ['png', 'jpg', 'jpeg', 'pdf'];
-const DEFAULT_REAL_WIDTH_M = 10;
 
 function isAllowed(file: File) {
   if (ALLOWED_MIME.includes(file.type)) return true;
@@ -17,7 +16,7 @@ interface CanvasAreaProps {
   isPending?: boolean;
   errorMessage?: string;
   selectedFileName?: string | null;
-  onFile: (file: File, realWidthM: number) => void;
+  onFile: (file: File) => void;
   /** "빈 도면으로 시작" — 이미지 없이 SceneDraft 생성. 미제공 시 버튼 숨김. */
   onStartBlank?: () => void;
   isStartingBlank?: boolean;
@@ -34,19 +33,14 @@ export function CanvasArea({
 }: CanvasAreaProps) {
   const [dragOver, setDragOver] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
-  const [realWidthM, setRealWidthM] = useState<number>(DEFAULT_REAL_WIDTH_M);
 
   const accept = (f: File) => {
     if (!isAllowed(f)) {
       setLocalError('PNG / JPG / JPEG / PDF 파일만 업로드 가능합니다.');
       return;
     }
-    if (!Number.isFinite(realWidthM) || realWidthM <= 0) {
-      setLocalError('도면의 실제 가로 길이를 0보다 큰 값으로 입력해주세요.');
-      return;
-    }
     setLocalError(null);
-    onFile(f, realWidthM);
+    onFile(f);
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -125,25 +119,9 @@ export function CanvasArea({
           </p>
         )}
 
-        <div className="mt-5 inline-flex items-center gap-2 rounded-lg border bg-background px-3 py-2 text-xs">
-          <Ruler className="h-3.5 w-3.5 text-muted-foreground" />
-          <label htmlFor="real-width-m" className="text-muted-foreground">
-            도면 실제 가로 길이
-          </label>
-          <input
-            id="real-width-m"
-            type="number"
-            step="0.1"
-            min="0.1"
-            value={realWidthM}
-            onChange={(e) => setRealWidthM(Number(e.target.value))}
-            disabled={isPending}
-            className="w-16 rounded-md border bg-background px-1.5 py-0.5 text-right text-xs tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-          />
-          <span className="text-muted-foreground">m</span>
-        </div>
-        <p className="mt-1 max-w-md text-[11px] text-muted-foreground">
-          이미지의 가로 폭이 실제 공간에서 몇 미터인지 입력하면 스케일이 정확히 환산됩니다.
+        <p className="mt-4 max-w-md text-[11px] text-muted-foreground">
+          AI 가 도면 치수를 자동으로 읽어 scale 을 추정합니다. 분석 후 우측 속성 패널에서
+          벽별 실측값을 보정할 수 있습니다.
         </p>
 
         {selectedFileName && !isPending && (

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -35,6 +35,8 @@ interface PropertiesPanelProps {
   onRotate?: () => void;
   /** 벽의 material_label 변경. 백엔드 PATCH /draft-walls/{id}. */
   onUpdateMaterial?: (next: string) => void;
+  /** 벽의 실측 길이(m) 변경 — metadata_json.dimension_match.user_meters 갱신. */
+  onUpdateWallDimension?: (meters: number | null) => void;
   /** 객체의 object_type 변경. 백엔드 PATCH /draft-objects/{id}. */
   onUpdateObjectType?: (next: string) => void;
   /** 객체 위치(X/Y) 변경 — 보류 편집에 저장. */
@@ -59,6 +61,7 @@ export function PropertiesPanel({
   onDelete,
   onRotate,
   onUpdateMaterial,
+  onUpdateWallDimension,
   onUpdateObjectType,
   onUpdateObjectPosition,
   onUpdateObjectSize,
@@ -84,6 +87,7 @@ export function PropertiesPanel({
           onDelete={onDelete}
           onRotate={onRotate}
           onUpdateMaterial={onUpdateMaterial}
+          onUpdateWallDimension={onUpdateWallDimension}
           onUpdateObjectType={onUpdateObjectType}
           onUpdateObjectPosition={onUpdateObjectPosition}
           onUpdateObjectSize={onUpdateObjectSize}
@@ -140,6 +144,7 @@ function SelectedBody({
   onDelete,
   onRotate,
   onUpdateMaterial,
+  onUpdateWallDimension,
   onUpdateObjectType,
   onUpdateObjectPosition,
   onUpdateObjectSize,
@@ -150,6 +155,7 @@ function SelectedBody({
   onDelete?: () => void;
   onRotate?: () => void;
   onUpdateMaterial?: (next: string) => void;
+  onUpdateWallDimension?: (meters: number | null) => void;
   onUpdateObjectType?: (next: string) => void;
   onUpdateObjectPosition?: (ref: SelectedEntityRef, x: number, y: number) => void;
   onUpdateObjectSize?: (ref: SelectedEntityRef, widthM: number, heightM: number) => void;
@@ -168,6 +174,16 @@ function SelectedBody({
           {/* [room 비활성화] room 속성 패널 숨김. 다시 켜려면 아래 줄 주석 해제. */}
           {/* {selected.kind === 'room' && <RoomFields room={selected.data} />} */}
           {selected.kind === 'opening' && <OpeningFields opening={selected.data} />}
+        </Section>
+      )}
+
+      {selected.kind === 'wall' && (
+        <Section label="실측 길이">
+          <WallDimensionSection
+            wall={selected.data}
+            onUpdate={onUpdateWallDimension}
+            disabled={isSaving}
+          />
         </Section>
       )}
 
@@ -288,6 +304,126 @@ function WallFields({ wall }: { wall: DraftWall }) {
       <Row label="재질" value={materialLabel(wall.material_label)} />
       <Row label="신뢰도" value={fmtConfidence(wall.confidence)} />
     </Grid>
+  );
+}
+
+/**
+ * 벽의 OCR 치수 매칭 결과 표시 + 사용자 실측값 편집.
+ * - 백엔드가 도면 OCR 로 자동 매칭한 dimension_match 가 있으면 텍스트/추정 m 표시
+ * - 사용자가 입력한 user_meters 가 있으면 그 값 prefill, 없으면 parsed_meters
+ * - Enter / blur 시 `onUpdate(meters | null)` 호출 → 부모(EditorPage)가 PATCH 처리
+ */
+function WallDimensionSection({
+  wall,
+  onUpdate,
+  disabled,
+}: {
+  wall: DraftWall;
+  onUpdate?: (meters: number | null) => void;
+  disabled?: boolean;
+}) {
+  const meta = (wall.metadata_json ?? {}) as Record<string, unknown>;
+  const dim = (meta.dimension_match ?? null) as
+    | {
+        text?: string;
+        parsed_meters?: number;
+        matched_wall_px_len?: number | null;
+        user_meters?: number | null;
+        ocr_confidence?: number;
+      }
+    | null;
+
+  // 입력값 초기값: user_meters 우선, 없으면 OCR parsed_meters.
+  const initialInput =
+    dim?.user_meters != null
+      ? String(dim.user_meters)
+      : dim?.parsed_meters != null
+        ? String(dim.parsed_meters)
+        : '';
+
+  const [input, setInput] = useState(initialInput);
+
+  // wall 바뀔 때 입력값 동기화 (다른 벽 선택 시 stale state 방지).
+  // wall.id 가 키이므로 별도 effect 없이 controlled input 재마운트되도록
+  // key 를 부모 Section 에서 제공해도 되지만, 이 컴포넌트는 selected 가 바뀌면
+  // 새 wall prop 으로 재렌더 → useState 초기값은 첫 마운트에만 적용됨.
+  // 명시적 동기화를 위해 wall.id 가 바뀌면 입력 reset (간단히 effect 사용).
+  // 의존성 추가 효과는 PropertiesPanel 의 selected 단위 unmount/remount 으로도 됨.
+  // 여기선 effect 없이 두고, EditorPage 에서 selected 변경 시 PropertiesPanel 이
+  // 재마운트되는 흐름에 의존.
+
+  const commit = () => {
+    if (!onUpdate) return;
+    const trimmed = input.trim();
+    if (trimmed === '') {
+      onUpdate(null);
+      return;
+    }
+    const v = Number(trimmed);
+    if (!Number.isFinite(v) || v <= 0) return;
+    onUpdate(v);
+  };
+
+  return (
+    <div className="space-y-2.5">
+      {dim ? (
+        <div className="rounded-md border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+          <div className="flex items-center justify-between gap-2">
+            <span>OCR 인식</span>
+            <span className="font-mono text-foreground">{dim.text ?? '-'}</span>
+          </div>
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <span>자동 추정</span>
+            <span className="font-mono text-foreground">
+              {dim.parsed_meters != null ? `${dim.parsed_meters.toFixed(2)} m` : '-'}
+            </span>
+          </div>
+        </div>
+      ) : (
+        <p className="rounded-md border border-dashed bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground">
+          이 벽에 자동 매칭된 도면 치수가 없습니다. 아래에 직접 입력해 보정할 수 있어요.
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-muted-foreground">실측값</label>
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          disabled={disabled || !onUpdate}
+          placeholder={dim?.parsed_meters != null ? String(dim.parsed_meters) : '예: 3.5'}
+          className="w-24 rounded-md border bg-background px-2 py-1.5 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-70"
+        />
+        <span className="text-xs text-muted-foreground">m</span>
+        {dim?.user_meters != null && (
+          <button
+            type="button"
+            onClick={() => {
+              setInput('');
+              onUpdate?.(null);
+            }}
+            disabled={disabled}
+            className="ml-auto text-[11px] text-muted-foreground underline hover:text-foreground disabled:opacity-50"
+          >
+            초기화
+          </button>
+        )}
+      </div>
+
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        실측값을 입력하면 이 벽의 길이 기준으로 scale 보정에 활용됩니다.
+      </p>
+    </div>
   );
 }
 

--- a/frontend/src/features/editor/UploadCard.tsx
+++ b/frontend/src/features/editor/UploadCard.tsx
@@ -14,13 +14,12 @@ function isAllowed(file: File) {
 interface UploadCardProps {
   isPending?: boolean;
   errorMessage?: string;
-  onSubmit: (file: File, realWidthM: number) => void;
+  onSubmit: (file: File) => void;
 }
 
 export function UploadCard({ isPending, errorMessage, onSubmit }: UploadCardProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
-  const [realWidth, setRealWidth] = useState<number>(10);
   const [dragOver, setDragOver] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -49,7 +48,7 @@ export function UploadCard({ isPending, errorMessage, onSubmit }: UploadCardProp
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!file) return;
-    onSubmit(file, realWidth);
+    onSubmit(file);
   };
 
   const error = localError ?? errorMessage ?? null;
@@ -112,20 +111,10 @@ export function UploadCard({ isPending, errorMessage, onSubmit }: UploadCardProp
           />
         </div>
 
-        <div className="flex items-center gap-3">
-          <label className="text-xs text-muted-foreground">실제 너비(m)</label>
-          <input
-            type="number"
-            step="0.1"
-            min="0.1"
-            value={realWidth}
-            onChange={(e) => setRealWidth(Number(e.target.value) || 0)}
-            className="w-24 rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-          <p className="text-[11px] text-muted-foreground">
-            도면이 표현하는 실제 가로 길이 (스케일 환산용)
-          </p>
-        </div>
+        <p className="text-[11px] text-muted-foreground">
+          AI 가 도면 치수를 자동으로 읽어 scale 을 추정합니다. 분석 후 벽별 실측값으로
+          보정할 수 있습니다.
+        </p>
 
         {error && (
           <p className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">

--- a/frontend/src/features/header/InferenceModeToggle.tsx
+++ b/frontend/src/features/header/InferenceModeToggle.tsx
@@ -1,0 +1,54 @@
+import { Cloud, Cpu } from 'lucide-react';
+import { useInferenceMode } from '@/hooks/use-inference-mode';
+import { cn } from '@/lib/utils';
+
+/**
+ * 우상단 추론 백엔드 토글 (SageMaker ↔ Local).
+ * - ON  (default) : SageMaker async (S3 + 폴링)
+ * - OFF           : 로컬 AI 서버 (`AI_SERVICE_URL`) 동기 호출
+ *
+ * 상태는 localStorage 영속. 분석 API 호출 시점에 `getInferenceModeOnce()` 로 읽어 form/body 전달.
+ */
+export function InferenceModeToggle() {
+  const { isSagemaker, setMode } = useInferenceMode();
+  const label = isSagemaker ? 'SageMaker' : 'Local';
+  const Icon = isSagemaker ? Cloud : Cpu;
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isSagemaker}
+      title={
+        isSagemaker
+          ? 'SageMaker (async) 사용 중. 끄면 로컬 AI 서버로 우회합니다.'
+          : 'Local AI 서버 사용 중. 켜면 SageMaker async 로 전환합니다.'
+      }
+      onClick={() => setMode(isSagemaker ? 'local' : 'sagemaker')}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium shadow-sm transition-colors',
+        isSagemaker
+          ? 'border-primary/40 bg-primary/5 text-primary hover:bg-primary/10'
+          : 'border-amber-400/50 bg-amber-50 text-amber-700 hover:bg-amber-100',
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      <span>SageMaker</span>
+      {/* Track */}
+      <span
+        className={cn(
+          'relative ml-1 inline-flex h-3.5 w-7 items-center rounded-full transition-colors',
+          isSagemaker ? 'bg-primary' : 'bg-muted',
+        )}
+      >
+        <span
+          className={cn(
+            'inline-block h-2.5 w-2.5 transform rounded-full bg-white shadow transition-transform',
+            isSagemaker ? 'translate-x-3.5' : 'translate-x-0.5',
+          )}
+        />
+      </span>
+      <span className="ml-1 tabular-nums text-[10px] opacity-70">{label}</span>
+    </button>
+  );
+}

--- a/frontend/src/hooks/use-inference-mode.ts
+++ b/frontend/src/hooks/use-inference-mode.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+export type InferenceMode = 'sagemaker' | 'local';
+
+const STORAGE_KEY = 'wf:inference_mode';
+
+/**
+ * 추론 백엔드 선택 (SageMaker on/off 토글).
+ * - localStorage 에 영속, 탭 간 동기화 (storage event)
+ * - default = 'sagemaker' (production 경로)
+ * - 'local' = AI_SERVICE_URL (백엔드의 `local_inference_service`) 동기 호출
+ */
+function readMode(): InferenceMode {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v === 'local' ? 'local' : 'sagemaker';
+  } catch {
+    return 'sagemaker';
+  }
+}
+
+export function useInferenceMode(): {
+  mode: InferenceMode;
+  setMode: (m: InferenceMode) => void;
+  isSagemaker: boolean;
+} {
+  const [mode, setModeState] = useState<InferenceMode>(readMode);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setModeState(readMode());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const setMode = (m: InferenceMode) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, m);
+    } catch {
+      /* localStorage 사용 불가능한 환경 — 메모리에만 유지 */
+    }
+    setModeState(m);
+  };
+
+  return { mode, setMode, isSagemaker: mode === 'sagemaker' };
+}
+
+/**
+ * 모듈 스코프에서 현재 모드 읽기 — analyze API call site 처럼 hook 사용이 곤란할 때.
+ * (탭 간 동기화/리액티브 갱신은 안 됨. 호출 시점에 최신값 1회 조회.)
+ */
+export function getInferenceModeOnce(): InferenceMode {
+  return readMode();
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { ProjectSelector } from '@/features/header/ProjectSelector';
 import { FloorSelector } from '@/features/header/FloorSelector';
 import { ProfileMenu } from '@/features/header/ProfileMenu';
+import { InferenceModeToggle } from '@/features/header/InferenceModeToggle';
 import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
 
 const NAV = [
@@ -81,6 +82,7 @@ export function AppLayout() {
             <FloorSelector />
           </div>
           <div className="flex items-center gap-2">
+            <InferenceModeToggle />
             {!isMobileAppPage && (
               <button
                 type="button"

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -88,7 +88,7 @@ export default function DashboardPage() {
     : null;
   // Asset.storage_url 이 s3:// URI 라서 직접 못 쓰고, /download-url 로 presigned 받음.
   const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan');
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
   const fallbackAsset = (floorAssetsQuery.data ?? [])
     .slice()
     .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -166,7 +166,7 @@ export default function EditorPage() {
   // 2순위: 층의 floorplan 자산 중 가장 최근 것 (fallback).
   // Asset.storage_url 이 s3:// URI 라서 직접 못 쓰고, /download-url 로 presigned 받음.
   const sourceAssetId = baseScene?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan');
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
   const fallbackAsset = useMemo(() => {
     const list = floorAssetsQuery.data ?? [];
     if (list.length === 0) return null;
@@ -547,6 +547,19 @@ export default function EditorPage() {
     runPatch('wall', selectedRef.id, { material_label: material });
   };
 
+  // 벽 실측 길이 (m) 갱신 — metadata_json.dimension_match.user_meters 에 저장.
+  // null 이면 사용자 override 해제 (OCR 추정값으로 fallback).
+  const handleUpdateWallDimension = (meters: number | null) => {
+    if (!selectedRef || selectedRef.kind !== 'wall') return;
+    const wall = activeDraft?.walls.find((w) => w.id === selectedRef.id);
+    if (!wall) return;
+    const meta = (wall.metadata_json ?? {}) as Record<string, unknown>;
+    const dim = (meta.dimension_match ?? {}) as Record<string, unknown>;
+    const nextDim = { ...dim, user_meters: meters };
+    const nextMeta = { ...meta, dimension_match: nextDim };
+    runPatch('wall', selectedRef.id, { metadata_json: nextMeta });
+  };
+
   // 객체 종류 변경
   const handleUpdateObjectType = (objectType: string) => {
     if (!selectedRef || selectedRef.kind !== 'object') return;
@@ -640,15 +653,15 @@ export default function EditorPage() {
     }
   }, [jobPoll.isSucceeded, jobPoll.isFailed]);
 
-  const handleFile = (file: File, realWidthM: number) => {
+  const handleFile = (file: File) => {
     setPendingFileName(file.name);
     if (!floorId) return;
     // 캔버스 배경용 로컬 캐시 — 백엔드가 source_asset_id 안 채워도 시각화 가능.
     saveLocalFloorplanImage(floorId, file);
+    // scale_ratio 는 백엔드의 OCR 치수 자동 추정으로 결정됨. 사용자 입력 m 없음.
     analyze.mutate(
       {
         file,
-        real_width_m: realWidthM,
         project_id: projectId ?? undefined,
         floor_id: floorId,
       },
@@ -694,7 +707,7 @@ export default function EditorPage() {
   // 글로벌(헤더/PromotedCard) 업로드용 hidden input — CanvasArea 안 떠있을 때도 동작.
   const globalFileInputRef = useRef<HTMLInputElement>(null);
   const openFilePicker = () => {
-    // CanvasArea 떠있으면 그쪽 입력으로 (real_width_m 같이 입력), 아니면 글로벌(기본 10m).
+    // CanvasArea 떠있으면 그쪽 입력으로, 아니면 글로벌.
     if (fileInputRef.current) {
       fileInputRef.current.click();
     } else {
@@ -705,10 +718,10 @@ export default function EditorPage() {
     const f = e.target.files?.[0];
     e.target.value = '';
     if (!f) return;
-    handleFile(f, 10);
+    handleFile(f);
     toast.info(
       '도면 분석 시작',
-      '실제 가로 길이는 10m 로 가정합니다. 더 정확한 값이 필요하면 분석 후 새로 업로드하세요.',
+      'AI 가 도면 치수를 읽어 자동으로 scale 을 추정합니다. 분석 후 벽별 실측값으로 보정할 수 있습니다.',
     );
   };
   // handleFile 안에서 saveLocalFloorplanImage 이미 호출됨.
@@ -876,6 +889,7 @@ export default function EditorPage() {
         onDelete={handleDeleteSelected}
         onRotate={handleRotateSelected}
         onUpdateMaterial={handleUpdateMaterial}
+        onUpdateWallDimension={handleUpdateWallDimension}
         onUpdateObjectPosition={handleUpdateObjectPosition}
         onUpdateObjectSize={handleResizeObject}
         isSaving={patchEntity.isPending || patchVersionEntity.isPending}

--- a/frontend/src/types/asset.ts
+++ b/frontend/src/types/asset.ts
@@ -1,6 +1,6 @@
 import type { ISODateString, UUID } from './common';
 
-export type AssetType = 'floorplan' | 'photo' | 'document' | string;
+export type AssetType = 'floorplan_image' | 'photo' | 'document' | string;
 
 // §5.1 응답 (POST /floors/{floor_id}/assets) 및 §5.3 GET /assets/{id}
 export interface Asset {


### PR DESCRIPTION
## 개요

OCR/Line Detection 기반 Wall Segmentation 후보정 파이프라인을 연동하고, 기존 SageMaker 추론 외에 로컬 AI 서버 기반 추론 모드를 선택할 수 있도록 개선

기존에는 U-Net probability map에 고정 threshold를 적용하면서 도면 해상도, 선 굵기, 스캔 품질, 텍스트/치수선 등에 따라 벽이 끊기거나 텍스트가 벽으로 오탐되는 문제가 있었다

이번 PR에서는 OCR bbox, line detection, threshold candidate scoring을 활용해 도면별로 더 적합한 threshold를 선택하고, 후보정 metadata를 SceneDraft 결과에 함께 남기도록 develop

## 주요 변경사항

### 1. SageMaker / Local 추론 모드 선택 추가

- 프론트엔드 우상단에 `SageMaker / Local` 추론 모드 토글을 추가했
- 선택한 추론 모드는 `localStorage`에 저장되어 새로고침 후에도 유지
- 업로드 및 asset 분석 요청 시 `inference_mode`를 함께 전달
- 기본값은 `sagemaker`이며, 로컬 테스트 시 `local` 모드로 전환 가능

### 2. 로컬 AI 서버 추론 플로우 추가
- `AI_SERVICE_URL` 기반 로컬 AI 서버 호출 흐름을 추가했습니다.
- 로컬 모드에서는 다음 API를 호출
  - `POST /inference/unet`
  - `POST /inference/yolo`
- 로컬 AI 서버 응답을 기존 SageMaker 결과와 동일한 `InferenceResult` 형태로 맞춰, 이후 fusion 및 SceneDraft 저장 플로우를 재사용하도록 구성.
- 로컬 모드에서도 Job 생성 → 백그라운드 실행 → polling 구조를 유지

### 3. 로컬 asset 저장 및 raw streaming 지원
- 로컬 추론 모드에서는 S3 업로드 대신 로컬 파일 경로를 `file://` 형태의 `storage_url`로 등록
- `/assets/{asset_id}/download-url`에서 storage type에 따라 다른 URL을 반환하도록 수정
  - S3 asset: presigned URL 반환
  - local asset: `/assets/{asset_id}/raw` 반환
- `/assets/{asset_id}/raw` endpoint를 추가하여 로컬 파일을 직접 streaming할 수 있도록 수정

### 4. OCR/Line 기반 Wall Segmentation 후보정
- U-Net probability map을 원본 이미지 좌표계에 맞게 resize합니다.
- 여러 threshold candidate를 평가하여 도면별로 적합한 threshold를 선택.
- threshold scoring에 다음 정보를 활용.
  - OCR text bbox penalty
  - line detection alignment score
  - dimension text matching
  - wall skeleton confidence
- Otsu fallback 및 explicit threshold fallback을 유지하여 후보정 실패 시에도 기존 방식으로 동작할 수 있도록 유지
- morphology 처리 방식을 조정하여 인접한 벽이 과도하게 합쳐지는 문제를 완화
- 후처리 결과를 `postprocess_metadata`로 반환하도록 확장

### 5. 창/문 중복 감지 방지
- 기존에는 door/window 타입별로 NMS를 따로 적용하고 있어, 같은 위치에 창과 문이 동시에 남는 문제가 있었다.
- opening 후보 전체에 대해 cross-type NMS를 적용하도록 변경.
- 동일 위치에 door/window가 중복 감지된 경우 score가 높은 detection만 유지

### 6. Wall 후보정 실험 endpoint 추가
- `/experiments/wall/postprocess/{file_id}` endpoint를 추가
- `.npy` probability map과 optional threshold를 받아 wall 후보정 결과를 확인
- threshold 선택 결과, OCR/line metadata, debug output 등을 함께 확인할 수 있어 후보정 튜닝에 활용할 수 있습니다.

### 7. Floor spatial metadata migration 추가
- `floors.spatial_meta` JSONB 컬럼을 추가.
- 측정 좌표계, scale, floor-level spatial 설정을 asset metadata와 분리해 floor 단위로 관리할 수 있도록 준비
- 향후 asset 교체와 무관하게 측정/보정용 공간 metadata를 유지하기 위한 기반


### Frontend
- inference mode hook 추가
- SageMaker / Local toggle UI 추가
- scene draft API 요청에 `inference_mode` 전달
- editor/upload 흐름에서 선택된 추론 모드 반영

## 테스트
- [ ] SageMaker 모드에서 기존 업로드 → 분석 → polling → SceneDraft 생성 플로우가 정상 동작하는지 확인
- [x] Local 모드에서 `AI_SERVICE_URL` 기반 U-Net/YOLO 호출이 정상 동작하는지 확인
- [x] Local 모드에서 생성된 `file://` asset이 `/assets/{id}/raw`로 정상 조회되는지 확인
- [ ] `/assets/{id}/download-url`이 S3/local asset 각각에 대해 올바른 URL을 반환하는지 확인
- [ ] `/experiments/wall/postprocess/{file_id}`로 wall 후보정 결과와 metadata가 반환되는지 확인
- [x] 동일 위치에 창/문이 중복 표시되지 않는지 확인

## 주의사항
asset 이미지가 안보임