### PR TITLE
[feat/fix] 실측 페이지 기능 고도화 및 캔버스 뷰박스 최적화

### DIFF
--- a/frontend/src/api/measurement-session.ts
+++ b/frontend/src/api/measurement-session.ts
@@ -2,6 +2,7 @@ import { api } from './client';
 import type { Paginated, UUID } from '@/types/common';
 import type {
   DetectedAp,
+  EstimatedCoverage,
   MeasurementPoint,
   MeasurementSession,
 } from '@/types/measurement-session';
@@ -39,5 +40,15 @@ export const measurementSessionApi = {
   listDetectedAps: (sessionId: UUID) =>
     api
       .get<DetectedAp[]>(`/measurement-sessions/${sessionId}/detected-aps`)
+      .then((r) => r.data),
+
+  // GET /measurement-sessions/{session_id}/estimated-coverage — GP regression dense RSSI 맵 (#81).
+  // 응답에 presigned heatmap_url / uncertainty_url 포함. resolution_m 으로 해상도 조절(0.1~2.0).
+  getEstimatedCoverage: (sessionId: UUID, params?: { resolution_m?: number }) =>
+    api
+      .get<EstimatedCoverage>(
+        `/measurement-sessions/${sessionId}/estimated-coverage`,
+        { params },
+      )
       .then((r) => r.data),
 };

--- a/frontend/src/api/measurement-session.ts
+++ b/frontend/src/api/measurement-session.ts
@@ -1,0 +1,43 @@
+import { api } from './client';
+import type { Paginated, UUID } from '@/types/common';
+import type {
+  DetectedAp,
+  MeasurementPoint,
+  MeasurementSession,
+} from '@/types/measurement-session';
+
+// §10.4 / §10.5 — 백엔드 PR #77 (commit fc7977d) 로 구현 완료.
+
+export interface ListSessionsParams {
+  status?: 'in_progress' | 'completed' | string;
+  page?: number;
+  page_size?: number;
+}
+
+export const measurementSessionApi = {
+  // GET /floors/{floor_id}/measurement-sessions — 층의 세션 목록 (페이지네이션 + status 필터).
+  listByFloor: (floorId: UUID, params?: ListSessionsParams) =>
+    api
+      .get<Paginated<MeasurementSession>>(`/floors/${floorId}/measurement-sessions`, {
+        params,
+      })
+      .then((r) => r.data),
+
+  // GET /measurement-sessions/{session_id}
+  get: (sessionId: UUID) =>
+    api.get<MeasurementSession>(`/measurement-sessions/${sessionId}`).then((r) => r.data),
+
+  // GET /measurement-sessions/{session_id}/points (페이지네이션, default page_size=100, max 500)
+  listPoints: (sessionId: UUID, params?: { page?: number; page_size?: number }) =>
+    api
+      .get<Paginated<MeasurementPoint>>(`/measurement-sessions/${sessionId}/points`, {
+        params,
+      })
+      .then((r) => r.data),
+
+  // GET /measurement-sessions/{session_id}/detected-aps — list 직접 반환 (envelope 없음).
+  listDetectedAps: (sessionId: UUID) =>
+    api
+      .get<DetectedAp[]>(`/measurement-sessions/${sessionId}/detected-aps`)
+      .then((r) => r.data),
+};

--- a/frontend/src/api/rf-run.ts
+++ b/frontend/src/api/rf-run.ts
@@ -1,6 +1,12 @@
 import { api } from './client';
-import type { UUID } from '@/types/common';
-import type { RfJob, RfMap, RfRun, RfRunCreate, RfRunCreated } from '@/types/rf';
+import type { Paginated, UUID } from '@/types/common';
+import type { RfJob, RfMap, RfRun, RfRunCreate, RfRunCreated, RfRunStatus } from '@/types/rf';
+
+export interface ListRfRunsParams {
+  status?: RfRunStatus;
+  page?: number;
+  page_size?: number;
+}
 
 export const rfRunApi = {
   // §13.1 POST /rf-runs — 비동기 시뮬레이션 큐 등록 (HTTP 202)
@@ -13,6 +19,12 @@ export const rfRunApi = {
   // §13.3 GET /rf-runs/{rf_run_id}/maps — 완료 후 RF 맵 목록 (storage_url 은 s3:// URI)
   listMaps: (id: UUID) =>
     api.get<RfMap[]>(`/rf-runs/${id}/maps`).then((r) => r.data),
+
+  // GET /floors/{floor_id}/rf-runs — 층의 RF Run 목록 (created_at desc, 페이지네이션 + status 필터)
+  listByFloor: (floorId: UUID, params?: ListRfRunsParams) =>
+    api
+      .get<Paginated<RfRun>>(`/floors/${floorId}/rf-runs`, { params })
+      .then((r) => r.data),
 };
 
 export const rfJobApi = {

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -99,16 +99,18 @@ function computeViewBox(
   return { x: b.minX - padding, y: b.minY - padding, w: w + 2 * padding, h: h + 2 * padding };
 }
 
-// draft.id 별 최초 viewBox 를 localStorage 에 캐싱 (이미지 extent 없을 때의 fallback).
-// 새로고침 후에도 같은 draft 면 같은 viewBox 가 복원되어, 그룹 리사이즈로 도형이
-// 줄어들었을 때 캔버스가 작아진 도형에 자동 맞춤되는 현상(라벨·핸들이 커보임)을 막는다.
+// 최초 viewBox 를 localStorage 에 캐싱 (이미지 extent 없을 때의 fallback).
+// 키는 floor_id — promote(확정) 직후 draft → version-as-draft 로 전환되면서
+// DraftSceneCanvas 가 잠깐 unmount → remount 될 때, 새 draft.id 기준으로는 cache miss 가 나
+// "도형 bounds 에 fit" 된 좁은 viewBox 로 다시 계산되는 문제를 막는다.
+// 같은 층 안에선 어떤 draft/version 이든 동일한 캔버스 영역을 공유해야 자연스럽다.
 // 이미지 extent (real_width_m + natural dims) 가 있는 경우엔 union viewBox 가 자연스럽게
 // 안정적이므로 캐시 불필요.
-const VIEWBOX_CACHE_PREFIX = 'draft-viewbox:v1:';
+const VIEWBOX_CACHE_PREFIX = 'draft-viewbox:v2:';
 
-function loadCachedViewBox(draftId: string): ViewBox | null {
+function loadCachedViewBox(key: string): ViewBox | null {
   try {
-    const raw = localStorage.getItem(VIEWBOX_CACHE_PREFIX + draftId);
+    const raw = localStorage.getItem(VIEWBOX_CACHE_PREFIX + key);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<ViewBox>;
     if (
@@ -127,19 +129,29 @@ function loadCachedViewBox(draftId: string): ViewBox | null {
   return null;
 }
 
-function saveCachedViewBox(draftId: string, vb: ViewBox) {
+function saveCachedViewBox(key: string, vb: ViewBox) {
   try {
-    localStorage.setItem(VIEWBOX_CACHE_PREFIX + draftId, JSON.stringify(vb));
+    localStorage.setItem(VIEWBOX_CACHE_PREFIX + key, JSON.stringify(vb));
   } catch {
     // quota exceeded / private mode: 무시. 캐시 없이도 동작.
   }
 }
 
+function viewBoxCacheKey(draft: SceneDraft): string {
+  return draft.floor_id ?? draft.id;
+}
+
+/**
+ * 최초 viewBox 결정. floor 별로 첫 mount 때 한 번만 계산하고 캐시 → 이후 remount
+ * (promote 전후, 새로고침, draft↔version 전환 등) 시엔 같은 값을 복원.
+ * → 도형을 작게 그리거나 확정해도 캔버스 영역이 안 바뀌어 객체가 갑자기 커지는 현상 방지.
+ */
 function resolveInitialViewBox(draft: SceneDraft): ViewBox {
-  const cached = loadCachedViewBox(draft.id);
+  const key = viewBoxCacheKey(draft);
+  const cached = loadCachedViewBox(key);
   if (cached) return cached;
   const computed = computeViewBox(draft);
-  saveCachedViewBox(draft.id, computed);
+  saveCachedViewBox(key, computed);
   return computed;
 }
 

--- a/frontend/src/features/editor/PromotedCard.tsx
+++ b/frontend/src/features/editor/PromotedCard.tsx
@@ -9,9 +9,18 @@ interface PromotedCardProps {
   version: SceneVersion;
   versions?: SceneVersion[];
   onReupload: () => void;
+  /** "빈 도면으로 시작" — 새 SceneDraft 를 빈 상태로 생성. 미제공 시 버튼 숨김. */
+  onStartBlank?: () => void;
+  isStartingBlank?: boolean;
 }
 
-export function PromotedCard({ version, versions, onReupload }: PromotedCardProps) {
+export function PromotedCard({
+  version,
+  versions,
+  onReupload,
+  onStartBlank,
+  isStartingBlank,
+}: PromotedCardProps) {
   const [minimized, setMinimized] = useState(false);
 
   // versions 리스트에 is_current 가 잡혀있으면 그쪽을 진실의 원천으로 사용.
@@ -90,6 +99,16 @@ export function PromotedCard({ version, versions, onReupload }: PromotedCardProp
         >
           새 버전 업로드
         </button>
+        {onStartBlank && (
+          <button
+            type="button"
+            onClick={onStartBlank}
+            disabled={isStartingBlank}
+            className="rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+          >
+            {isStartingBlank ? '생성 중…' : '빈 도면으로 시작'}
+          </button>
+        )}
         <Link
           to="/simulation"
           className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"

--- a/frontend/src/features/header/FloorSelector.tsx
+++ b/frontend/src/features/header/FloorSelector.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Check, ChevronDown, Plus, Trash2 } from 'lucide-react';
+import { Check, ChevronDown, Pencil, Plus, Trash2 } from 'lucide-react';
 import { Popover } from '@/components/ui/Popover';
-import { useCreateFloor, useDeleteFloor, useFloors } from '@/hooks/use-floors';
+import {
+  useCreateFloor,
+  useDeleteFloor,
+  useFloors,
+  useUpdateFloor,
+} from '@/hooks/use-floors';
 import { useAppStore } from '@/stores/app-store';
 import { cn } from '@/lib/utils';
 import type { Floor } from '@/types/floor';
@@ -90,7 +95,10 @@ function FloorMenu({
   const [creating, setCreating] = useState(false);
   // 인라인 삭제 확인 상태. 두 번째 클릭에 진짜 삭제 — 모달 없이 가볍게.
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  // 인라인 편집 상태. ✏️ 클릭 시 폼 노출.
+  const [editingId, setEditingId] = useState<string | null>(null);
   const deleteFloor = useDeleteFloor(projectId);
+  const updateFloor = useUpdateFloor(projectId);
   const sorted = [...floors].sort((a, b) => a.floor_order - b.floor_order);
 
   const handleDeleteClick = (e: React.MouseEvent, floorId: string) => {
@@ -115,6 +123,23 @@ function FloorMenu({
           <li className="px-3 py-3 text-xs text-muted-foreground">층이 없습니다.</li>
         )}
         {sorted.map((f) => {
+          if (editingId === f.id) {
+            return (
+              <li key={f.id} className="px-3 py-2">
+                <EditFloorForm
+                  floor={f}
+                  isSaving={updateFloor.isPending}
+                  onSave={(body) =>
+                    updateFloor.mutate(
+                      { id: f.id, body },
+                      { onSuccess: () => setEditingId(null) },
+                    )
+                  }
+                  onCancel={() => setEditingId(null)}
+                />
+              </li>
+            );
+          }
           const confirming = confirmingDeleteId === f.id;
           const deleting = deleteFloor.isPending && confirmingDeleteId === f.id;
           return (
@@ -133,6 +158,19 @@ function FloorMenu({
                   </span>
                 </div>
                 {f.id === selectedFloorId && <Check className="h-3.5 w-3.5 text-primary" />}
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmingDeleteId(null);
+                  setEditingId(f.id);
+                }}
+                aria-label="층 정보 수정"
+                title="이름·높이 수정"
+                className="inline-flex h-7 w-7 items-center justify-center text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground group-hover:opacity-100"
+              >
+                <Pencil className="h-3.5 w-3.5" />
               </button>
               <button
                 type="button"
@@ -179,6 +217,78 @@ function FloorMenu({
         )}
       </div>
     </div>
+  );
+}
+
+function EditFloorForm({
+  floor,
+  isSaving,
+  onSave,
+  onCancel,
+}: {
+  floor: Floor;
+  isSaving: boolean;
+  onSave: (body: { floor_name?: string; height_m?: number }) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(floor.floor_name);
+  const [height, setHeight] = useState(floor.height_m);
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const body: { floor_name?: string; height_m?: number } = {};
+    if (trimmed !== floor.floor_name) body.floor_name = trimmed;
+    if (Number.isFinite(height) && height > 0 && height !== floor.height_m) {
+      body.height_m = height;
+    }
+    if (Object.keys(body).length === 0) {
+      onCancel();
+      return;
+    }
+    onSave(body);
+  };
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <label className="block">
+        <span className="text-[10px] text-muted-foreground">층 이름</span>
+        <input
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') onCancel();
+          }}
+          className="w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </label>
+      <label className="block">
+        <span className="text-[10px] text-muted-foreground">높이 (m)</span>
+        <input
+          type="number"
+          step="0.1"
+          value={height}
+          onChange={(e) => setHeight(Number(e.target.value))}
+          className="w-full rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </label>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isSaving || !name.trim()}
+          className="flex-1 rounded-md bg-primary px-2 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSaving ? '저장 중…' : '저장'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border px-2 py-1.5 text-xs hover:bg-accent"
+        >
+          취소
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/frontend/src/features/header/FloorSelector.tsx
+++ b/frontend/src/features/header/FloorSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Check, ChevronDown, Plus } from 'lucide-react';
+import { Check, ChevronDown, Plus, Trash2 } from 'lucide-react';
 import { Popover } from '@/components/ui/Popover';
-import { useCreateFloor, useFloors } from '@/hooks/use-floors';
+import { useCreateFloor, useDeleteFloor, useFloors } from '@/hooks/use-floors';
 import { useAppStore } from '@/stores/app-store';
 import { cn } from '@/lib/utils';
 import type { Floor } from '@/types/floor';
@@ -59,6 +59,13 @@ export function FloorSelector() {
             setFloor(f.id);
             close();
           }}
+          onDeleted={(deletedId) => {
+            // 현재 선택된 층이 삭제됐으면, 남은 첫 층으로 자동 전환 (없으면 null).
+            if (deletedId === selectedFloorId) {
+              const remaining = floors.filter((f) => f.id !== deletedId);
+              setFloor(remaining[0]?.id ?? null);
+            }
+          }}
         />
       )}
     </Popover>
@@ -71,40 +78,84 @@ function FloorMenu({
   projectId,
   onSelect,
   onCreated,
+  onDeleted,
 }: {
   floors: Floor[];
   selectedFloorId: string | null;
   projectId: string;
   onSelect: (id: string) => void;
   onCreated: (f: Floor) => void;
+  onDeleted: (deletedId: string) => void;
 }) {
   const [creating, setCreating] = useState(false);
+  // 인라인 삭제 확인 상태. 두 번째 클릭에 진짜 삭제 — 모달 없이 가볍게.
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const deleteFloor = useDeleteFloor(projectId);
   const sorted = [...floors].sort((a, b) => a.floor_order - b.floor_order);
+
+  const handleDeleteClick = (e: React.MouseEvent, floorId: string) => {
+    e.stopPropagation();
+    if (confirmingDeleteId !== floorId) {
+      setConfirmingDeleteId(floorId);
+      return;
+    }
+    deleteFloor.mutate(floorId, {
+      onSuccess: () => {
+        setConfirmingDeleteId(null);
+        onDeleted(floorId);
+      },
+      onError: () => setConfirmingDeleteId(null),
+    });
+  };
+
   return (
     <div>
       <ul className="max-h-72 overflow-y-auto py-1">
         {sorted.length === 0 && !creating && (
           <li className="px-3 py-3 text-xs text-muted-foreground">층이 없습니다.</li>
         )}
-        {sorted.map((f) => (
-          <li key={f.id}>
-            <button
-              onClick={() => onSelect(f.id)}
-              className={cn(
-                'flex w-full items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent',
-                f.id === selectedFloorId && 'bg-accent/60 font-medium',
-              )}
-            >
-              <div className="flex flex-col items-start">
-                <span className="truncate">{f.floor_name}</span>
-                <span className="text-[10px] text-muted-foreground">
-                  높이 {f.height_m}m
-                </span>
-              </div>
-              {f.id === selectedFloorId && <Check className="h-3.5 w-3.5 text-primary" />}
-            </button>
-          </li>
-        ))}
+        {sorted.map((f) => {
+          const confirming = confirmingDeleteId === f.id;
+          const deleting = deleteFloor.isPending && confirmingDeleteId === f.id;
+          return (
+            <li key={f.id} className="group flex items-center">
+              <button
+                onClick={() => onSelect(f.id)}
+                className={cn(
+                  'flex flex-1 items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent',
+                  f.id === selectedFloorId && 'bg-accent/60 font-medium',
+                )}
+              >
+                <div className="flex flex-col items-start">
+                  <span className="truncate">{f.floor_name}</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    높이 {f.height_m}m
+                  </span>
+                </div>
+                {f.id === selectedFloorId && <Check className="h-3.5 w-3.5 text-primary" />}
+              </button>
+              <button
+                type="button"
+                onClick={(e) => handleDeleteClick(e, f.id)}
+                disabled={deleting}
+                aria-label={confirming ? '삭제 확인' : '층 삭제'}
+                title={confirming ? '한 번 더 누르면 삭제됩니다' : '층 삭제'}
+                className={cn(
+                  'mr-1 inline-flex h-7 items-center justify-center rounded-md px-2 text-[10px] font-medium transition-colors disabled:opacity-50',
+                  confirming
+                    ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                    : 'text-muted-foreground opacity-0 hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100',
+                )}
+              >
+                {confirming ? (
+                  deleting ? '삭제 중…' : '확인'
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </li>
+          );
+        })}
       </ul>
       <div className="border-t p-2">
         {creating ? (

--- a/frontend/src/features/header/ProjectSelector.tsx
+++ b/frontend/src/features/header/ProjectSelector.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Check, ChevronDown, Plus } from 'lucide-react';
+import { Check, ChevronDown, Pencil, Plus, Trash2 } from 'lucide-react';
 import { Popover } from '@/components/ui/Popover';
-import { useCreateProject, useProjects } from '@/hooks/use-projects';
+import {
+  useCreateProject,
+  useDeleteProject,
+  useProjects,
+  useUpdateProject,
+} from '@/hooks/use-projects';
 import { useAppStore } from '@/stores/app-store';
 import { cn } from '@/lib/utils';
 import type { Project } from '@/types/project';
@@ -51,6 +56,12 @@ export function ProjectSelector() {
             setProject(p.id);
             close();
           }}
+          onDeleted={(deletedId) => {
+            if (deletedId === selectedId) {
+              const remaining = projects.filter((p) => p.id !== deletedId);
+              setProject(remaining[0]?.id ?? null);
+            }
+          }}
         />
       )}
     </Popover>
@@ -62,33 +73,104 @@ function ProjectMenu({
   selectedId,
   onSelect,
   onCreated,
+  onDeleted,
 }: {
   projects: Project[];
   selectedId: string | null;
   onSelect: (id: string) => void;
   onCreated: (p: Project) => void;
+  onDeleted: (deletedId: string) => void;
 }) {
   const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const updateProject = useUpdateProject();
+  const deleteProject = useDeleteProject();
+
+  const handleDeleteClick = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    if (confirmingDeleteId !== id) {
+      setConfirmingDeleteId(id);
+      return;
+    }
+    deleteProject.mutate(id, {
+      onSuccess: () => {
+        setConfirmingDeleteId(null);
+        onDeleted(id);
+      },
+      onError: () => setConfirmingDeleteId(null),
+    });
+  };
+
   return (
     <div>
       <ul className="max-h-72 overflow-y-auto py-1">
         {projects.length === 0 && !creating && (
           <li className="px-3 py-3 text-xs text-muted-foreground">프로젝트가 없습니다.</li>
         )}
-        {projects.map((p) => (
-          <li key={p.id}>
-            <button
-              onClick={() => onSelect(p.id)}
-              className={cn(
-                'flex w-full items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent',
-                p.id === selectedId && 'bg-accent/60 font-medium',
-              )}
-            >
-              <span className="truncate">{p.name}</span>
-              {p.id === selectedId && <Check className="h-3.5 w-3.5 text-primary" />}
-            </button>
-          </li>
-        ))}
+        {projects.map((p) => {
+          if (editingId === p.id) {
+            return (
+              <li key={p.id} className="px-3 py-2">
+                <RenameProjectForm
+                  project={p}
+                  isSaving={updateProject.isPending}
+                  onSave={(name) =>
+                    updateProject.mutate(
+                      { id: p.id, body: { name } },
+                      { onSuccess: () => setEditingId(null) },
+                    )
+                  }
+                  onCancel={() => setEditingId(null)}
+                />
+              </li>
+            );
+          }
+          const confirming = confirmingDeleteId === p.id;
+          const deleting = deleteProject.isPending && confirming;
+          return (
+            <li key={p.id} className="group flex items-center">
+              <button
+                onClick={() => onSelect(p.id)}
+                className={cn(
+                  'flex flex-1 items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent',
+                  p.id === selectedId && 'bg-accent/60 font-medium',
+                )}
+              >
+                <span className="truncate">{p.name}</span>
+                {p.id === selectedId && <Check className="h-3.5 w-3.5 text-primary" />}
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmingDeleteId(null);
+                  setEditingId(p.id);
+                }}
+                aria-label="이름 변경"
+                title="이름 변경"
+                className="inline-flex h-7 w-7 items-center justify-center text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground group-hover:opacity-100"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => handleDeleteClick(e, p.id)}
+                disabled={deleting}
+                aria-label={confirming ? '삭제 확인' : '프로젝트 삭제'}
+                title={confirming ? '한 번 더 누르면 삭제됩니다' : '프로젝트 삭제'}
+                className={cn(
+                  'mr-1 inline-flex h-7 items-center justify-center rounded-md px-2 text-[10px] font-medium transition-colors disabled:opacity-50',
+                  confirming
+                    ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                    : 'text-muted-foreground opacity-0 hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100',
+                )}
+              >
+                {confirming ? (deleting ? '삭제 중…' : '확인') : <Trash2 className="h-3.5 w-3.5" />}
+              </button>
+            </li>
+          );
+        })}
       </ul>
       <div className="border-t p-2">
         {creating ? (
@@ -110,6 +192,58 @@ function ProjectMenu({
         )}
       </div>
     </div>
+  );
+}
+
+function RenameProjectForm({
+  project,
+  isSaving,
+  onSave,
+  onCancel,
+}: {
+  project: Project;
+  isSaving: boolean;
+  onSave: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(project.name);
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === project.name) {
+      onCancel();
+      return;
+    }
+    onSave(trimmed);
+  };
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onCancel();
+        }}
+        className="w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isSaving || !name.trim()}
+          className="flex-1 rounded-md bg-primary px-2 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSaving ? '저장 중…' : '저장'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border px-2 py-1.5 text-xs hover:bg-accent"
+        >
+          취소
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -35,6 +35,14 @@ interface Props {
   mode: MeasurementViewMode;
   /** 강조 표시할 측정 포인트 (불량 지점). 외곽 링이 진하게 표시됨. */
   highlightedPointId?: string | null;
+  /**
+   * GP regression dense heatmap (백엔드 #81 / `/estimated-coverage`).
+   * 있으면 'heatmap' / 'both' 모드에서 측정점 radial gradient 대신 이 이미지를 깔아준다.
+   */
+  estimatedHeatmap?: {
+    url: string;
+    bounds: { min_x: number; min_y: number; max_x: number; max_y: number };
+  } | null;
 }
 
 interface Bounds {
@@ -96,6 +104,7 @@ export function MeasurementCanvas({
   aps,
   mode,
   highlightedPointId,
+  estimatedHeatmap,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const sceneId = sceneVersion?.id ?? null;
@@ -134,8 +143,29 @@ export function MeasurementCanvas({
           ))}
         </defs>
 
-        {/* 히트맵: 도형보다 아래에 깔아 도면이 위에 보이도록. */}
-        {showHeatmap &&
+        {/* 히트맵: 도형보다 아래에 깔아 도면이 위에 보이도록.
+            GP regression dense heatmap 이 있으면 그것을 우선 표시 (전체 도면 커버).
+            없으면 측정점 주변 radial gradient 로 fallback. */}
+        {showHeatmap && estimatedHeatmap ? (
+          <image
+            href={estimatedHeatmap.url}
+            xlinkHref={estimatedHeatmap.url}
+            x={estimatedHeatmap.bounds.min_x}
+            y={estimatedHeatmap.bounds.min_y}
+            width={estimatedHeatmap.bounds.max_x - estimatedHeatmap.bounds.min_x}
+            height={estimatedHeatmap.bounds.max_y - estimatedHeatmap.bounds.min_y}
+            preserveAspectRatio="none"
+            opacity={0.65}
+            pointerEvents="none"
+            onError={() => {
+              console.warn(
+                '[MeasurementCanvas] estimated coverage heatmap 로드 실패:',
+                estimatedHeatmap.url,
+              );
+            }}
+          />
+        ) : (
+          showHeatmap &&
           sortedPoints.map((p) => (
             <circle
               key={`heat-${p.id}`}
@@ -145,7 +175,8 @@ export function MeasurementCanvas({
               fill={`url(#heat-${p.quality})`}
               pointerEvents="none"
             />
-          ))}
+          ))
+        )}
 
         {(sceneVersion?.walls ?? []).map((w) => (
           <WallShape key={w.id} wall={w} />

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -1,0 +1,337 @@
+import { useMemo, useRef } from 'react';
+import { parseGeometry } from '@/features/editor/geometry-utils';
+import type {
+  DraftObject,
+  DraftOpening,
+  DraftWall,
+  SceneVersion,
+} from '@/types/scene';
+import { cn } from '@/lib/utils';
+
+export type MeasurementPointQuality = 'good' | 'warning' | 'poor';
+
+export interface MeasurementPoint {
+  id: string;
+  x_m: number;
+  y_m: number;
+  quality: MeasurementPointQuality;
+  /** 시퀀스 표시용 — 측정 경로 라인 연결 순서. */
+  order: number;
+}
+
+export interface PlacedApSimple {
+  id: string;
+  x_m: number;
+  y_m: number;
+  label?: string;
+}
+
+export type MeasurementViewMode = 'route' | 'heatmap' | 'both';
+
+interface Props {
+  sceneVersion: SceneVersion | null | undefined;
+  points: MeasurementPoint[];
+  aps: PlacedApSimple[];
+  mode: MeasurementViewMode;
+  /** 강조 표시할 측정 포인트 (불량 지점). 외곽 링이 진하게 표시됨. */
+  highlightedPointId?: string | null;
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function emptyBounds(): Bounds {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+}
+
+function extendBounds(b: Bounds, x: number, y: number) {
+  if (x < b.minX) b.minX = x;
+  if (y < b.minY) b.minY = y;
+  if (x > b.maxX) b.maxX = x;
+  if (y > b.maxY) b.maxY = y;
+}
+
+/** viewBox 는 도형(walls/openings) 기준. 객체는 건물 밖으로 나갈 수 있어 제외. */
+function computeViewBox(scene: SceneVersion | null | undefined) {
+  const b = emptyBounds();
+  for (const wall of scene?.walls ?? []) {
+    const g = parseGeometry(wall.centerline_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  for (const op of scene?.openings ?? []) {
+    const g = parseGeometry(op.line_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
+  const w = b.maxX - b.minX || 1;
+  const h = b.maxY - b.minY || 1;
+  const padding = Math.max(w, h) * 0.1;
+  return { x: b.minX - padding, y: b.minY - padding, w: w + 2 * padding, h: h + 2 * padding };
+}
+
+const QUALITY_FILL: Record<MeasurementPointQuality, string> = {
+  good: 'oklch(0.72 0.18 145)',
+  warning: 'oklch(0.78 0.15 85)',
+  poor: 'oklch(0.62 0.22 25)',
+};
+
+const QUALITY_HEATMAP_RGBA: Record<MeasurementPointQuality, string> = {
+  good: 'rgba(74, 222, 128, 0.55)',
+  warning: 'rgba(250, 204, 21, 0.45)',
+  poor: 'rgba(248, 113, 113, 0.6)',
+};
+
+/**
+ * 실측/진단 캔버스. 확정 버전 도형 위에 측정 경로(line + 색상 dot) 와/또는
+ * 실측 히트맵(radial gradient) 을 모드에 따라 토글 렌더링.
+ * 데이터(points, aps) 가 비어있어도 도면만 렌더되도록 동작.
+ */
+export function MeasurementCanvas({
+  sceneVersion,
+  points,
+  aps,
+  mode,
+  highlightedPointId,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const sceneId = sceneVersion?.id ?? null;
+  const vb = useMemo(() => computeViewBox(sceneVersion), [sceneId]);
+  const sortedPoints = useMemo(
+    () => [...points].sort((a, b) => a.order - b.order),
+    [points],
+  );
+
+  // 히트맵 점 반경 — viewBox 크기에 비례. 보통 ~1.5m 정도 영향권으로 보이도록.
+  const heatmapRadius = Math.max(0.8, Math.min(vb.w, vb.h) * 0.15);
+
+  const showRoute = mode === 'route' || mode === 'both';
+  const showHeatmap = mode === 'heatmap' || mode === 'both';
+
+  return (
+    <div
+      className={cn(
+        'relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl border bg-[#f8fafc] p-6',
+        '[background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)]',
+        '[background-position:0_0] [background-size:18px_18px]',
+      )}
+    >
+      <svg
+        ref={svgRef}
+        viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="h-full w-full select-none"
+      >
+        <defs>
+          {(['good', 'warning', 'poor'] as const).map((q) => (
+            <radialGradient key={q} id={`heat-${q}`}>
+              <stop offset="0%" stopColor={QUALITY_HEATMAP_RGBA[q]} />
+              <stop offset="100%" stopColor={QUALITY_HEATMAP_RGBA[q].replace(/[\d.]+\)$/, '0)')} />
+            </radialGradient>
+          ))}
+        </defs>
+
+        {/* 히트맵: 도형보다 아래에 깔아 도면이 위에 보이도록. */}
+        {showHeatmap &&
+          sortedPoints.map((p) => (
+            <circle
+              key={`heat-${p.id}`}
+              cx={p.x_m}
+              cy={p.y_m}
+              r={heatmapRadius}
+              fill={`url(#heat-${p.quality})`}
+              pointerEvents="none"
+            />
+          ))}
+
+        {(sceneVersion?.walls ?? []).map((w) => (
+          <WallShape key={w.id} wall={w} />
+        ))}
+        {(sceneVersion?.openings ?? []).map((o) => (
+          <OpeningShape key={o.id} opening={o} />
+        ))}
+        {(sceneVersion?.objects ?? []).map((o) => (
+          <ObjectShape key={o.id} object={o} />
+        ))}
+
+        {/* 측정 경로 라인 — 점들 순서대로 점선 연결. */}
+        {showRoute && sortedPoints.length >= 2 && (
+          <polyline
+            points={sortedPoints.map((p) => `${p.x_m},${p.y_m}`).join(' ')}
+            fill="none"
+            stroke="oklch(0.6 0.18 255)"
+            strokeWidth="2"
+            strokeDasharray="6 4"
+            vectorEffect="non-scaling-stroke"
+            pointerEvents="none"
+          />
+        )}
+
+        {/* 측정 포인트 점. */}
+        {showRoute &&
+          sortedPoints.map((p) => (
+            <g key={`pt-${p.id}`} pointerEvents="none">
+              <circle
+                cx={p.x_m}
+                cy={p.y_m}
+                r={Math.max(0.08, vb.w * 0.008)}
+                fill={QUALITY_FILL[p.quality]}
+                stroke={highlightedPointId === p.id ? 'oklch(0.45 0.22 25)' : 'white'}
+                strokeWidth={highlightedPointId === p.id ? 0.06 : 0.04}
+                vectorEffect="non-scaling-stroke"
+              />
+            </g>
+          ))}
+
+        {/* AP 마커 — 파란 원에 흰색 wifi 아이콘. */}
+        {aps.map((ap) => (
+          <ApMarker key={ap.id} ap={ap} />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+// ============================================
+// 도형 (read-only)
+// ============================================
+
+function WallShape({ wall }: { wall: DraftWall }) {
+  const g = parseGeometry(wall.centerline_geom);
+  if (g?.type !== 'LineString') return null;
+  const start = g.coordinates[0];
+  const end = g.coordinates[g.coordinates.length - 1];
+  if (!start || !end) return null;
+  return (
+    <line
+      x1={start[0]}
+      y1={start[1]}
+      x2={end[0]}
+      y2={end[1]}
+      stroke="oklch(0.25 0 0)"
+      strokeWidth="4"
+      strokeLinecap="round"
+      vectorEffect="non-scaling-stroke"
+      pointerEvents="none"
+    />
+  );
+}
+
+function OpeningShape({ opening }: { opening: DraftOpening }) {
+  const g = parseGeometry(opening.line_geom);
+  if (g?.type !== 'LineString') return null;
+  const start = g.coordinates[0];
+  const end = g.coordinates[g.coordinates.length - 1];
+  if (!start || !end) return null;
+  const isDoor = opening.opening_type === 'door';
+  const color = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  return (
+    <line
+      x1={start[0]}
+      y1={start[1]}
+      x2={end[0]}
+      y2={end[1]}
+      stroke={color}
+      strokeWidth="5"
+      strokeLinecap="butt"
+      vectorEffect="non-scaling-stroke"
+      pointerEvents="none"
+    />
+  );
+}
+
+function ObjectShape({ object }: { object: DraftObject }) {
+  const g = parseGeometry(object.point_geom);
+  if (g?.type !== 'Point') return null;
+  const [x, y] = g.coordinates;
+  const meta = (object.metadata_json ?? {}) as Record<string, unknown>;
+  const w = typeof meta.width_m === 'number' && meta.width_m > 0 ? meta.width_m : 1.6;
+  const h = typeof meta.height_m === 'number' && meta.height_m > 0 ? meta.height_m : 1.6;
+  const label =
+    (typeof meta.label === 'string' && meta.label) ||
+    objectTypeLabel(object.object_type);
+  return (
+    <g pointerEvents="none">
+      <rect
+        x={x - w / 2}
+        y={y - h / 2}
+        width={w}
+        height={h}
+        rx="0.15"
+        fill="oklch(0.95 0.03 240)"
+        stroke="oklch(0.74 0.08 240)"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      {label && (
+        <text
+          x={x}
+          y={y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={Math.min(w, h) * 0.22}
+          fontWeight="500"
+          fill="oklch(0.4 0.04 240)"
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+}
+
+const OBJECT_TYPE_LABEL: Record<string, string> = {
+  furniture: '가구',
+  table: '테이블',
+  bathroom: '화장실',
+  kitchen: '주방',
+  stairs: '계단',
+  counter: '카운터',
+  storage: '창고',
+};
+
+function objectTypeLabel(t: string | null | undefined): string | null {
+  if (!t) return null;
+  return OBJECT_TYPE_LABEL[t] ?? t;
+}
+
+function ApMarker({ ap }: { ap: PlacedApSimple }) {
+  const fill = 'oklch(0.55 0.22 254)';
+  const r = 0.5;
+  const iconSize = r * 1.1;
+  const iconScale = iconSize / 24;
+  return (
+    <g pointerEvents="none">
+      <circle cx={ap.x_m} cy={ap.y_m} r={r} fill={fill} />
+      <g
+        transform={`translate(${ap.x_m - iconSize / 2}, ${ap.y_m - iconSize / 2}) scale(${iconScale})`}
+        fill="none"
+        stroke="white"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 20h.01" />
+        <path d="M2 8.82a15 15 0 0 1 20 0" />
+        <path d="M5 12.859a10 10 0 0 1 14 0" />
+        <path d="M8.5 16.429a5 5 0 0 1 7 0" />
+      </g>
+      {ap.label && (
+        <text
+          x={ap.x_m}
+          y={ap.y_m + r + 0.35}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={0.35}
+          fontWeight="600"
+          fill="oklch(0.4 0.1 254)"
+        >
+          {ap.label}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/frontend/src/features/mobile/MobileConnectModal.tsx
+++ b/frontend/src/features/mobile/MobileConnectModal.tsx
@@ -143,7 +143,7 @@ function ReadyState({
   const copyDeepLink = async () => {
     try {
       await navigator.clipboard.writeText(deepLink);
-      toast.info('딥링크가 복사되었습니다');
+      toast.info('링크가 복사되었습니다');
     } catch {
       toast.error('복사에 실패했습니다', deepLink);
     }
@@ -171,7 +171,7 @@ function ReadyState({
           className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border bg-background px-3 py-2 text-xs font-medium hover:bg-accent"
         >
           <Copy className="h-3.5 w-3.5" />
-          딥링크 복사
+          링크 복사
         </button>
         <button
           type="button"

--- a/frontend/src/features/simulation/SimulationHistory.tsx
+++ b/frontend/src/features/simulation/SimulationHistory.tsx
@@ -13,9 +13,11 @@ export interface SimulationHistoryItem {
 interface Props {
   items: SimulationHistoryItem[];
   showCompareButton?: boolean;
+  onSelect?: (id: string) => void;
+  emptyMessage?: string;
 }
 
-export function SimulationHistory({ items, showCompareButton }: Props) {
+export function SimulationHistory({ items, showCompareButton, onSelect, emptyMessage }: Props) {
   return (
     <section className="rounded-2xl border bg-background p-5 shadow-sm">
       <header className="mb-4 flex items-center gap-2">
@@ -23,35 +25,43 @@ export function SimulationHistory({ items, showCompareButton }: Props) {
         <h3 className="text-sm font-bold">시뮬레이션 기록</h3>
       </header>
 
-      <ul className="space-y-3">
-        {items.map((item) => (
-          <li key={item.id}>
-            <button
-              type="button"
-              className={cn(
-                'w-full rounded-lg border p-3 text-left transition-colors hover:border-primary/40',
-                item.active && 'border-primary/40 bg-primary/5',
-              )}
-            >
-              <div className="flex items-start justify-between gap-2">
-                <span className="text-sm font-semibold">{item.label}</span>
-                <span className="shrink-0 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
-                  {item.timeLabel}
-                </span>
-              </div>
-              <div className="mt-2 flex items-center gap-3 text-[12px] text-muted-foreground">
-                <span>
-                  평균: <span className="font-semibold text-foreground">{formatNum(item.avgRssiDbm)}dBm</span>
-                </span>
-                <span>
-                  커버리지:{' '}
-                  <span className="font-semibold text-foreground">{formatNum(item.coveragePercent)}%</span>
-                </span>
-              </div>
-            </button>
-          </li>
-        ))}
-      </ul>
+      {items.length === 0 ? (
+        <p className="py-2 text-xs text-muted-foreground">
+          {emptyMessage ?? '아직 시뮬레이션 기록이 없습니다.'}
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {items.map((item) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() => onSelect?.(item.id)}
+                disabled={!onSelect}
+                className={cn(
+                  'w-full rounded-lg border p-3 text-left transition-colors hover:border-primary/40 disabled:cursor-default',
+                  item.active && 'border-primary/40 bg-primary/5',
+                )}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-sm font-semibold">{item.label}</span>
+                  <span className="shrink-0 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+                    {item.timeLabel}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center gap-3 text-[12px] text-muted-foreground">
+                  <span>
+                    평균: <span className="font-semibold text-foreground">{formatNum(item.avgRssiDbm)}dBm</span>
+                  </span>
+                  <span>
+                    커버리지:{' '}
+                    <span className="font-semibold text-foreground">{formatNum(item.coveragePercent)}%</span>
+                  </span>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
 
       {showCompareButton && (
         <button

--- a/frontend/src/hooks/use-floors.ts
+++ b/frontend/src/hooks/use-floors.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { floorApi } from '@/api/floor';
+import type { HttpError } from '@/api/client';
+import { toast } from '@/stores/toast-store';
 import type { UUID } from '@/types/common';
 import type { CreateFloorRequest } from '@/types/floor';
 
@@ -23,6 +25,21 @@ export function useCreateFloor(projectId: UUID | null) {
     },
     onSuccess: () => {
       if (projectId) qc.invalidateQueries({ queryKey: floorsKey(projectId) });
+    },
+  });
+}
+
+export function useDeleteFloor(projectId: UUID | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (floorId: UUID) => floorApi.remove(floorId),
+    onSuccess: () => {
+      if (projectId) qc.invalidateQueries({ queryKey: floorsKey(projectId) });
+      toast.info('층이 삭제되었습니다');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('층 삭제 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
     },
   });
 }

--- a/frontend/src/hooks/use-floors.ts
+++ b/frontend/src/hooks/use-floors.ts
@@ -3,7 +3,7 @@ import { floorApi } from '@/api/floor';
 import type { HttpError } from '@/api/client';
 import { toast } from '@/stores/toast-store';
 import type { UUID } from '@/types/common';
-import type { CreateFloorRequest } from '@/types/floor';
+import type { CreateFloorRequest, UpdateFloorRequest } from '@/types/floor';
 
 const floorsKey = (projectId: UUID) => ['floors', projectId] as const;
 
@@ -25,6 +25,22 @@ export function useCreateFloor(projectId: UUID | null) {
     },
     onSuccess: () => {
       if (projectId) qc.invalidateQueries({ queryKey: floorsKey(projectId) });
+    },
+  });
+}
+
+export function useUpdateFloor(projectId: UUID | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: UUID; body: UpdateFloorRequest }) =>
+      floorApi.update(id, body),
+    onSuccess: () => {
+      if (projectId) qc.invalidateQueries({ queryKey: floorsKey(projectId) });
+      toast.info('층 정보가 수정되었습니다');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('층 수정 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
     },
   });
 }

--- a/frontend/src/hooks/use-measurement-session.ts
+++ b/frontend/src/hooks/use-measurement-session.ts
@@ -32,3 +32,13 @@ export function useMeasurementPoints(sessionId: UUID | null, pageSize = 500) {
     retry: false,
   });
 }
+
+/** §10.5 — 세션에서 발견된 고유 AP 목록 (envelope 없이 list 직접 반환). */
+export function useDetectedAps(sessionId: UUID | null) {
+  return useQuery({
+    queryKey: ['detected-aps', sessionId] as const,
+    queryFn: () => measurementSessionApi.listDetectedAps(sessionId as UUID),
+    enabled: !!sessionId,
+    retry: false,
+  });
+}

--- a/frontend/src/hooks/use-measurement-session.ts
+++ b/frontend/src/hooks/use-measurement-session.ts
@@ -42,3 +42,21 @@ export function useDetectedAps(sessionId: UUID | null) {
     retry: false,
   });
 }
+
+/**
+ * GP regression 으로 측정점 → 도면 전체 dense RSSI 히트맵 추정 (#81).
+ * 측정점이 충분치 않거나 백엔드가 추정 실패하면 404/422 → 빈 상태로 fallback.
+ * resolution_m: 0.1~2.0. 기본 0.5 (백엔드 기본값과 동일).
+ */
+export function useEstimatedCoverage(sessionId: UUID | null, resolutionM = 0.5) {
+  return useQuery({
+    queryKey: ['estimated-coverage', sessionId, resolutionM] as const,
+    queryFn: () =>
+      measurementSessionApi.getEstimatedCoverage(sessionId as UUID, {
+        resolution_m: resolutionM,
+      }),
+    enabled: !!sessionId,
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/frontend/src/hooks/use-measurement-session.ts
+++ b/frontend/src/hooks/use-measurement-session.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { measurementSessionApi } from '@/api/measurement-session';
+import type { UUID } from '@/types/common';
+
+// §10.4 — 백엔드 GET 엔드포인트 구현 완료 (PR #77).
+
+export function useFloorMeasurementSessions(floorId: UUID | null) {
+  return useQuery({
+    queryKey: ['measurement-sessions', floorId] as const,
+    queryFn: () => measurementSessionApi.listByFloor(floorId as UUID),
+    enabled: !!floorId,
+    staleTime: 30_000,
+  });
+}
+
+export function useMeasurementSession(sessionId: UUID | null) {
+  return useQuery({
+    queryKey: ['measurement-session', sessionId] as const,
+    queryFn: () => measurementSessionApi.get(sessionId as UUID),
+    enabled: !!sessionId,
+    retry: false,
+  });
+}
+
+/** 세션의 측정 포인트 — 페이지 1개로 한 번에 가져옴 (시각화는 보통 전체 포인트 필요). */
+export function useMeasurementPoints(sessionId: UUID | null, pageSize = 500) {
+  return useQuery({
+    queryKey: ['measurement-points', sessionId, pageSize] as const,
+    queryFn: () =>
+      measurementSessionApi.listPoints(sessionId as UUID, { page: 1, page_size: pageSize }),
+    enabled: !!sessionId,
+    retry: false,
+  });
+}

--- a/frontend/src/hooks/use-projects.ts
+++ b/frontend/src/hooks/use-projects.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { projectApi, type ProjectListParams } from '@/api/project';
-import type { CreateProjectRequest } from '@/types/project';
+import type { HttpError } from '@/api/client';
+import { toast } from '@/stores/toast-store';
+import type { UUID } from '@/types/common';
+import type { CreateProjectRequest, UpdateProjectRequest } from '@/types/project';
 
 const KEY = ['projects'] as const;
 
@@ -17,5 +20,36 @@ export function useCreateProject() {
   return useMutation({
     mutationFn: (body: CreateProjectRequest) => projectApi.create(body),
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+  });
+}
+
+export function useUpdateProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: UUID; body: UpdateProjectRequest }) =>
+      projectApi.update(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEY });
+      toast.info('프로젝트가 수정되었습니다');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('프로젝트 수정 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
+    },
+  });
+}
+
+export function useDeleteProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: UUID) => projectApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEY });
+      toast.info('프로젝트가 삭제되었습니다');
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('프로젝트 삭제 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
+    },
   });
 }

--- a/frontend/src/hooks/use-rf-run.ts
+++ b/frontend/src/hooks/use-rf-run.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { rfJobApi, rfRunApi } from '@/api/rf-run';
+import { rfJobApi, rfRunApi, type ListRfRunsParams } from '@/api/rf-run';
 import type { HttpError } from '@/api/client';
 import { toast } from '@/stores/toast-store';
 import type { UUID } from '@/types/common';
@@ -71,6 +71,19 @@ export function useRfRun(rfRunId: UUID | null) {
     isSucceeded: isJobSucceeded(status),
     isFailed: isJobFailed(status),
   };
+}
+
+/**
+ * GET /floors/{floor_id}/rf-runs — 층의 RF Run 목록 (최신순).
+ * 기본 status 필터 없음 — 호출 측에서 'succeeded' 등으로 좁힐 수 있음.
+ */
+export function useFloorRfRuns(floorId: UUID | null, params?: ListRfRunsParams) {
+  return useQuery({
+    queryKey: ['rf-runs', floorId, params ?? null] as const,
+    queryFn: () => rfRunApi.listByFloor(floorId as UUID, params),
+    enabled: !!floorId,
+    staleTime: 30_000,
+  });
 }
 
 /** GET /rf-runs/{id}/maps — RF Run 이 succeeded 된 후에만 활성화 */

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -8,6 +8,7 @@ import {
   Activity,
   Settings,
   Wifi,
+  QrCode,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProjectSelector } from '@/features/header/ProjectSelector';
@@ -87,7 +88,7 @@ export function AppLayout() {
                 onClick={() => setMobileConnectOpen(true)}
                 className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
               >
-                <Smartphone className="h-4 w-4" />
+                <QrCode className="h-4 w-4" />
                 모바일 앱 연결
               </button>
             )}

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -823,6 +823,16 @@ export default function EditorPage() {
                       setPendingFileName(null);
                       openFilePicker();
                     }}
+                    onStartBlank={
+                      floorId
+                        ? () => {
+                            setJustPromoted(null);
+                            setPendingFileName(null);
+                            handleStartBlankDraft();
+                          }
+                        : undefined
+                    }
+                    isStartingBlank={createEmptyDraft.isPending}
                   />
                 </OverlayLayer>
               ) : isAnalyzing ? (
@@ -860,6 +870,15 @@ export default function EditorPage() {
                       setPendingFileName(null);
                       openFilePicker();
                     }}
+                    onStartBlank={
+                      floorId
+                        ? () => {
+                            setPendingFileName(null);
+                            handleStartBlankDraft();
+                          }
+                        : undefined
+                    }
+                    isStartingBlank={createEmptyDraft.isPending}
                   />
                 </OverlayLayer>
               ) : null)}

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
@@ -7,18 +7,30 @@ import {
   MapPin,
   Smartphone,
   TrendingUp,
+  Wifi,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { HelpFab } from '@/components/HelpFab';
 import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
 import { Popover } from '@/components/ui/Popover';
 import { useAppStore } from '@/stores/app-store';
-import type { MeasurementSession } from '@/types/measurement-session';
+import type {
+  DetectedAp,
+  MeasurementPoint as ApiPoint,
+  MeasurementSession,
+} from '@/types/measurement-session';
+import type { ApLayout } from '@/types/ap-layout';
+import type { RfMap } from '@/types/rf';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import {
+  useDetectedAps,
   useFloorMeasurementSessions,
   useMeasurementPoints,
 } from '@/hooks/use-measurement-session';
+import { useFloorRfRuns, useRfMaps } from '@/hooks/use-rf-run';
+import { useApLayouts } from '@/hooks/use-ap-layouts';
+import { parseGeometry } from '@/features/editor/geometry-utils';
 import {
   MeasurementCanvas,
   type MeasurementPoint as CanvasPoint,
@@ -26,7 +38,6 @@ import {
   type MeasurementViewMode,
   type PlacedApSimple,
 } from '@/features/measurement/MeasurementCanvas';
-import type { MeasurementPoint as ApiPoint } from '@/types/measurement-session';
 
 export default function MeasurementPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -49,8 +60,28 @@ export default function MeasurementPage() {
 
   const canvasPoints = useMemo(() => apiPointsToCanvas(points), [points]);
 
+  // 가장 최근 succeeded RF Run → AP layouts + RF Map metrics.
+  const rfRunsQuery = useFloorRfRuns(floorId, { status: 'succeeded', page_size: 5 });
+  const latestRfRunId = rfRunsQuery.data?.items?.[0]?.id ?? null;
+  const apLayoutsQuery = useApLayouts(latestRfRunId);
+  const canvasAps = useMemo(
+    () => apLayoutsToCanvas(apLayoutsQuery.data ?? []),
+    [apLayoutsQuery.data],
+  );
+  const rfMapsQuery = useRfMaps(latestRfRunId, !!latestRfRunId);
+  const predictedAvgDbm = useMemo(
+    () => extractPredictedAvgDbm(rfMapsQuery.data ?? []),
+    [rfMapsQuery.data],
+  );
+  const measuredAvgDbm = useMemo(() => computeMeasuredAvg(points), [points]);
+
+  // §10.5 발견된 AP 목록.
+  const detectedApsQuery = useDetectedAps(activeSession?.id ?? null);
+  const detectedAps = detectedApsQuery.data ?? [];
+
   const [mode, setMode] = useState<MeasurementViewMode>('route');
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [actionGuideOpen, setActionGuideOpen] = useState(false);
 
   const hasVersion = versions.length > 0;
   const hasMeasurement = points.length > 0;
@@ -84,7 +115,7 @@ export default function MeasurementPage() {
                 <MeasurementCanvas
                   sceneVersion={sceneVersion}
                   points={canvasPoints}
-                  aps={[] as PlacedApSimple[]}
+                  aps={canvasAps}
                   mode={mode}
                 />
                 {!hasMeasurement && <CanvasEmptyOverlay loading={pointsQuery.isFetching} />}
@@ -93,13 +124,22 @@ export default function MeasurementPage() {
           </section>
 
           <aside className="flex min-h-0 flex-col gap-3 overflow-y-auto">
-            <DiagnosticCard points={canvasPoints} />
-            <CauseAnalysisCard hasData={hasMeasurement} />
+            <DiagnosticCard
+              points={canvasPoints}
+              predictedAvgDbm={predictedAvgDbm}
+              measuredAvgDbm={measuredAvgDbm}
+            />
+            <CauseAnalysisCard
+              hasData={hasMeasurement}
+              onOpenGuide={() => setActionGuideOpen(true)}
+            />
+            {detectedAps.length > 0 && <DetectedApsCard aps={detectedAps} />}
           </aside>
         </div>
       )}
 
       <MobileConnectModal open={mobileOpen} onClose={() => setMobileOpen(false)} />
+      <ActionGuideModal open={actionGuideOpen} onClose={() => setActionGuideOpen(false)} />
       <HelpFab />
     </div>
   );
@@ -125,6 +165,45 @@ function apiPointsToCanvas(points: ApiPoint[]): CanvasPoint[] {
     quality: qualityFromRssi(p.rssi_dbm),
     order: p.step_index ?? idx + 1,
   }));
+}
+
+/** ApLayout.point_geom → 캔버스 AP 마커. 파싱 실패한 건 제외. */
+function apLayoutsToCanvas(layouts: ApLayout[]): PlacedApSimple[] {
+  const result: PlacedApSimple[] = [];
+  for (const l of layouts) {
+    const g = parseGeometry(l.point_geom);
+    if (g?.type !== 'Point') continue;
+    const [x, y] = g.coordinates;
+    result.push({ id: l.id, x_m: x, y_m: y, label: l.ap_name });
+  }
+  return result;
+}
+
+/** RfMap.metrics_json.rss_dbm.mean 추출 (없으면 옛 avg_rssi_dbm fallback). */
+function extractPredictedAvgDbm(maps: RfMap[]): number | null {
+  for (const m of maps) {
+    const v = readRssMean(m.metrics_json);
+    if (v != null) return v;
+  }
+  return null;
+}
+
+function readRssMean(metrics: Record<string, unknown> | null | undefined): number | null {
+  if (!metrics) return null;
+  const rss = metrics['rss_dbm'];
+  if (rss && typeof rss === 'object') {
+    const mean = (rss as Record<string, unknown>)['mean'];
+    if (typeof mean === 'number' && Number.isFinite(mean)) return mean;
+  }
+  const legacy = metrics['avg_rssi_dbm'];
+  if (typeof legacy === 'number' && Number.isFinite(legacy)) return legacy;
+  return null;
+}
+
+function computeMeasuredAvg(points: ApiPoint[]): number | null {
+  const vals = points.map((p) => p.rssi_dbm).filter((v): v is number => v != null);
+  if (vals.length === 0) return null;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
 }
 
 // ============================================
@@ -341,11 +420,19 @@ function CanvasEmptyOverlay({ loading }: { loading: boolean }) {
 // 우측 진단 카드
 // ============================================
 
-function DiagnosticCard({ points }: { points: CanvasPoint[] }) {
+function DiagnosticCard({
+  points,
+  predictedAvgDbm,
+  measuredAvgDbm,
+}: {
+  points: CanvasPoint[];
+  predictedAvgDbm: number | null;
+  measuredAvgDbm: number | null;
+}) {
   // 가장 신호가 약한 (불량 > 주의 > 양호) 포인트를 우선 노출.
-  const worst = useMemo(() => pickWorstPoint(points), [points]);
+  const worst = useMemo(() => (points.length > 0 ? pickWorstPoint(points) : null), [points]);
 
-  if (points.length === 0) {
+  if (!worst) {
     return (
       <div className="rounded-xl border bg-card p-4 shadow-sm">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold">
@@ -393,11 +480,84 @@ function DiagnosticCard({ points }: { points: CanvasPoint[] }) {
         </span>
       </div>
 
-      <p className="mt-3 text-[11px] text-muted-foreground">
+      <p className="mt-1 text-[11px] text-muted-foreground">
         좌표 {worst.x_m.toFixed(2)}, {worst.y_m.toFixed(2)} m
       </p>
 
-      {/* 예측치(시뮬레이션) 비교는 RF Run 결과와 매칭이 필요 — calibration-runs API 연결 후 노출 예정. */}
+      {/* 예측 vs 실측 평균 비교. RF Run 결과(예측 평균 dBm) + 측정 평균 RSSI. */}
+      <div className="mt-3 grid grid-cols-2 gap-2 rounded-lg border bg-muted/40 p-3">
+        <DbmCell label="예측 평균 (시뮬레이션)" value={predictedAvgDbm} tone="muted" />
+        <DbmCell
+          label="실측 평균"
+          value={measuredAvgDbm}
+          tone={
+            predictedAvgDbm != null && measuredAvgDbm != null && measuredAvgDbm - predictedAvgDbm < -8
+              ? 'danger'
+              : 'normal'
+          }
+        />
+      </div>
+
+      <DiffNote predicted={predictedAvgDbm} measured={measuredAvgDbm} />
+    </div>
+  );
+}
+
+function DiffNote({
+  predicted,
+  measured,
+}: {
+  predicted: number | null;
+  measured: number | null;
+}) {
+  if (predicted == null) {
+    return (
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        비교 가능한 시뮬레이션 결과가 없습니다. 먼저 시뮬레이션을 실행해주세요.
+      </p>
+    );
+  }
+  if (measured == null) return null;
+  const diff = measured - predicted;
+  const tone =
+    diff < -8 ? 'text-destructive' : diff < -3 ? 'text-amber-700' : 'text-muted-foreground';
+  const tail = diff < -8 ? ' — 예상보다 크게 약합니다.' : diff < -3 ? ' — 일부 약화.' : '';
+  return (
+    <p className={cn('mt-2 text-[11px]', tone)}>
+      예측 대비 실측 {diff >= 0 ? '+' : ''}
+      {diff.toFixed(1)} dBm{tail}
+    </p>
+  );
+}
+
+function DbmCell({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number | null;
+  tone: 'normal' | 'muted' | 'danger';
+}) {
+  return (
+    <div>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          'mt-0.5 text-2xl font-bold tabular-nums',
+          tone === 'danger' && 'text-destructive',
+          tone !== 'danger' && 'text-foreground',
+        )}
+      >
+        {value == null ? (
+          <span className="text-base text-muted-foreground">—</span>
+        ) : (
+          <>
+            {value.toFixed(1)}
+            <span className="ml-0.5 text-xs font-medium text-muted-foreground">dBm</span>
+          </>
+        )}
+      </p>
     </div>
   );
 }
@@ -411,7 +571,13 @@ function pickWorstPoint(points: CanvasPoint[]): CanvasPoint {
   return [...points].sort((a, b) => rank[a.quality] - rank[b.quality])[0];
 }
 
-function CauseAnalysisCard({ hasData }: { hasData: boolean }) {
+function CauseAnalysisCard({
+  hasData,
+  onOpenGuide,
+}: {
+  hasData: boolean;
+  onOpenGuide: () => void;
+}) {
   return (
     <div className="rounded-xl border bg-card p-4 shadow-sm">
       <h3 className="flex items-center gap-1.5 text-sm font-semibold">
@@ -429,13 +595,126 @@ function CauseAnalysisCard({ hasData }: { hasData: boolean }) {
       )}
       <button
         type="button"
-        disabled={!hasData}
-        className="mt-3 inline-flex w-full items-center justify-center gap-1 rounded-md border bg-background px-3 py-2 text-xs font-medium text-foreground hover:bg-accent disabled:opacity-50"
+        onClick={onOpenGuide}
+        className="mt-3 inline-flex w-full items-center justify-center gap-1 rounded-md border bg-background px-3 py-2 text-xs font-medium text-foreground hover:bg-accent"
       >
         조치 방법 확인하기
         <ChevronRight className="h-3.5 w-3.5" />
       </button>
     </div>
+  );
+}
+
+// ============================================
+// 발견된 AP 목록 카드
+// ============================================
+
+function DetectedApsCard({ aps }: { aps: DetectedAp[] }) {
+  // RSSI 강한 순(절댓값 작은 순)으로 정렬.
+  const sorted = useMemo(
+    () =>
+      [...aps].sort((a, b) => (b.rssi_avg ?? -200) - (a.rssi_avg ?? -200)),
+    [aps],
+  );
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+        <Wifi className="h-4 w-4 text-primary" />
+        발견된 AP ({sorted.length})
+      </h3>
+      <ul className="mt-2 space-y-1.5">
+        {sorted.map((ap) => (
+          <li
+            key={ap.ap_bssid}
+            className="flex items-center justify-between gap-2 rounded-md border bg-background px-2.5 py-1.5 text-xs"
+          >
+            <div className="min-w-0">
+              <p className="truncate font-medium">{ap.ap_ssid ?? '(SSID 없음)'}</p>
+              <p className="truncate text-[10px] text-muted-foreground">
+                {ap.ap_bssid}
+                {ap.channel != null && ` · ch ${ap.channel}`}
+                {ap.frequency_mhz != null && ` · ${(ap.frequency_mhz / 1000).toFixed(1)}GHz`}
+              </p>
+            </div>
+            <div className="text-right tabular-nums">
+              <p className="text-xs font-semibold">
+                {ap.rssi_avg != null ? `${ap.rssi_avg.toFixed(0)} dBm` : '—'}
+              </p>
+              <p className="text-[10px] text-muted-foreground">{ap.point_count}회</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ============================================
+// 조치 방법 모달
+// ============================================
+
+function ActionGuideModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md rounded-2xl border bg-card p-6 shadow-xl"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="닫기"
+          className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <h2 className="flex items-center gap-1.5 text-base font-semibold">
+          <AlertTriangle className="h-4 w-4 text-amber-500" />
+          신호 약화 조치 가이드
+        </h2>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          예측보다 실측이 크게 낮은 지점에서 시도해볼 수 있는 일반적인 조치들입니다.
+        </p>
+        <ol className="mt-4 space-y-3">
+          <GuideStep n={1} title="AP 위치 재배치" body="해당 지점과 가까운 위치로 AP 를 옮기거나, 벽·금속 구조물에서 떨어뜨려 보세요. 시뮬레이션 페이지에서 후보 위치를 재생성할 수 있습니다." />
+          <GuideStep n={2} title="벽 재질 확인" body="콘크리트·금속 가벽은 전파 흡수가 큽니다. 도면 편집에서 해당 벽의 재질을 실제와 맞게 수정하면 시뮬레이션 정확도가 올라갑니다." />
+          <GuideStep n={3} title="채널·대역 점검" body="2.4GHz 대역은 간섭이 심합니다. 발견된 AP 목록에서 동일 채널이 많이 잡히면 AP 채널을 변경하거나 5GHz 우선 사용을 검토하세요." />
+          <GuideStep n={4} title="송신 출력 조정" body="AP 송신 출력이 너무 낮으면 외곽 커버리지가 부족합니다. 시뮬레이션 파라미터의 tx_power_dbm 을 올려 재시뮬레이션 해보세요." />
+        </ol>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-5 w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function GuideStep({ n, title, body }: { n: number; title: string; body: string }) {
+  return (
+    <li className="flex gap-3">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+        {n}
+      </span>
+      <div>
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{body}</p>
+      </div>
+    </li>
   );
 }
 

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -25,6 +25,7 @@ import type { RfMap } from '@/types/rf';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import {
   useDetectedAps,
+  useEstimatedCoverage,
   useFloorMeasurementSessions,
   useMeasurementPoints,
 } from '@/hooks/use-measurement-session';
@@ -79,6 +80,14 @@ export default function MeasurementPage() {
   const detectedApsQuery = useDetectedAps(activeSession?.id ?? null);
   const detectedAps = detectedApsQuery.data ?? [];
 
+  // #81 GP regression dense RSSI heatmap — 측정점 → 도면 전체 추정.
+  const coverageQuery = useEstimatedCoverage(activeSession?.id ?? null);
+  const estimatedHeatmap = useMemo(() => {
+    const c = coverageQuery.data;
+    if (!c) return null;
+    return { url: c.heatmap_url, bounds: c.bounds };
+  }, [coverageQuery.data]);
+
   const [mode, setMode] = useState<MeasurementViewMode>('route');
   const [mobileOpen, setMobileOpen] = useState(false);
   const [actionGuideOpen, setActionGuideOpen] = useState(false);
@@ -117,6 +126,7 @@ export default function MeasurementPage() {
                   points={canvasPoints}
                   aps={canvasAps}
                   mode={mode}
+                  estimatedHeatmap={estimatedHeatmap}
                 />
                 {!hasMeasurement && <CanvasEmptyOverlay loading={pointsQuery.isFetching} />}
               </div>

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -1,53 +1,458 @@
-import { Activity, Smartphone } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import {
+  Activity,
+  AlertTriangle,
+  ChevronRight,
+  Clock,
+  MapPin,
+  Smartphone,
+  TrendingUp,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { HelpFab } from '@/components/HelpFab';
+import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
+import { Popover } from '@/components/ui/Popover';
 import { useAppStore } from '@/stores/app-store';
-import { useFloorVersions } from '@/hooks/use-scene-version';
+import type { MeasurementSession } from '@/types/measurement-session';
+import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
+import {
+  useFloorMeasurementSessions,
+  useMeasurementPoints,
+} from '@/hooks/use-measurement-session';
+import {
+  MeasurementCanvas,
+  type MeasurementPoint as CanvasPoint,
+  type MeasurementPointQuality,
+  type MeasurementViewMode,
+  type PlacedApSimple,
+} from '@/features/measurement/MeasurementCanvas';
+import type { MeasurementPoint as ApiPoint } from '@/types/measurement-session';
 
 export default function MeasurementPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
+
+  // 확정된 도면 (캔버스 배경).
   const versionsQuery = useFloorVersions(floorId);
-  const hasVersion = (versionsQuery.data?.length ?? 0) > 0;
+  const versions = versionsQuery.data ?? [];
+  const currentVersion = versions.find((v) => v.is_current) ?? versions[0] ?? null;
+  const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
+  const sceneVersion = versionDetailQuery.data ?? null;
+
+  // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
+  const sessionsQuery = useFloorMeasurementSessions(floorId);
+  const sessions = sessionsQuery.data?.items ?? [];
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const activeSession =
+    sessions.find((s) => s.id === selectedSessionId) ?? sessions[0] ?? null;
+  const pointsQuery = useMeasurementPoints(activeSession?.id ?? null);
+  const points = pointsQuery.data?.items ?? [];
+
+  const canvasPoints = useMemo(() => apiPointsToCanvas(points), [points]);
+
+  const [mode, setMode] = useState<MeasurementViewMode>('route');
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const hasVersion = versions.length > 0;
+  const hasMeasurement = points.length > 0;
 
   return (
-    <div className="relative flex h-full flex-col p-6">
-      <header className="space-y-1.5">
+    <div className="relative flex h-full flex-col gap-5 p-6">
+      <PageHeader
+        sessions={sessions}
+        activeSession={activeSession}
+        onSelectSession={(id) => setSelectedSessionId(id)}
+        onStartMeasurement={() => setMobileOpen(true)}
+      />
+
+      {!floorId ? (
+        <EmptyState
+          title="층을 먼저 선택해주세요"
+          subtitle="상단 셀렉터에서 작업할 도면(층)을 선택하면 측정 시작 흐름이 표시됩니다."
+        />
+      ) : !hasVersion ? (
+        <EmptyState
+          title="확정된 도면이 필요합니다"
+          subtitle="공간 편집에서 도면을 분석·확정한 후 모바일 앱으로 실측을 진행할 수 있습니다."
+        />
+      ) : (
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-5 xl:grid-cols-[1fr_22rem]">
+          <section className="flex min-h-0 flex-col gap-3">
+            <TabBar mode={mode} onChange={setMode} />
+            <div className="relative flex min-h-0 flex-1 flex-col gap-2 rounded-xl border bg-card p-4 shadow-sm">
+              <Legend />
+              <div className="relative min-h-112 flex-1">
+                <MeasurementCanvas
+                  sceneVersion={sceneVersion}
+                  points={canvasPoints}
+                  aps={[] as PlacedApSimple[]}
+                  mode={mode}
+                />
+                {!hasMeasurement && <CanvasEmptyOverlay loading={pointsQuery.isFetching} />}
+              </div>
+            </div>
+          </section>
+
+          <aside className="flex min-h-0 flex-col gap-3 overflow-y-auto">
+            <DiagnosticCard points={canvasPoints} />
+            <CauseAnalysisCard hasData={hasMeasurement} />
+          </aside>
+        </div>
+      )}
+
+      <MobileConnectModal open={mobileOpen} onClose={() => setMobileOpen(false)} />
+      <HelpFab />
+    </div>
+  );
+}
+
+// ============================================
+// API → 캔버스 포인트 변환
+// ============================================
+
+/** RSSI(dBm) → 신호 품질 라벨. 일반적인 Wi-Fi 임계값(>-67 양호 / >-75 주의 / 이하 불량). */
+function qualityFromRssi(rssi: number | null): MeasurementPointQuality {
+  if (rssi == null) return 'warning';
+  if (rssi >= -67) return 'good';
+  if (rssi >= -75) return 'warning';
+  return 'poor';
+}
+
+function apiPointsToCanvas(points: ApiPoint[]): CanvasPoint[] {
+  return points.map((p, idx) => ({
+    id: p.id,
+    x_m: p.floor_position.x,
+    y_m: p.floor_position.y,
+    quality: qualityFromRssi(p.rssi_dbm),
+    order: p.step_index ?? idx + 1,
+  }));
+}
+
+// ============================================
+// 헤더
+// ============================================
+
+function PageHeader({
+  sessions,
+  activeSession,
+  onSelectSession,
+  onStartMeasurement,
+}: {
+  sessions: MeasurementSession[];
+  activeSession: MeasurementSession | null;
+  onSelectSession: (id: string) => void;
+  onStartMeasurement: () => void;
+}) {
+  const hasSessions = sessions.length > 0;
+  return (
+    <header className="flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1.5">
         <h1 className="text-2xl font-semibold tracking-tight">실측 및 진단</h1>
         <p className="text-sm text-muted-foreground">
           모바일 기기로 측정한 실제 와이파이 품질 데이터와 시뮬레이션을 통합하여 분석합니다.
         </p>
-      </header>
-
-      <div className="mt-5 flex flex-1 items-center justify-center">
-        <div className="flex max-w-lg flex-col items-center gap-3 rounded-2xl border border-dashed bg-background p-10 text-center shadow-sm">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10">
-            <Activity className="h-6 w-6 text-primary" strokeWidth={1.8} />
-          </div>
-          {!floorId ? (
-            <>
-              <p className="text-base font-semibold">층을 먼저 선택해주세요</p>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                상단 셀렉터에서 작업할 도면(층)을 선택하면 측정 시작 흐름이 표시됩니다.
-              </p>
-            </>
-          ) : !hasVersion ? (
-            <>
-              <p className="text-base font-semibold">확정된 도면이 필요합니다</p>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                공간 편집에서 도면을 분석·확정한 후 모바일 앱으로 실측을 진행할 수 있습니다.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-base font-semibold">측정 데이터가 없습니다</p>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                상단 헤더의 <span className="inline-flex items-center gap-1 align-middle font-medium text-foreground"><Smartphone className="h-3.5 w-3.5" /> 모바일 앱 연결</span> 버튼으로 QR을 발급해 측정을 시작하세요. 측정이 완료되면 결과 시각화가 이곳에 표시됩니다.
-              </p>
-            </>
+      </div>
+      <div className="flex items-center gap-2">
+        <Popover
+          align="end"
+          contentClassName="w-72 max-h-80 overflow-y-auto"
+          trigger={({ toggle }) => (
+            <button
+              type="button"
+              onClick={toggle}
+              disabled={!hasSessions}
+              className="inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-accent disabled:opacity-50"
+            >
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              이력 보기
+              {activeSession && (
+                <span className="text-xs font-normal text-muted-foreground">
+                  ({formatRelative(activeSession.created_at)})
+                </span>
+              )}
+            </button>
           )}
+        >
+          {({ close }) => (
+            <div className="py-1">
+              <p className="px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                측정 세션 ({sessions.length})
+              </p>
+              {sessions.map((s) => {
+                const isActive = activeSession?.id === s.id;
+                return (
+                  <button
+                    key={s.id}
+                    type="button"
+                    onClick={() => {
+                      onSelectSession(s.id);
+                      close();
+                    }}
+                    className={cn(
+                      'flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-xs hover:bg-accent',
+                      isActive && 'bg-accent',
+                    )}
+                  >
+                    <span className="flex w-full items-center justify-between">
+                      <span className="font-medium text-foreground">
+                        {formatRelative(s.created_at)}
+                      </span>
+                      <SessionStatusBadge status={s.status} />
+                    </span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {s.measurement_type} · {s.id.slice(0, 8)}…
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </Popover>
+        <button
+          type="button"
+          onClick={onStartMeasurement}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+        >
+          <Smartphone className="h-4 w-4" />
+          새로운 측정 시작
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function SessionStatusBadge({ status }: { status: string }) {
+  const style =
+    status === 'completed'
+      ? 'bg-emerald-100 text-emerald-700'
+      : status === 'in_progress'
+      ? 'bg-amber-100 text-amber-700'
+      : 'bg-muted text-muted-foreground';
+  const label =
+    status === 'completed' ? '완료' : status === 'in_progress' ? '진행 중' : status;
+  return (
+    <span className={cn('rounded px-1.5 py-0.5 text-[10px] font-medium', style)}>{label}</span>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  if (sameDay(d, today)) return `오늘 ${hh}:${mm}`;
+  if (sameDay(d, yesterday)) return `어제 ${hh}:${mm}`;
+  return `${d.getMonth() + 1}/${d.getDate()} ${hh}:${mm}`;
+}
+
+function sameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+// ============================================
+// 탭 / 범례
+// ============================================
+
+const TABS: { id: MeasurementViewMode; label: string }[] = [
+  { id: 'route', label: '측정 경로 보기' },
+  { id: 'heatmap', label: '실측 히트맵' },
+  { id: 'both', label: '예측·실측 통합 분석' },
+];
+
+function TabBar({
+  mode,
+  onChange,
+}: {
+  mode: MeasurementViewMode;
+  onChange: (m: MeasurementViewMode) => void;
+}) {
+  return (
+    <div role="tablist" className="flex items-center gap-6 border-b">
+      {TABS.map((t) => {
+        const active = mode === t.id;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(t.id)}
+            className={cn(
+              '-mb-px border-b-2 px-1 py-2.5 text-sm font-medium transition-colors',
+              active
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="inline-flex w-fit items-center gap-3 rounded-md border bg-background px-3 py-1.5 text-[11px] text-muted-foreground shadow-sm">
+      <span className="font-semibold text-foreground">실측 포인트 범례</span>
+      <LegendDot color="oklch(0.72 0.18 145)" label="양호" />
+      <LegendDot color="oklch(0.78 0.15 85)" label="주의" />
+      <LegendDot color="oklch(0.62 0.22 25)" label="불량" />
+    </div>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="inline-block h-2 w-2 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      {label}
+    </span>
+  );
+}
+
+function CanvasEmptyOverlay({ loading }: { loading: boolean }) {
+  return (
+    <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+      <div className="pointer-events-auto max-w-sm rounded-xl border bg-background/95 px-5 py-4 text-center shadow-sm backdrop-blur">
+        <p className="text-sm font-semibold">
+          {loading ? '측정 데이터 불러오는 중...' : '측정 데이터가 없습니다'}
+        </p>
+        <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+          상단의 "새로운 측정 시작" 또는 헤더의 "모바일 앱 연결" 로 측정을 진행하면
+          여기에 결과가 표시됩니다.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// 우측 진단 카드
+// ============================================
+
+function DiagnosticCard({ points }: { points: CanvasPoint[] }) {
+  // 가장 신호가 약한 (불량 > 주의 > 양호) 포인트를 우선 노출.
+  const worst = useMemo(() => pickWorstPoint(points), [points]);
+
+  if (points.length === 0) {
+    return (
+      <div className="rounded-xl border bg-card p-4 shadow-sm">
+        <h2 className="flex items-center gap-1.5 text-sm font-semibold">
+          <TrendingUp className="h-4 w-4 text-primary" />
+          예측·실측 통합 진단
+        </h2>
+        <p className="mt-3 text-xs text-muted-foreground">
+          측정 데이터가 없습니다. 모바일 앱으로 측정을 진행하면 가장 신호가 약한 지점의
+          진단이 자동으로 표시됩니다.
+        </p>
+      </div>
+    );
+  }
+
+  const statusLabel =
+    worst.quality === 'poor'
+      ? '상태 불량'
+      : worst.quality === 'warning'
+      ? '상태 주의'
+      : '상태 양호';
+  const statusStyle =
+    worst.quality === 'poor'
+      ? 'bg-destructive/10 text-destructive'
+      : worst.quality === 'warning'
+      ? 'bg-amber-100 text-amber-700'
+      : 'bg-emerald-100 text-emerald-700';
+
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <h2 className="flex items-center gap-1.5 text-sm font-semibold">
+        <TrendingUp className="h-4 w-4 text-primary" />
+        예측·실측 통합 진단
+      </h2>
+
+      <div className="mt-4 flex items-start justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <MapPin className="h-4 w-4 text-destructive" />
+          <p className="text-sm font-semibold">
+            측정 포인트{' '}
+            <span className="text-muted-foreground">#{worst.order}</span>
+          </p>
         </div>
+        <span className={cn('rounded-md px-2 py-0.5 text-[11px] font-medium', statusStyle)}>
+          {statusLabel}
+        </span>
       </div>
 
-      <HelpFab />
+      <p className="mt-3 text-[11px] text-muted-foreground">
+        좌표 {worst.x_m.toFixed(2)}, {worst.y_m.toFixed(2)} m
+      </p>
+
+      {/* 예측치(시뮬레이션) 비교는 RF Run 결과와 매칭이 필요 — calibration-runs API 연결 후 노출 예정. */}
+    </div>
+  );
+}
+
+function pickWorstPoint(points: CanvasPoint[]): CanvasPoint {
+  const rank: Record<MeasurementPointQuality, number> = {
+    poor: 0,
+    warning: 1,
+    good: 2,
+  };
+  return [...points].sort((a, b) => rank[a.quality] - rank[b.quality])[0];
+}
+
+function CauseAnalysisCard({ hasData }: { hasData: boolean }) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+        <AlertTriangle className="h-4 w-4 text-amber-500" />
+        원인 분석 및 조치
+      </h3>
+      {hasData ? (
+        <p className="mt-2 rounded-md bg-amber-50 px-3 py-2.5 text-xs leading-relaxed text-amber-900">
+          캘리브레이션 결과가 도착하면 신호 약화의 원인 후보와 조치가 여기에 표시됩니다.
+        </p>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">
+          불량 지점이 검출되면 원인 후보와 조치 방안이 여기에 표시됩니다.
+        </p>
+      )}
+      <button
+        type="button"
+        disabled={!hasData}
+        className="mt-3 inline-flex w-full items-center justify-center gap-1 rounded-md border bg-background px-3 py-2 text-xs font-medium text-foreground hover:bg-accent disabled:opacity-50"
+      >
+        조치 방법 확인하기
+        <ChevronRight className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+// ============================================
+// 빈 상태
+// ============================================
+
+function EmptyState({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="flex max-w-lg flex-col items-center gap-3 rounded-2xl border border-dashed bg-background p-10 text-center shadow-sm">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10">
+          <Activity className="h-6 w-6 text-primary" strokeWidth={1.8} />
+        </div>
+        <p className="text-base font-semibold">{title}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -14,7 +14,7 @@ import {
 import { useMemo } from 'react';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
-import { useCreateRfRun, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
+import { useCreateRfRun, useFloorRfRuns, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
 import {
   useApCandidates,
   useApLayouts,
@@ -46,7 +46,8 @@ export default function SimulationPage() {
   const currentVersion =
     versionsQuery.data?.find((v) => v.is_current) ?? versionsQuery.data?.[0] ?? null;
 
-  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  // 사용자가 명시적으로 선택한 run (또는 새로 실행한 run). null 이면 "최신 succeeded 자동" 모드.
+  const [pickedRunId, setPickedRunId] = useState<string | null>(null);
 
   // 사용자가 배치한 AP 목록 + 추가 모드(true 면 다음 클릭이 새 AP 추가).
   const [aps, setAps] = useState<PlacedAp[]>([]);
@@ -54,6 +55,18 @@ export default function SimulationPage() {
 
   // 캔버스 배경으로 보여줄 확정 버전 상세 (rooms/walls/openings/objects 포함).
   const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
+
+  // 층의 과거 RF Run 목록 (이력 카드 + 자동 복원용).
+  const pastRunsQuery = useFloorRfRuns(floorId, { page_size: 20 });
+  const pastRuns = useMemo(() => pastRunsQuery.data?.items ?? [], [pastRunsQuery.data]);
+
+  // 활성 run = 사용자가 명시 선택한 것 ?? 최근 succeeded fallback.
+  // → 새로고침/재진입 시에도 가장 최근 succeeded 자동 활성.
+  const activeRunId = useMemo(() => {
+    if (pickedRunId) return pickedRunId;
+    return pastRuns.find((r) => r.status === 'succeeded')?.id ?? null;
+  }, [pickedRunId, pastRuns]);
+  const setActiveRunId = setPickedRunId;
 
   // 시뮬레이션 페이지는 배경 도면 이미지를 안 깔음 — 도형만 + 히트맵 오버레이.
   // (배경 이미지는 공간편집/대시보드 한정.)
@@ -127,23 +140,24 @@ export default function SimulationPage() {
     rfMapsQuery.data?.[0]?.metrics_json,
   );
 
-  // 시뮬레이션 기록 — 현재 실행 + (TODO: 과거 RF runs 목록)
-  const history: SimulationHistoryItem[] = currentVersion
-    ? [
-        ...(rfRunPoll.isSucceeded
-          ? [
-              {
-                id: `run-${activeRunId}`,
-                label: `시뮬레이션 결과 #${rfRunPoll.rfRun?.id?.slice(0, 6) ?? ''}`,
-                timeLabel: '방금 전',
-                avgRssiDbm: metrics.avgRssiDbm ?? 0,
-                coveragePercent: metrics.coveragePercent ?? 0,
-                active: true,
-              },
-            ]
-          : []),
-      ]
-    : [];
+  // 시뮬레이션 기록 — 백엔드의 RF Run 목록을 표시. 클릭하면 해당 run 으로 전환.
+  const history: SimulationHistoryItem[] = useMemo(
+    () =>
+      pastRuns
+        .filter((r) => r.status === 'succeeded')
+        .map((r) => {
+          const m = parseMetrics(r.metrics_json);
+          return {
+            id: r.id,
+            label: `시뮬레이션 결과 #${r.id.slice(0, 6)}`,
+            timeLabel: formatRunTime(r.created_at),
+            avgRssiDbm: m.avgRssiDbm ?? 0,
+            coveragePercent: m.coveragePercent ?? 0,
+            active: r.id === activeRunId,
+          };
+        }),
+    [pastRuns, activeRunId],
+  );
 
   return (
     <div className="relative flex h-full flex-col p-6">
@@ -227,7 +241,12 @@ export default function SimulationPage() {
             {state === 'complete' && activeRunId && (
               <ApPlacementPanel rfRunId={activeRunId} />
             )}
-            <SimulationHistory items={history} showCompareButton={false} />
+            <SimulationHistory
+              items={history}
+              showCompareButton={false}
+              onSelect={(id) => setActiveRunId(id)}
+              emptyMessage="아직 시뮬레이션 기록이 없습니다. AP 를 배치하고 시뮬레이션을 실행해보세요."
+            />
           </aside>
         </div>
       )}
@@ -584,6 +603,27 @@ function ApLayoutRow({
  * 백엔드 응답 예: { z: 1, min_x, min_y, max_x, max_y }.
  * 4개 좌표 중 하나라도 유효하지 않으면 null → 히트맵 오버레이 생략.
  */
+/** RF Run.created_at → "방금 전" / "오늘 14:32" / "어제 09:10" / "5/18 14:32". */
+function formatRunTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  if (diffMs < 60_000) return '방금 전';
+  if (diffMs < 3600_000) return `${Math.floor(diffMs / 60_000)}분 전`;
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  const sameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  if (sameDay(d, now)) return `오늘 ${hh}:${mm}`;
+  if (sameDay(d, yesterday)) return `어제 ${hh}:${mm}`;
+  return `${d.getMonth() + 1}/${d.getDate()} ${hh}:${mm}`;
+}
+
 function parseHeatmapBounds(
   bounds: Record<string, unknown> | null | undefined,
 ): { minX: number; minY: number; maxX: number; maxY: number } | null {

--- a/frontend/src/types/measurement-session.ts
+++ b/frontend/src/types/measurement-session.ts
@@ -1,0 +1,52 @@
+import type { ISODateString, UUID } from './common';
+
+// §10 실측 세션 / 포인트 — 백엔드 schemas/measurement.py 응답과 정합.
+
+export type MeasurementSessionStatus = 'in_progress' | 'completed' | string;
+
+export interface MeasurementSession {
+  id: UUID;
+  project_id: UUID;
+  floor_id: UUID;
+  scene_version_id: UUID | null;
+  asset_id: UUID | null;
+  measurement_type: string;
+  status: MeasurementSessionStatus;
+  created_at: ISODateString;
+}
+
+export interface FloorPosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface MeasurementPoint {
+  id: UUID;
+  session_id: UUID;
+  client_point_id: string | null;
+  batch_id: string | null;
+  floor_position: FloorPosition;
+  rssi_dbm: number | null;
+  ap_bssid: string | null;
+  ap_ssid: string | null;
+  channel: number | null;
+  frequency_mhz: number | null;
+  timestamp_at_point: ISODateString | null;
+  ar_tracking_state: string | null;
+  ar_confidence: number | null;
+  step_index: number | null;
+  metadata_json: Record<string, unknown>;
+  created_at: ISODateString;
+}
+
+export interface DetectedAp {
+  ap_bssid: string;
+  ap_ssid: string | null;
+  channel: number | null;
+  frequency_mhz: number | null;
+  point_count: number;
+  rssi_avg: number | null;
+  rssi_min: number | null;
+  rssi_max: number | null;
+}

--- a/frontend/src/types/measurement-session.ts
+++ b/frontend/src/types/measurement-session.ts
@@ -50,3 +50,31 @@ export interface DetectedAp {
   rssi_min: number | null;
   rssi_max: number | null;
 }
+
+// §10.X (#81) — GP regression 으로 측정점 → 도면 전체 dense RSSI 추정.
+// 백엔드 EstimatedCoverageResponseDTO 와 정합.
+
+export interface FloorBounds {
+  min_x: number;
+  min_y: number;
+  max_x: number;
+  max_y: number;
+}
+
+export interface EstimatedRssiRange {
+  min: number;
+  max: number;
+  mean: number;
+}
+
+export interface EstimatedCoverage {
+  heatmap_url: string;
+  uncertainty_url: string;
+  bounds: FloorBounds;
+  grid_shape: [number, number]; // [H, W]
+  grid_resolution_m: number;
+  rssi_range: EstimatedRssiRange;
+  uncertainty_max_db: number;
+  input_point_count: number;
+  kernel_repr: string;
+}


### PR DESCRIPTION
실측 페이지 기능 추가 및 개선
- 실측 페이지 내 측정 시작 및 이력 드롭다운 UI 연동
- 측정 API 응답 스키마 정합화로 데이터 처리 안정성 확보
- 실측 페이지 AP 마커 및 dBm 비교 기능 구현
- 발견 AP 조치 가이드 표시 기능 및 층 삭제 기능 추가

사용자 경험(UX) 개선
- '빈 도면으로 시작하기' 버튼 추가

버그 수정 및 최적화
- 확정 전후 캔버스 viewBox 유지 로직 수정 (캐시 키를 floor_id로 변경하여 층 변경 시 캔버스 상태가 어긋나는 문제 해결)