### PR TITLE
[Fix] 도면 기반 벽·방 추출 안정성 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ htmlcov/
 *.cover
 .hypothesis/
 backend/tests/
+backend/wall_debug/
 
 # build
 *.egg-info/

--- a/backend/app/geometry/__init__.py
+++ b/backend/app/geometry/__init__.py
@@ -35,6 +35,8 @@ from app.geometry.reconciliation import (
     bridge_collinear_walls,
     project_openings_onto_walls,
     snap_wall_endpoints,
+    synthesize_opening_wall_segments,
+    synthesize_partition_walls_from_ticks,
 )
 
 __all__ = [
@@ -62,4 +64,6 @@ __all__ = [
     "bridge_collinear_walls",
     "project_openings_onto_walls",
     "snap_wall_endpoints",
+    "synthesize_opening_wall_segments",
+    "synthesize_partition_walls_from_ticks",
 ]

--- a/backend/app/geometry/reconciliation.py
+++ b/backend/app/geometry/reconciliation.py
@@ -15,7 +15,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from typing import Protocol
 
-from app.geometry.matching import segment_orientation
+from app.geometry.matching import (
+    Bbox,
+    bbox_orientation,
+    segment_orientation,
+)
 
 # tolerance 비율 (wall 좌표 전체 extent 대비)
 DEFAULT_COLLINEAR_AXIS_RATIO = 0.012   # collinear 판정: 수직(perp) 위치 차이 허용
@@ -303,3 +307,174 @@ def project_openings_onto_walls(
         projected += 1
 
     return projected
+
+
+# ============================================================
+# 4. 개구부(문/창) 를 벽 증거로 → 벽 중심선 조각 합성
+# ============================================================
+def synthesize_opening_wall_segments(
+    opening_bboxes: Iterable[Bbox],
+    walls: Sequence[_WallLike],
+    *,
+    perp_ratio: float = 0.04,
+    reach_ratio: float = 0.10,
+    min_perp_px: float = 15.0,
+) -> list[tuple[float, float, float, float]]:
+    """문/창 bbox 를 "여기 벽이 지나간다" 는 증거로 보고 벽 중심선 조각을 합성한다.
+
+    U-Net 은 개구부 위치에서 벽 확률이 떨어져 벽이 끊기는 경우가 흔하다. 그러면
+    `polygonize` 가 방을 못 닫아(내벽이 사라진 것처럼) 인접 방이 하나로 합쳐진다.
+    개구부는 정의상 벽에 박혀 있으므로, 그 자리에 짧은 중심선 조각을 끼워 넣으면
+    끊긴 양쪽 벽을 이어 방 폐합률을 높인다.
+
+    ⚠️ 반환된 조각은 **방 추출 입력에만** 더해야 한다 (영속 wall 에 넣으면 문 위에
+    벽이 중복 렌더됨). 호출자가 분리 책임.
+
+    축 결정 — bbox 방향은 door swing 때문에 신뢰 불가(host 벽과 직교로 보일 수 있음).
+    그래서 **host 벽을 먼저 찾고 그 벽의 방향을 축으로** 삼는다:
+      - 각 H/V wall 의 무한직선까지의 수직거리(perp_off) + 선분 끝까지의 along-axis
+        거리(along_gap) 계산.
+      - perp_off ≤ perp_tol, along_gap ≤ reach_tol 이면 host 후보. perp_off 최소 채택.
+      - host 가 잡히면 그 벽과 collinear(같은 perp) 하게, bbox 의 host-축 길이만큼 조각 생성.
+      - 못 찾으면 bbox 가 명확히 길쭉할 때만 그 축으로 fallback (ambiguous 는 skip).
+
+    좌표 단위: 픽셀 (fusion 파이프라인 기준).
+    반환: (x1, y1, x2, y2) 중심선 좌표 리스트.
+    """
+    walls = list(walls)
+    extent = _coord_extent(walls)
+
+    segments: list[tuple[float, float, float, float]] = []
+    for bbox in opening_bboxes:
+        x1, y1, x2, y2 = (float(v) for v in bbox)
+        cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+        bw, bh = abs(x2 - x1), abs(y2 - y1)
+        if bw <= 0.0 and bh <= 0.0:
+            continue
+
+        # perp_tol 은 door swing 으로 bbox 중심이 벽선에서 떨어진 만큼 흡수해야 함 →
+        # bbox 짧은 변 절반도 하한으로 반영.
+        perp_tol = max(min_perp_px, extent * perp_ratio, 0.5 * min(bw, bh))
+        reach_tol = max(extent * reach_ratio, 2.0 * max(bw, bh))
+
+        best_wall: _WallLike | None = None
+        best_axis = ""
+        best_perp_off = perp_tol
+        for w in walls:
+            o = segment_orientation(w.x1, w.y1, w.x2, w.y2)
+            if o == "horizontal":
+                wp = (w.y1 + w.y2) / 2.0
+                perp_off = abs(cy - wp)
+                lo, hi = sorted((w.x1, w.x2))
+                along_gap = 0.0 if lo <= cx <= hi else min(abs(cx - lo), abs(cx - hi))
+            elif o == "vertical":
+                wp = (w.x1 + w.x2) / 2.0
+                perp_off = abs(cx - wp)
+                lo, hi = sorted((w.y1, w.y2))
+                along_gap = 0.0 if lo <= cy <= hi else min(abs(cy - lo), abs(cy - hi))
+            else:
+                continue  # diagonal/degenerate → 축 모호, 제외
+            if perp_off <= best_perp_off and along_gap <= reach_tol:
+                best_perp_off = perp_off
+                best_wall = w
+                best_axis = o
+
+        if best_wall is not None:
+            if best_axis == "horizontal" and bw > 0.0:
+                perp = (best_wall.y1 + best_wall.y2) / 2.0
+                half = bw / 2.0
+                segments.append((cx - half, perp, cx + half, perp))
+            elif best_axis == "vertical" and bh > 0.0:
+                perp = (best_wall.x1 + best_wall.x2) / 2.0
+                half = bh / 2.0
+                segments.append((perp, cy - half, perp, cy + half))
+            continue
+
+        # fallback: host 벽 못 찾음 → bbox 가 명확히 길쭉할 때만 그 축으로.
+        op_orient = bbox_orientation(x1, y1, x2, y2)
+        if op_orient == "horizontal" and bw > 0.0:
+            half = bw / 2.0
+            segments.append((cx - half, cy, cx + half, cy))
+        elif op_orient == "vertical" and bh > 0.0:
+            half = bh / 2.0
+            segments.append((cx, cy - half, cx, cy + half))
+
+    return segments
+
+
+# ============================================================
+# 5. 치수선 그리드 tick → (게이팅) 누락 칸막이 복구
+# ============================================================
+def _cluster_ticks(values: Iterable[float], tol: float) -> list[float]:
+    """가까운 tick 값들을 하나로 합침 (정렬 후 tol 이내 중복 제거)."""
+    out: list[float] = []
+    for v in sorted(values):
+        if out and abs(v - out[-1]) <= tol:
+            continue
+        out.append(v)
+    return out
+
+
+def synthesize_partition_walls_from_ticks(
+    vtick_xs: Iterable[float],   # 벽 없는 세로 그리드라인 x (수평 치수선 tick)
+    htick_ys: Iterable[float],   # 벽 없는 가로 그리드라인 y (수직 치수선 tick)
+    walls: Sequence[_WallLike],
+    *,
+    tol_ratio: float = 0.02,
+    min_tol_px: float = 12.0,
+) -> list[tuple[float, float, float, float]]:
+    """치수선 그리드 tick + 직교벽 끝점 = 누락 칸막이 증거 → 칸막이 조각 합성.
+
+    게이팅(교차증거 필수): tick 자리에 직교벽의 **끝점**이 가까이 있을 때만 합성.
+      - 가로벽이 허공에서 끝남(xlo/xhi ≈ T) = 거기 세로 칸막이가 만나야 함
+      - + 치수 tick = 그리드 경계
+      두 독립 증거가 겹칠 때만 → 과분할 위험 ↓. 끝점에서 반대편 직교벽까지 연결.
+
+    개구부 앵커(synthesize_opening_wall_segments)와 상보적 — 이쪽은 "벽 끝점"
+    증거를 쓰므로 개구부 신호와 중복되지 않는다.
+
+    ⚠️ 개구부 조각과 동일하게 **방 추출 입력 전용**. 영속 벽엔 넣지 말 것.
+    반환: (x1, y1, x2, y2) 중심선 좌표 리스트.
+    """
+    walls = list(walls)
+    extent = _coord_extent(walls)
+    tol = max(min_tol_px, extent * tol_ratio)
+
+    hwalls: list[tuple[float, float, float]] = []  # (xlo, xhi, ymid)
+    vwalls: list[tuple[float, float, float]] = []  # (ylo, yhi, xmid)
+    for w in walls:
+        o = segment_orientation(w.x1, w.y1, w.x2, w.y2)
+        if o == "horizontal":
+            hwalls.append((min(w.x1, w.x2), max(w.x1, w.x2), (w.y1 + w.y2) / 2.0))
+        elif o == "vertical":
+            vwalls.append((min(w.y1, w.y2), max(w.y1, w.y2), (w.x1 + w.x2) / 2.0))
+
+    segments: list[tuple[float, float, float, float]] = []
+
+    # 세로 칸막이: 세로 tick x=T, 가로벽 끝점이 T 근처
+    for t in _cluster_ticks(vtick_xs, tol):
+        anchors = [ym for (xlo, xhi, ym) in hwalls if min(abs(xlo - t), abs(xhi - t)) <= tol]
+        if not anchors:
+            continue
+        covering = [ym for (xlo, xhi, ym) in hwalls if xlo - tol <= t <= xhi + tol]
+        ay = anchors[0]
+        others = [y for y in covering if abs(y - ay) > tol]
+        if not others:
+            continue
+        by = min(others, key=lambda y: abs(y - ay))
+        segments.append((t, min(ay, by), t, max(ay, by)))
+
+    # 가로 칸막이: 가로 tick y=T, 세로벽 끝점이 T 근처
+    for t in _cluster_ticks(htick_ys, tol):
+        anchors = [xm for (ylo, yhi, xm) in vwalls if min(abs(ylo - t), abs(yhi - t)) <= tol]
+        if not anchors:
+            continue
+        covering = [xm for (ylo, yhi, xm) in vwalls if ylo - tol <= t <= yhi + tol]
+        ax = anchors[0]
+        others = [x for x in covering if abs(x - ax) > tol]
+        if not others:
+            continue
+        bx = min(others, key=lambda x: abs(x - ax))
+        segments.append((min(ax, bx), t, max(ax, bx), t))
+
+    return segments

--- a/backend/app/schemas/scene.py
+++ b/backend/app/schemas/scene.py
@@ -18,9 +18,11 @@ class Opening(BaseModel):
 
 class Room(BaseModel):
     id: str
-    points: List[List[float]]  
-    center: List[float]        
-    area: float              
+    points: List[List[float]]
+    center: List[float]
+    area: float
+    type: Optional[str] = None   # 객체 탐지로 부여된 방 종류 (예: "bathroom")
+    name: Optional[str] = None   # 표시용 이름 (예: "화장실")
 
 class Topology(BaseModel):
     adjacencies: List[List[str]] 

--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -124,6 +124,61 @@ class FusionService:
             logger.warning("치수 tick 칸막이 복구 skip", exc_info=True)
             return []
 
+    @staticmethod
+    def _promote_space_detections_to_rooms(furniture_objects, rooms):
+        """공간형 탐지(화장실 등)를 포함하는 방에 종류로 부여하고 객체에서 제거.
+
+        det 중심을 포함하는 방을 찾아 room.type/name 세팅 → 떠다니는 객체 대신 방으로.
+        반환: 승격되지 않은 가구 객체 리스트 (포함 방 못 찾으면 객체로 남김).
+        """
+        SPACE_CLASSES = {"bathroom": "화장실"}
+        MAX_SPACE_ROOM_M2 = 15.0  # 이보다 큰 방은 화장실이 아닌 병합/오방 → 승격 안 함
+        if not furniture_objects or not rooms:
+            return furniture_objects
+        try:
+            from shapely.geometry import Point, Polygon
+        except Exception:
+            return furniture_objects
+
+        room_polys = []
+        for r in rooms:
+            try:
+                if len(r.points) >= 3:
+                    room_polys.append((r, Polygon(r.points)))
+            except Exception:
+                continue
+
+        promoted: set[int] = set()
+        for fi, det in enumerate(furniture_objects):
+            label = SPACE_CLASSES.get(det.class_name)
+            if label is None:
+                continue
+            try:
+                bx1, by1, bx2, by2 = det.bbox_xyxy
+            except Exception:
+                continue
+            c = Point((bx1 + bx2) / 2.0, (by1 + by2) / 2.0)
+            target = None
+            for r, poly in room_polys:
+                try:
+                    if poly.contains(c) or poly.buffer(10.0).contains(c):
+                        # 큰 방(병합/오방)이면 화장실로 오태깅 방지 → 승격 보류.
+                        if r.area is not None and r.area > MAX_SPACE_ROOM_M2:
+                            break
+                        target = r
+                        break
+                except Exception:
+                    continue
+            if target is not None:
+                target.type = det.class_name
+                target.name = label
+                promoted.add(fi)
+                logger.info("space detection '%s' → room %s 로 승격", det.class_name, target.id)
+
+        if not promoted:
+            return furniture_objects
+        return [d for i, d in enumerate(furniture_objects) if i not in promoted]
+
     def _run_wi_twin_pipeline(
         self,
         ml_output: MlOutputDTO,
@@ -254,6 +309,13 @@ class FusionService:
                 det.id = f"furniture_{len(furniture_objects)}"
                 furniture_objects.append(det)
 
+        # 공간형 탐지(화장실 등)를 "방"으로 승격 — 떠다니는 고정크기 객체 박스 대신
+        # 그 탐지를 포함하는 방의 종류로 태깅. (Wi-Fi: 화장실은 경계 벽 재질이 달라
+        # 방으로 묶어두면 벽 재질 지정/시뮬에 유리. 객체보다 벽-바인딩에 적합)
+        furniture_objects = self._promote_space_detections_to_rooms(
+            furniture_objects, extracted_rooms
+        )
+
         # 중복 detection 제거 (NMS) — type 무관 단일 pass.
         # 같은 위치에 door 와 window 가 동시 감지되면 score 1 등만 유지.
         # (이전엔 type 별로 따로 NMS 였지만 사용자가 한 개만 보이길 원해 변경.)
@@ -297,13 +359,25 @@ class FusionService:
                 matched_count, len(openings), projected,
             )
 
+        # 객체는 bbox×scale 로 실제 크기(width_m/height_m) 부여 → 떠다니는 고정 1.6m
+        # 박스 대신 탐지된 실제 크기로 렌더 (화장실 등이 거대하게 그려지던 문제 해결).
+        def _obj_dump(obj: DetectionDTO) -> dict:
+            d = obj.model_dump()
+            try:
+                bx1, by1, bx2, by2 = obj.bbox_xyxy
+                d["width_m"] = round(max(abs(bx2 - bx1) * scale_ratio, 0.1), 3)
+                d["height_m"] = round(max(abs(by2 - by1) * scale_ratio, 0.1), 3)
+            except Exception:
+                pass
+            return d
+
         return SceneSchema(
             scale_ratio=scale_ratio,
             walls=[w.model_dump() for w in calibrated_walls],
             openings=[o.model_dump() for o in openings],
             rooms=[r.model_dump() for r in extracted_rooms],
             topology=topology_result.model_dump(),
-            objects=[obj.model_dump() for obj in furniture_objects],
+            objects=[_obj_dump(obj) for obj in furniture_objects],
             inference_metadata=sagemaker_meta,
             postprocess_metadata=postprocess_meta_dict,
         )

--- a/backend/app/services/fusion_service.py
+++ b/backend/app/services/fusion_service.py
@@ -22,6 +22,8 @@ from app.geometry import (
     nms_filter_indices,
     project_openings_onto_walls,
     snap_wall_endpoints,
+    synthesize_opening_wall_segments,
+    synthesize_partition_walls_from_ticks,
 )
 from app.schemas.ai_response import (
     DetectionDTO,
@@ -61,8 +63,66 @@ class FusionService:
             sagemaker_meta,
             result.source_image_local_path,
             debug_dir,
+            result.ocr_priors,
+            result.line_priors,
+            result.roi_transform,
         )
         return scene
+
+    @staticmethod
+    def _recover_partitions_from_dimension_ticks(
+        postprocess, walls, scale_ratio: float
+    ) -> list[tuple[float, float, float, float]]:
+        """치수선 그리드 tick(벽 없는 경계) + 직교벽 끝점 → 누락 칸막이 조각.
+
+        best-effort: 입력이 없거나 실패하면 빈 리스트 (방 추출에 영향 없음).
+        """
+        try:
+            dim_matches = getattr(postprocess, "dimension_matches", None) or []
+            if not dim_matches or not walls or not scale_ratio or scale_ratio <= 0:
+                return []
+            from app.services.wall_extraction_helpers import dimension_matching as _dm
+            from app.services.wall_extraction_helpers.ocr import OCREntry
+
+            entries = []
+            for m in dim_matches:
+                bb = m.get("bbox") or []
+                if len(bb) != 4:
+                    continue
+                entries.append(
+                    OCREntry(
+                        bbox=tuple(int(v) for v in bb),  # type: ignore[arg-type]
+                        text=str(m.get("text", "")),
+                        confidence=float(m.get("ocr_confidence", 0.0)),
+                    )
+                )
+            if not entries:
+                return []
+
+            wall_px = [[w.x1, w.y1, w.x2, w.y2] for w in walls]
+            spans = _dm.build_dimension_spans(entries, float(scale_ratio), wall_px)
+            if not spans:
+                return []
+
+            # 벽이 안 붙은(boundary None) tick 만 칸막이 후보로.
+            vtick_xs: list[float] = []
+            htick_ys: list[float] = []
+            for s in spans:
+                if s.orientation == "horizontal":
+                    if s.boundary_lo_wall is None:
+                        vtick_xs.append(s.axis_lo)
+                    if s.boundary_hi_wall is None:
+                        vtick_xs.append(s.axis_hi)
+                else:
+                    if s.boundary_lo_wall is None:
+                        htick_ys.append(s.axis_lo)
+                    if s.boundary_hi_wall is None:
+                        htick_ys.append(s.axis_hi)
+
+            return synthesize_partition_walls_from_ticks(vtick_xs, htick_ys, walls)
+        except Exception:
+            logger.warning("치수 tick 칸막이 복구 skip", exc_info=True)
+            return []
 
     def _run_wi_twin_pipeline(
         self,
@@ -71,19 +131,27 @@ class FusionService:
         sagemaker_meta: dict[str, Any] | None = None,
         source_image_local_path=None,
         debug_dir=None,
+        ocr_priors: list[dict] | None = None,
+        line_priors: list[dict] | None = None,
+        roi_transform: dict | None = None,
     ) -> SceneSchema:
         # wall_extraction 은 .npy 파일 경로를 받아 prob_map 로딩.
-        # source_image 있으면 §69 multi-threshold + OCR scoring + 치수 매칭 흐름 활성화.
-        # GeometryService 보다 먼저 호출 — OCR 치수 기반 scale 추정을 받아 scale 결정.
+        # priors (AI 서버 사전 분석 결과) 가 있으면 wall_extraction 이 그걸 사용,
+        # 없으면 source_image_local_path 기반으로 자체 OCR/line 추출.
         wall_result = wall_extractor.execute_from_prob_map(
             prob_map_local_path,
             threshold=None,
             detections=ml_output.detections,
             image_path=source_image_local_path,
             debug_dir=debug_dir,
+            ocr_priors=ocr_priors,
+            line_priors=line_priors,
         )
         raw_coords = wall_result.walls
         postprocess_meta_dict = wall_result.postprocess.to_dict()
+        # AI 서버가 같이 내려준 RoiTransform 도 영속화 (디버깅/프론트 표시용).
+        if roi_transform is not None:
+            postprocess_meta_dict["roi_transform"] = roi_transform
 
         # OCR 치수 추정 scale 이 있으면 그걸로, 없으면 default fallback (사용자가
         # PropertiesPanel 에서 벽별 실측 입력해 후속 보정).
@@ -138,7 +206,42 @@ class FusionService:
                 n_walls_before, len(calibrated_walls),
             )
 
-        extracted_rooms: list[Room] = geo_service.extract_rooms(calibrated_walls)
+        # 개구부(문/창) 를 벽 증거로 활용 — U-Net 이 개구부에서 벽을 끊는 경우가 많아
+        # 그 자리에 중심선 조각을 끼워 끊긴 벽을 잇는다 → 방 폐합률 ↑ (도면별 편차 ↓).
+        # ⚠️ 합성 조각은 방 추출 입력에만 더하고 영속 wall 에는 넣지 않는다 (문 위 벽 중복 방지).
+        opening_bboxes = [
+            tuple(float(v) for v in det.bbox_xyxy)
+            for det in ml_output.detections
+            if det.class_name in {"door", "window"}
+        ]
+        opening_segments = synthesize_opening_wall_segments(
+            opening_bboxes, calibrated_walls
+        )
+
+        # 치수선 그리드 tick → 누락 칸막이 복구 (게이팅: 직교벽 끝점 + tick 두 증거).
+        # 개구부 신호와 상보적. 실패해도 방 추출엔 영향 없게 best-effort.
+        partition_segments = self._recover_partitions_from_dimension_ticks(
+            wall_result.postprocess, calibrated_walls, scale_ratio
+        )
+
+        # 합성 조각(개구부 + 칸막이)은 방 추출 입력에만 더하고 영속 wall 에는 안 넣음.
+        synth_segments = list(opening_segments) + list(partition_segments)
+        walls_for_rooms: list[Wall] = calibrated_walls
+        if synth_segments:
+            walls_for_rooms = list(calibrated_walls) + [
+                Wall(
+                    id=f"synth_seg_{i}",
+                    x1=sx1, y1=sy1, x2=sx2, y2=sy2,
+                    thickness=0.0,  # 추정 두께 median 에서 제외되도록 0 (extract_rooms 가 >0 만 사용)
+                )
+                for i, (sx1, sy1, sx2, sy2) in enumerate(synth_segments)
+            ]
+            logger.info(
+                "wall completion: 방 추출용 합성 조각 +%d개 (개구부 %d, 치수 tick %d)",
+                len(synth_segments), len(opening_segments), len(partition_segments),
+            )
+
+        extracted_rooms: list[Room] = geo_service.extract_rooms(walls_for_rooms)
         topology_result = topo_service.analyze(extracted_rooms, ml_output.detections)
 
         # door/window 와 가구 detection 분리

--- a/backend/app/services/geometry_service.py
+++ b/backend/app/services/geometry_service.py
@@ -73,8 +73,17 @@ class GeometryService:
         rooms = []
         valid_room_count = 0
         
-        # 벽 두께(약 15cm)만큼 안쪽으로 수축하여 실제 가용 면적 계산
-        shrink_dist = 0.15 / self.scale_ratio 
+        # 벽 안쪽 면 기준 가용 면적 계산을 위해 안쪽으로 수축.
+        # 폴리곤은 벽 '중심선' 으로 그려지므로(LineString w.x1,y1→x2,y2),
+        # 중심선 → 안쪽 면 거리는 벽 두께의 절반이다 → thickness/2 만큼만 수축.
+        # 두께는 calibrate_walls 가 문 폭으로 추정해 각 wall.thickness 에 채워둔 실측값 사용
+        # (calibrate 전이거나 thickness 미설정 시에만 0.15m fallback).
+        thicknesses = [
+            float(w.thickness) for w in walls
+            if getattr(w, "thickness", None) and w.thickness > 0
+        ]
+        wall_thickness_m = float(np.median(thicknesses)) if thicknesses else 0.15
+        shrink_dist = (wall_thickness_m / 2.0) / self.scale_ratio
 
         for poly in polygons:
             # (1) 안쪽으로 수축

--- a/backend/app/services/geometry_service.py
+++ b/backend/app/services/geometry_service.py
@@ -85,28 +85,37 @@ class GeometryService:
         wall_thickness_m = float(np.median(thicknesses)) if thicknesses else 0.15
         shrink_dist = (wall_thickness_m / 2.0) / self.scale_ratio
 
+        # 노이즈 단순화 tolerance (좌표 extent 의 0.5%, 최소 2px).
+        simplify_tol = max(2.0, coord_range * 0.005)
+
         for poly in polygons:
-            # (1) 안쪽으로 수축
+            # (1) 안쪽으로 수축 (벽 중심선 → 안쪽 면, 두께 절반)
             inner_poly = poly.buffer(-shrink_dist)
             if inner_poly.is_empty:
                 continue
-            
-            # (2) 직사각형화 (Envelope)
-            rect_poly = inner_poly.envelope
-            
+            # buffer 결과가 MultiPolygon 이면 가장 큰 조각만.
+            if inner_poly.geom_type == "MultiPolygon":
+                inner_poly = max(inner_poly.geoms, key=lambda g: g.area)
+            # (2) 실제 벽 모양 유지 (envelope 사각형 대신) — 잔잔한 노이즈만 단순화.
+            shape = inner_poly.simplify(simplify_tol, preserve_topology=True)
+            if not shape.is_valid:
+                shape = shape.buffer(0)
+            if shape.is_empty or shape.geom_type != "Polygon":
+                continue
+
             # (3) 면적 계산 (m²)
-            real_area = rect_poly.area * (self.scale_ratio ** 2)
-            
+            real_area = shape.area * (self.scale_ratio ** 2)
+
             # 너무 작거나(노이즈) 너무 큰(외곽선) 공간 필터링
             if real_area < 2.0 or real_area > 300.0:
                 continue
 
-            # (4) Room 객체 생성
-            coords = [list(pt) for pt in rect_poly.exterior.coords]
+            # (4) Room 객체 생성 — 실제 폴리곤 외곽 좌표 그대로.
+            coords = [list(pt) for pt in shape.exterior.coords]
             rooms.append(Room(
                 id=f"room_{valid_room_count}",
                 points=coords,
-                center=[round(rect_poly.centroid.x, 3), round(rect_poly.centroid.y, 3)],
+                center=[round(shape.centroid.x, 3), round(shape.centroid.y, 3)],
                 area=round(real_area, 2)
             ))
             valid_room_count += 1
@@ -115,32 +124,55 @@ class GeometryService:
         return rooms
 
     def calibrate_walls(self, walls: List[Wall], detections: List[Any]) -> List[Wall]:
-        """
-        탐지된 문의 크기를 기준으로 이미지의 실제 벽 두께를 추정하고 보정합니다.
+        """벽 역할(외벽/내벽)을 추정해 현실적인 두께를 차등 적용.
+
+        한국 주거 기준: 외벽·세대간벽은 두껍고(~0.2m 콘크리트), 내부 칸막이는
+        얇다(~0.12m). 문 폭으로 기준 두께를 잡되, 건물 외곽(bbox 경계)에 있는 벽은
+        외벽으로 보고 두껍게, 안쪽 벽은 얇게.
         """
         if not walls:
             return []
 
-        # 문의 폭을 통해 벽 두께 추정
+        # 문의 폭으로 기준(외벽) 두께 추정 — 상식 범위(0.15~0.25m) 벗어나면 0.2m.
         door_px_widths = []
         for d in detections:
-            # DetectionDTO 구조에 따라 접근 (class_name 또는 class)
             label = getattr(d, 'class_name', getattr(d, 'class', None))
             if label == "door":
                 bx1, by1, bx2, by2 = d.bbox_xyxy
                 door_px_widths.append(min(abs(bx2 - bx1), abs(by2 - by1)))
-
         if door_px_widths:
-            avg_door_px = sum(door_px_widths) / len(door_px_widths)
-            estimated_thickness_m = avg_door_px * self.scale_ratio
-            # 상식적인 범위(10cm~40cm)를 벗어나면 20cm로 고정
-            wall_thickness_m = estimated_thickness_m if 0.1 <= estimated_thickness_m <= 0.4 else 0.2
+            est = (sum(door_px_widths) / len(door_px_widths)) * self.scale_ratio
+            exterior_t = est if 0.15 <= est <= 0.25 else 0.2
         else:
-            wall_thickness_m = 0.2
+            exterior_t = 0.2
+        interior_t = round(exterior_t * 0.6, 3)  # 내벽은 외벽의 ~60% (칸막이)
 
-        # 모든 벽의 두께 업데이트
+        # 건물 외곽 bbox + 경계 판정 margin (전체 extent 의 4%).
+        xs = [c for w in walls for c in (w.x1, w.x2)]
+        ys = [c for w in walls for c in (w.y1, w.y2)]
+        min_x, max_x, min_y, max_y = min(xs), max(xs), min(ys), max(ys)
+        margin = max(8.0, max(max_x - min_x, max_y - min_y) * 0.04)
+
+        ext_n = 0
         for wall in walls:
-            wall.thickness = round(wall_thickness_m, 3)
+            is_ext = self._wall_is_exterior(wall, min_x, max_x, min_y, max_y, margin)
+            wall.thickness = round(exterior_t, 3) if is_ext else interior_t
+            wall.role = "outer" if is_ext else "inner"
+            ext_n += 1 if is_ext else 0
 
-        logger.info(f"벽 두께 보정 완료: {wall_thickness_m:.3f}m")
+        logger.info(
+            "벽 두께 보정: 외벽 %.3fm(%d개) / 내벽 %.3fm(%d개)",
+            exterior_t, ext_n, interior_t, len(walls) - ext_n,
+        )
         return walls
+
+    @staticmethod
+    def _wall_is_exterior(w: Wall, min_x, max_x, min_y, max_y, margin: float) -> bool:
+        """벽이 건물 외곽(bbox 경계)에 평행하게 붙어 있으면 외벽으로 판정."""
+        dx, dy = abs(w.x2 - w.x1), abs(w.y2 - w.y1)
+        if dx >= dy:  # 수평 벽 → 위/아래 경계 근처면 외벽
+            y_mid = (w.y1 + w.y2) / 2.0
+            return abs(y_mid - min_y) <= margin or abs(y_mid - max_y) <= margin
+        # 수직 벽 → 좌/우 경계 근처면 외벽
+        x_mid = (w.x1 + w.x2) / 2.0
+        return abs(x_mid - min_x) <= margin or abs(x_mid - max_x) <= margin

--- a/backend/app/services/local_inference_service.py
+++ b/backend/app/services/local_inference_service.py
@@ -109,6 +109,21 @@ def run_local_inference(
             unet_out.get("wallProbOverlayPath"), mask_local_path, prob_map,
         )
 
+        # 4b) 사전 분석 priors — AI 서버가 채워주면 사용, 없으면 None → 백엔드 fallback.
+        # (rf-service contract: UnetOutput.ocrPriors / linePriors / roiTransform)
+        ocr_priors = _extract_priors_list(unet_out, "ocrPriors")
+        line_priors = _extract_priors_list(unet_out, "linePriors")
+        roi_transform = unet_out.get("roiTransform") if isinstance(
+            unet_out.get("roiTransform"), dict
+        ) else None
+        logger.info(
+            "local inference: priors job_id=%s ocr=%s lines=%s roi=%s",
+            job_id,
+            len(ocr_priors) if ocr_priors is not None else None,
+            len(line_priors) if line_priors is not None else None,
+            "yes" if roi_transform else "no",
+        )
+
         # 5) yolo 호출 (detections 는 inline list — 계약: output.detections[])
         logger.info("local inference: POST /inference/yolo job_id=%s", job_id)
         yolo_payload = _post_inference(
@@ -158,6 +173,9 @@ def run_local_inference(
             image_height_px=height_px,
             result_payload=result_payload,
             source_image_local_path=source_image_path,
+            ocr_priors=ocr_priors,
+            line_priors=line_priors,
+            roi_transform=roi_transform,
         )
     except Exception:
         # 실패하면 temp 정리하고 예외 다시 던짐 — 성공시엔 호출자 책임.
@@ -246,6 +264,24 @@ def _require_output(payload: dict[str, Any], *, task: str) -> dict[str, Any]:
             502,
         )
     return output
+
+
+def _extract_priors_list(
+    output: dict[str, Any], key: str
+) -> list[dict[str, Any]] | None:
+    """AI 응답의 priors 필드(`ocrPriors` / `linePriors`)를 list[dict] 로 정규화.
+
+    - 필드 없거나 list 가 아니면 None 반환 → 호출자가 fallback 결정.
+    - 각 항목은 BaseModel 인스턴스가 아니라 dict 이므로 그대로 통과.
+    """
+    raw = output.get(key)
+    if not isinstance(raw, list):
+        return None
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict):
+            out.append(item)
+    return out
 
 
 def _require_str(d: dict[str, Any], key: str) -> str:

--- a/backend/app/services/sagemaker_inference_service.py
+++ b/backend/app/services/sagemaker_inference_service.py
@@ -82,6 +82,11 @@ class InferenceResult:
     result_payload: dict[str, Any]      # 원본 result.json (디버깅/메트릭)
     # 원본 도면 이미지 (S3 에서 다운). OCR/선분 검출에 필요. 다운로드 실패 시 None.
     source_image_local_path: Path | None = None
+    # 사전 분석 priors — AI 서버가 같이 내려주면 채워짐. 없으면 None → 백엔드가 자체 fallback.
+    # 형식은 packages/contracts/inference.py 의 OcrPrior/LinePrior/RoiTransform 와 일치.
+    ocr_priors: list[dict[str, Any]] | None = None    # [{text, bbox:[x1,y1,x2,y2], confidence}]
+    line_priors: list[dict[str, Any]] | None = None   # [{x1,y1,x2,y2,angle_deg?,length_px?}]
+    roi_transform: dict[str, Any] | None = None       # {offset_x, offset_y, width, height}
 
     def cleanup(self) -> None:
         try:

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -345,8 +345,10 @@ def save_scene_draft(
                 room_meta["dimension_spans"] = room_span
             db.add(
                 DraftRoom(
+                    # 표시용 이름은 의미있는 name(예: "화장실")만. 없으면 None
+                    # (room_0 같은 내부 id 를 라벨로 노출하지 않음).
                     scene_draft_id=scene_draft.id,
-                    room_name=str(room.get("id")) if room.get("id") is not None else None,
+                    room_name=(str(room["name"]) if room.get("name") else None),
                     room_type=room.get("type"),
                     source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
                     polygon_geom=room_polygon_geom(room, scale_ratio),
@@ -416,6 +418,13 @@ def save_scene_draft(
 
         for obj in request_dto.scene.objects:
             obj_type = obj.get("class_name") or obj.get("type") or "unknown"
+            # width_m/height_m 를 metadata_json 최상위에 둠 → 프론트 readObjectSize 가
+            # 이 값으로 실제 크기 렌더 (없으면 1.6m 기본). bbox×scale 로 fusion 이 채움.
+            obj_meta: dict[str, Any] = {"raw": obj}
+            if obj.get("width_m") is not None:
+                obj_meta["width_m"] = obj.get("width_m")
+            if obj.get("height_m") is not None:
+                obj_meta["height_m"] = obj.get("height_m")
             db.add(
                 DraftObject(
                     scene_draft_id=scene_draft.id,
@@ -423,7 +432,7 @@ def save_scene_draft(
                     confidence=_to_float(obj.get("score") or obj.get("confidence")),
                     source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
                     point_geom=object_point_geom(obj, scale_ratio),
-                    metadata_json={"raw": obj},
+                    metadata_json=obj_meta,
                 )
             )
 

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -137,6 +137,72 @@ def _build_wall_dimension_match_map(
     return result
 
 
+def _build_span_maps(
+    walls: list[dict],
+    rooms: list[dict],
+    postprocess_metadata: dict | None,
+    scale_ratio: float,
+) -> tuple[dict[int, dict], dict[int, dict]]:
+    """치수선 세그먼트를 구간(span) 으로 해석해 (벽 길이 맵, 방 가로/세로 맵) 반환.
+
+    벽: 평행 치수(세로벽↔세로치수, 가로벽↔가로치수) 를 IoU 로 매칭한 '도면 길이'.
+    방: 가로/세로 범위에 맞는 치수.
+    치수 텍스트가 벽에서 멀어 직접 매칭(`match_dimensions_to_walls`) 이 실패해도,
+    scale 로 세그먼트 픽셀 길이를 복원하므로 동작한다 (OCR/fallback scale 무관).
+    """
+    empty: tuple[dict, dict] = ({}, {})
+    if not postprocess_metadata or not walls:
+        return empty
+    raw_matches = postprocess_metadata.get("dimension_matches") or []
+    if not raw_matches:
+        return empty
+
+    # scale: OCR 추정값 우선, 없으면 geom 변환에 쓴 scale_ratio.
+    scale_est = postprocess_metadata.get("scale_estimate") or {}
+    scale = scale_est.get("scale_m_per_px") or scale_ratio
+    if not scale or scale <= 0:
+        return empty
+
+    try:
+        from app.services.wall_extraction_helpers import dimension_matching
+        from app.services.wall_extraction_helpers.ocr import OCREntry
+    except Exception:
+        return empty
+
+    wall_px: list[list[float]] = []
+    for w in walls:
+        try:
+            wall_px.append([float(w["x1"]), float(w["y1"]), float(w["x2"]), float(w["y2"])])
+        except (KeyError, TypeError, ValueError):
+            wall_px.append([0.0, 0.0, 0.0, 0.0])
+
+    entries = []
+    for m in raw_matches:
+        try:
+            bbox = tuple(int(v) for v in m.get("bbox", []))
+            if len(bbox) != 4:
+                continue
+            entries.append(
+                OCREntry(
+                    bbox=bbox,  # type: ignore[arg-type]
+                    text=str(m.get("text", "")),
+                    confidence=float(m.get("ocr_confidence", 0.0)),
+                )
+            )
+        except Exception:
+            continue
+    if not entries:
+        return empty
+
+    spans = dimension_matching.build_dimension_spans(entries, float(scale), wall_px)
+    if not spans:
+        return empty
+    # 벽: 평행 치수(자기 길이) 매칭. 방: 가로/세로 치수.
+    wall_len_map = dimension_matching.attach_wall_lengths_parallel(spans, wall_px)
+    room_span_map = dimension_matching.attach_spans_to_rooms(spans, rooms or [])
+    return wall_len_map, room_span_map
+
+
 def _resolve_project_floor(
     db: Session,
     project_id: str | None,
@@ -230,11 +296,16 @@ def save_scene_draft(
         db, request_dto.project_id, request_dto.floor_id, current_user,
     )
 
+    scale_ratio = float(request_dto.scene.scale_ratio or 1.0)
+
     summary_json: dict[str, Any] = {
         "source": DEFAULT_DRAFT_SOURCE,
         "analysis_method": DEFAULT_DRAFT_ANALYSIS_METHOD,
         "raw_result_version": request_dto.scene.scene_version,
         "storage": request_dto.upload.model_dump(),
+        # geom 변환에 쓴 최종 scale (m/px). OCR 추정/기본 fallback 무관하게 항상 기록.
+        # 프론트가 배경 도면 이미지를 미터 좌표에 정렬할 때 사용 (imageDims_px × scale).
+        "scale_ratio_m_per_px": scale_ratio,
     }
     if request_dto.scene.inference_metadata:
         summary_json["inference_metadata"] = request_dto.scene.inference_metadata
@@ -252,13 +323,24 @@ def save_scene_draft(
         created_by=request_dto.created_by or current_user.email,
     )
 
-    scale_ratio = float(request_dto.scene.scale_ratio or 1.0)
-
     try:
         db.add(scene_draft)
         db.flush()
 
-        for room in request_dto.scene.rooms:
+        # 치수선 세그먼트를 구간(span) 으로 해석 → 벽 평행 길이 + 방 가로/세로 치수.
+        # (치수선이 벽에서 멀어 직접 매칭이 안 되는 도면도 scale 로 복원해 부착)
+        wall_len_map, room_span_map = _build_span_maps(
+            request_dto.scene.walls,
+            request_dto.scene.rooms,
+            request_dto.scene.postprocess_metadata,
+            scale_ratio,
+        )
+
+        for room_idx, room in enumerate(request_dto.scene.rooms):
+            room_meta: dict[str, Any] = {"raw": room}
+            room_span = room_span_map.get(room_idx)
+            if room_span:
+                room_meta["dimension_spans"] = room_span
             db.add(
                 DraftRoom(
                     scene_draft_id=scene_draft.id,
@@ -267,7 +349,7 @@ def save_scene_draft(
                     source_method=DEFAULT_DRAFT_ANALYSIS_METHOD,
                     polygon_geom=room_polygon_geom(room, scale_ratio),
                     centroid_geom=room_centroid_geom(room, scale_ratio),
-                    metadata_json={"raw": room},
+                    metadata_json=room_meta,
                 )
             )
 
@@ -284,6 +366,9 @@ def save_scene_draft(
             dim_match = wall_dim_matches.get(idx)
             if dim_match is not None:
                 wall_meta["dimension_match"] = dim_match
+            wall_len = wall_len_map.get(idx)
+            if wall_len:
+                wall_meta["dimension_length"] = wall_len
 
             draft_wall = DraftWall(
                 scene_draft_id=scene_draft.id,

--- a/backend/app/services/scene_draft_service.py
+++ b/backend/app/services/scene_draft_service.py
@@ -197,8 +197,10 @@ def _build_span_maps(
     spans = dimension_matching.build_dimension_spans(entries, float(scale), wall_px)
     if not spans:
         return empty
-    # 벽: 평행 치수(자기 길이) 매칭. 방: 가로/세로 치수.
-    wall_len_map = dimension_matching.attach_wall_lengths_parallel(spans, wall_px)
+    # 벽: 평행 치수(자기 길이) 매칭 + scale 로 실제 길이 검증. 방: 가로/세로 치수.
+    wall_len_map = dimension_matching.attach_wall_lengths_parallel(
+        spans, wall_px, float(scale)
+    )
     room_span_map = dimension_matching.attach_spans_to_rooms(spans, rooms or [])
     return wall_len_map, room_span_map
 

--- a/backend/app/services/wall_extraction.py
+++ b/backend/app/services/wall_extraction.py
@@ -119,7 +119,7 @@ class WallExtractor:
         return clean
 
     # ── 2. Skeleton ───────────────────────────────────────────────────────
-    def _skeletonize(self, edges: np.ndarray, prob_map=None, debug_dir: Path | None = None) -> np.ndarray:
+    def _skeletonize(self, edges: np.ndarray, prob_map=None, conf_floor: float = 0.4, debug_dir: Path | None = None) -> np.ndarray:
         from skimage.morphology import thin
 
         num_labels, labels, stats, _ = cv2.connectedComponentsWithStats(edges)
@@ -133,9 +133,11 @@ class WallExtractor:
         binary = (clean > 0).astype(bool)
         thinned = thin(binary).astype(np.uint8) * 255
 
-        # prob_map 있으면 저확률 픽셀 제거
+        # prob_map 있으면 저확률 픽셀 제거. conf_floor 는 **선택된 threshold** 를 받음.
+        # (예전엔 0.4 하드코딩 → mask 가 prob>thr(예 0.25)여도 prob 0.25~0.4 벽은 여기서
+        #  지워져 "빨강인데 선 안 됨". 이제 mask 와 같은 floor 라 일관됨.)
         if prob_map is not None:
-            conf_mask = (prob_map > 0.4)
+            conf_mask = (prob_map > conf_floor)
             thinned = ((thinned > 0) & conf_mask).astype(np.uint8) * 255
 
         out_dir = self._resolve_debug_dir(debug_dir)
@@ -637,8 +639,8 @@ class WallExtractor:
 
         wall_thickness = self.estimate_wall_thickness(edges, detections or [])
 
-        # 2. 확률 가중 스켈레톤
-        skeleton = self._skeletonize(edges, prob_map=prob, debug_dir=debug_dir)
+        # 2. 확률 가중 스켈레톤 — conf_floor 를 선택된 threshold 에 맞춤 (숨은 0.4 게이트 제거).
+        skeleton = self._skeletonize(edges, prob_map=prob, conf_floor=float(thr), debug_dir=debug_dir)
 
         raw_lines = self._detect_lines(skeleton)
         hv_lines  = self._filter_hv(raw_lines)
@@ -649,8 +651,9 @@ class WallExtractor:
         snapped   = self._snap_endpoints(snapped, tol=20.0)
         filtered  = self._filter_short(snapped, skeleton.shape)
         
-        # 3. 신뢰도 필터 (완화: 0.6 → 0.4. mask 자체가 이미 prob>thr 로 1차 필터된 상태)
-        filtered  = self._filter_by_confidence(filtered, prob, min_conf=0.4)
+        # 3. 신뢰도 필터 — min_conf 를 선택된 threshold 에 맞춤. mask 가 이미 prob>thr 로
+        #    1차 필터된 상태라 동일 floor 로 두어 "마스크엔 있는데 여기서 또 떨궈지는" 이중 게이팅 방지.
+        filtered  = self._filter_by_confidence(filtered, prob, min_conf=float(thr))
 
         filled = self._fill_opening_gaps(filtered, detections or [])
         filled = self._merge_lines(filled, pos_thresh=int(wall_thickness * 3.0))

--- a/backend/app/services/wall_extraction.py
+++ b/backend/app/services/wall_extraction.py
@@ -18,7 +18,8 @@ class PostprocessMetadata:
     threshold_candidates: list[float] = field(default_factory=list)
     scores: list[dict] = field(default_factory=list)  # ThresholdScore.to_dict()
     ocr_regions_count: int = 0
-    line_segments_count: int = 0
+    line_segments_count: int = 0       # 벽 점수에 실제 사용된 wall_candidate 선분 수
+    dimension_lines_excluded: int = 0  # 치수선으로 분류돼 벽 후보에서 제외된 선분 수
     # OCR 진단용 원본 entries (각 항목: text/bbox/confidence/parsed_meters/parse_confidence).
     # "OCR 자체 실패" vs "OCR 성공했지만 parser 가 거부" vs "parse 됐지만 매칭 실패" 분리용.
     ocr_entries: list[dict] = field(default_factory=list)
@@ -29,6 +30,22 @@ class PostprocessMetadata:
     fallback_reason: str | None = None   # applied=False 일 때 사유
     debug_dir: str | None = None         # per-job 디버그 이미지 디렉토리 (있을 때)
 
+    # Priors source tracking — None vs [] 구분.
+    # "ai_service"        : AI 가 priors 제공 (빈 list 든 채워진 list 든)
+    # "backend_fallback"  : AI 가 안 줘서 backend 가 자체 OCR/line 실행
+    # "none"              : 둘 다 못 함 (image_path 없거나 실패)
+    ocr_priors_source: str = "none"
+    line_priors_source: str = "none"
+    fallback_used: bool = False           # 둘 중 하나라도 backend_fallback 이면 True
+
+    # 좌표계 진단 — 배경 이미지 ↔ 벽 정렬 디버깅용.
+    # prob_map 원본 shape, source image shape, 좌표 통일 resize 여부.
+    # 이미지가 벽과 어긋나면 여기서 dims 불일치/resize 누락 확인.
+    prob_shape: list[int] | None = None      # [H, W] of loaded prob_map (resize 전)
+    image_shape: list[int] | None = None     # [H, W] of source image (Phase A 에서 읽음)
+    coord_resized: bool = False              # prob_map → image dims resize 발생 여부
+    coord_aligned: bool = False              # 최종 prob 이 image 좌표계와 정렬됐는지
+
     def to_dict(self) -> dict:
         return {
             "applied": self.applied,
@@ -37,12 +54,20 @@ class PostprocessMetadata:
             "scores": list(self.scores),
             "ocr_regions_count": self.ocr_regions_count,
             "line_segments_count": self.line_segments_count,
+            "dimension_lines_excluded": self.dimension_lines_excluded,
             "ocr_entries": list(self.ocr_entries),
             "dimension_entries_count": self.dimension_entries_count,
             "dimension_matches": list(self.dimension_matches),
             "scale_estimate": self.scale_estimate,
             "fallback_reason": self.fallback_reason,
             "debug_dir": self.debug_dir,
+            "ocr_priors_source": self.ocr_priors_source,
+            "line_priors_source": self.line_priors_source,
+            "fallback_used": self.fallback_used,
+            "prob_shape": self.prob_shape,
+            "image_shape": self.image_shape,
+            "coord_resized": self.coord_resized,
+            "coord_aligned": self.coord_aligned,
         }
 
 
@@ -518,6 +543,8 @@ class WallExtractor:
         detections: List[Any] = None,
         image_path: Path | None = None,
         debug_dir: Path | None = None,
+        ocr_priors: list[dict] | None = None,
+        line_priors: list[dict] | None = None,
     ) -> WallExtractionResult:
         """U-Net wall probability map → walls + postprocess metadata.
 
@@ -525,6 +552,11 @@ class WallExtractor:
           1. `threshold` 인자가 명시되면 그 값 사용
           2. `image_path` 가 있으면 multi-threshold + OCR/선분 정합도 기반 best 선택 (§69)
           3. 그 외 → Otsu fallback
+
+        priors:
+          - `ocr_priors`/`line_priors` 가 제공되면 자체 OCR/line 검출 건너뛰고 그대로 사용.
+          - None 이면 fallback 으로 `image_path` 기반 내부 추출.
+          - AI 측에서 priors 를 채워주는 흐름(Phase 2)으로 가면 이 path 가 primary.
 
         반환: `WallExtractionResult` (walls + PostprocessMetadata). 호출자가 metadata
         를 `summary_json` 영속화 / 응답 / 디버깅에 활용.
@@ -538,20 +570,57 @@ class WallExtractor:
         # image_path 가 있으면 prob_map 을 원본 이미지 크기로 미리 resize 해서
         # 모든 downstream 처리(mask, skeleton, walls, OCR, dimension match)가 동일
         # 이미지 좌표계에서 동작하도록 보장.
+        #
+        # ⚠ 정렬 핵심: prob_map 은 반드시 source image dims 로 와야 프론트가 같은
+        # scale 로 배경 이미지를 겹쳤을 때 정확. image_path 를 못 읽으면 (download
+        # 실패 등) resize 가 스킵돼 prob dims ≠ image dims → 배경 이미지 어긋남.
+        _diag_prob_shape = [int(prob.shape[0]), int(prob.shape[1])]
+        _diag_image_shape: list[int] | None = None
+        _diag_resized = False
+        _diag_aligned = False
         if image_path is not None and Path(image_path).exists():
             img_for_dims = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
             if img_for_dims is not None:
                 h_img, w_img = img_for_dims.shape
+                _diag_image_shape = [int(h_img), int(w_img)]
                 h_prob, w_prob = prob.shape
                 if (h_img, w_img) != (h_prob, w_prob):
                     prob = cv2.resize(
                         prob.astype(np.float32), (w_img, h_img),
                         interpolation=cv2.INTER_LINEAR,
                     )
+                    _diag_resized = True
+                _diag_aligned = True  # prob 이 image 좌표계와 정렬됨 (resize 했거나 이미 동일)
+                import logging
+                logging.getLogger(__name__).info(
+                    "coord align: prob %s → image %s (resized=%s)",
+                    _diag_prob_shape, _diag_image_shape, _diag_resized,
+                )
+            else:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "coord align: image_path 읽기 실패 → prob dims 유지, 배경 정렬 어긋날 수 있음: %s",
+                    image_path,
+                )
+        else:
+            import logging
+            logging.getLogger(__name__).warning(
+                "coord align: image_path 없음 → prob dims 유지, 배경 정렬 어긋날 수 있음",
+            )
 
         # 1. threshold 결정 (+ metadata 동시 빌드, OCR entries 보존)
         # 이 시점의 prob 는 이미 image 좌표계에 정렬되어 있음.
-        meta, ocr_entries = self._pick_threshold(prob, threshold, image_path)
+        # priors 가 제공되면 _pick_threshold 가 자체 OCR/line 검출 대신 그걸 사용.
+        meta, ocr_entries = self._pick_threshold(
+            prob, threshold, image_path,
+            ocr_priors=ocr_priors,
+            line_priors=line_priors,
+        )
+        # 좌표계 진단값 기록
+        meta.prob_shape = _diag_prob_shape
+        meta.image_shape = _diag_image_shape
+        meta.coord_resized = _diag_resized
+        meta.coord_aligned = _diag_aligned
         if meta.debug_dir is None and debug_dir is not None:
             meta.debug_dir = str(debug_dir)
         if meta.selected_threshold is None:
@@ -615,16 +684,40 @@ class WallExtractor:
 
         self._save_debug(skeleton, result, detections or [], debug_dir=debug_dir)
 
-        # 4. 치수 OCR ↔ 추출된 벽 매칭 → scale 추정 (real_width_m fallback 용).
-        if ocr_entries and result:
+        # 4. Scale 추정 — 우선순위:
+        #    (a0) anchored 교차검증: 긴 기준선(체인 전체 span + 벽 외곽 anchor) cluster 합의.
+        #         짧은 tick 노이즈에 강함 → 가장 신뢰. (벽 결과 있으면 외곽 anchor 도 사용)
+        #    (a) tick-interval: 인접 OCR 치수 중심 거리. anchored 실패 시 fallback.
+        #    (b) wall-length fallback: 둘 다 실패하면 OCR ↔ 벽 길이 매칭. (legacy)
+        if ocr_entries:
             try:
                 from app.services.wall_extraction_helpers import dimension_matching
 
-                matches = dimension_matching.match_dimensions_to_walls(
-                    ocr_entries, result,
+                # (a0) Anchored 교차검증 (긴 기준선 cluster 합의)
+                est = dimension_matching.estimate_scale_crossvalidated(
+                    ocr_entries, result if result else None,
                 )
-                meta.dimension_matches = [m.to_dict() for m in matches]
-                est = dimension_matching.estimate_scale_from_matches(matches)
+
+                # (a) Fallback: tick-interval (인접 페어)
+                if est is None:
+                    pairs = dimension_matching.find_dimension_interval_pairs(ocr_entries)
+                    est = dimension_matching.estimate_scale_from_intervals(pairs)
+
+                # (b) Fallback: wall-length 매칭 (벽 결과 있고 위 모두 실패한 경우만)
+                if est is None and result:
+                    matches = dimension_matching.match_dimensions_to_walls(
+                        ocr_entries, result,
+                    )
+                    meta.dimension_matches = [m.to_dict() for m in matches]
+                    est = dimension_matching.estimate_scale_from_matches(matches)
+                elif est is not None:
+                    # tick-interval 성공 시에도 wall-length 매칭은 metadata 진단용으로 같이 채움
+                    if result:
+                        matches = dimension_matching.match_dimensions_to_walls(
+                            ocr_entries, result,
+                        )
+                        meta.dimension_matches = [m.to_dict() for m in matches]
+
                 if est is not None:
                     meta.scale_estimate = est.to_dict()
             except Exception as exc:
@@ -640,18 +733,23 @@ class WallExtractor:
         prob: np.ndarray,
         explicit: float | None,
         image_path: Path | None,
+        ocr_priors: list[dict] | None = None,
+        line_priors: list[dict] | None = None,
     ) -> tuple[PostprocessMetadata, list]:
         """§69 multi-threshold scoring 으로 best 선택 + 치수 매칭 입력 자료 보존.
 
+        priors:
+          - AI 서버가 OCR/line 결과를 같이 내려준 경우 (ocr_priors / line_priors 채워짐)
+            → 자체 OCR/line 검출 건너뛰고 그대로 scoring 에 사용.
+          - None 이면 fallback 으로 image_path 기반 자체 추출 (legacy).
+
         반환: `(PostprocessMetadata, ocr_entries)` — ocr_entries 는 후속 dimension
         매칭에 재사용. scoring 비활성이면 빈 리스트.
-
-          - `applied=True` & `selected_threshold` 설정: scoring 완료
-          - `applied=False`: scoring 비활성 — 호출자가 explicit 값 또는 Otsu fallback 사용
         """
         from app.services.wall_extraction_helpers.threshold_scoring import (
             DEFAULT_THRESHOLDS,
         )
+        from app.services.wall_extraction_helpers.ocr import OCREntry
 
         meta = PostprocessMetadata(
             applied=False,
@@ -696,21 +794,61 @@ class WallExtractor:
         else:
             prob_resized = prob
 
-        # OCR — 텍스트 보존된 entries (치수 매칭 + 페널티 양쪽 쓰임).
-        ocr_entries = []
-        text_mask = None
-        try:
-            ocr_entries = ocr.detect_text_entries(image_path)
+        # ── OCR entries 결정: priors > 자체 추출 ───────────────────────────
+        # None: AI 가 안 줌 → backend fallback
+        # []  : AI 가 줬는데 비어있음 → backend fallback 안 함 (디버깅 명확성)
+        ocr_entries: list = []
+        if ocr_priors is not None:
+            # AI 서버에서 받은 priors 사용. dict → OCREntry 재구성.
+            # (parsed_value_m / kind 같은 추가 필드도 보존하고 싶으면 OCREntry 확장 필요.
+            # 지금은 text/bbox/confidence 만 OCREntry 가 다루므로 그대로 매핑.)
+            for p in ocr_priors:
+                try:
+                    bbox_raw = p.get("bbox", [])
+                    bbox = tuple(int(round(float(v))) for v in bbox_raw)
+                    if len(bbox) != 4:
+                        continue
+                    ocr_entries.append(
+                        OCREntry(
+                            bbox=bbox,  # type: ignore[arg-type]
+                            text=str(p.get("text", "")),
+                            confidence=float(p.get("confidence") or 0.0),
+                        )
+                    )
+                except (TypeError, ValueError):
+                    continue
             meta.ocr_regions_count = len(ocr_entries)
-            text_mask = ocr.build_text_mask(
-                [e.bbox for e in ocr_entries], prob_resized.shape, pad=3,
-            )
-        except Exception as exc:
-            import logging
-            logging.getLogger(__name__).warning("OCR 추출 실패: %s", exc)
+            meta.ocr_priors_source = "ai_service"
+        else:
+            try:
+                ocr_entries = ocr.detect_text_entries(image_path)
+                meta.ocr_regions_count = len(ocr_entries)
+                meta.ocr_priors_source = "backend_fallback"
+                meta.fallback_used = True
+            except Exception as exc:
+                import logging
+                logging.getLogger(__name__).warning("OCR 추출 실패: %s", exc)
+                meta.ocr_priors_source = "none"
+
+        # ocr_penalty(텍스트 위 벽 = 감점) 용 text_mask 는 **신뢰도 높은 OCR 만** 사용.
+        # strip/회전으로 늘어난 저신뢰 깨진 글자까지 넣으면 text_mask 가 부풀어
+        # ocr_penalty 가 threshold 를 과하게 올리고 강한 외벽까지 깨던 회귀 방지.
+        # (scale/span/치수 매칭은 parsed dim 을 쓰므로 이 필터와 무관 — 기능 유지)
+        TEXT_MASK_MIN_CONF = 0.5
+        text_mask = None
+        if ocr_entries:
+            try:
+                confident_bboxes = [
+                    e.bbox for e in ocr_entries if e.confidence >= TEXT_MASK_MIN_CONF
+                ]
+                text_mask = (
+                    ocr.build_text_mask(confident_bboxes, prob_resized.shape, pad=3)
+                    if confident_bboxes else None
+                )
+            except Exception:
+                text_mask = None
 
         # 진단용: 각 OCR entry 의 raw text + bbox + conf + parse 결과를 metadata 에 보관.
-        # "OCR 실패" / "parser 거부" / "parse 됐지만 매칭 실패" 를 분리해 추적 가능.
         ocr_entries_dump: list[dict] = []
         dim_entries = []
         for e in ocr_entries:
@@ -732,17 +870,51 @@ class WallExtractor:
         meta.ocr_entries = ocr_entries_dump
         meta.dimension_entries_count = len(dim_entries)
 
+        # ── Line priors 결정: priors > 자체 추출 ──────────────────────────
+        # None: AI 가 안 줌 → backend fallback
+        # []  : AI 가 줬는데 비어있음 → backend fallback 안 함
         line_mask = None
-        try:
-            segs = line_detection.detect_line_segments(image_path)
-            meta.line_segments_count = int(len(segs))
-            line_mask = (
-                line_detection.build_line_mask(segs, prob_resized.shape, thickness=3)
-                if len(segs) > 0 else None
+        if line_priors is not None:
+            import numpy as _np
+            # threshold scoring 의 line_alignment 에는 wall_candidate 만 사용한다.
+            # AI 가 dimension_line / tick 으로 분류한 선분(치수선)은 벽 점수에서 제외.
+            # kind 미지정 선분은 하위호환을 위해 wall_candidate 로 간주.
+            wall_segs = [
+                p for p in line_priors
+                if all(k in p for k in ("x1", "y1", "x2", "y2"))
+                and p.get("kind", "wall_candidate") == "wall_candidate"
+            ]
+            meta.dimension_lines_excluded = int(
+                sum(1 for p in line_priors if p.get("kind") == "dimension_line")
             )
-        except Exception as exc:
-            import logging
-            logging.getLogger(__name__).warning("line detection 실패: %s", exc)
+            segs_arr = _np.array([
+                [int(round(float(p["x1"]))), int(round(float(p["y1"]))),
+                 int(round(float(p["x2"]))), int(round(float(p["y2"])))]
+                for p in wall_segs
+            ], dtype=_np.int32) if wall_segs else _np.empty((0, 4), dtype=_np.int32)
+            meta.line_segments_count = int(len(segs_arr))
+            meta.line_priors_source = "ai_service"
+            if len(segs_arr) > 0:
+                try:
+                    line_mask = line_detection.build_line_mask(
+                        segs_arr, prob_resized.shape, thickness=3,
+                    )
+                except Exception:
+                    line_mask = None
+        else:
+            try:
+                segs = line_detection.detect_line_segments(image_path)
+                meta.line_segments_count = int(len(segs))
+                line_mask = (
+                    line_detection.build_line_mask(segs, prob_resized.shape, thickness=3)
+                    if len(segs) > 0 else None
+                )
+                meta.line_priors_source = "backend_fallback"
+                meta.fallback_used = True
+            except Exception as exc:
+                import logging
+                logging.getLogger(__name__).warning("line detection 실패: %s", exc)
+                meta.line_priors_source = "none"
 
         best_thr, scores = threshold_scoring.pick_best_threshold(
             prob_resized,

--- a/backend/app/services/wall_extraction_helpers/dimension_matching.py
+++ b/backend/app/services/wall_extraction_helpers/dimension_matching.py
@@ -48,15 +48,66 @@ class ParsedDimension:
     unit_hint: str     # "m" / "mm" / "cm" / "mm_comma" / "m_decimal"
 
 
+# 흔한 OCR 글자↔숫자 오인식 보정표 (치수 토큰 한정 적용).
+_OCR_DIGIT_MAP = str.maketrans({
+    "O": "0", "o": "0", "D": "0",
+    "I": "1", "l": "1", "|": "1",
+    "Z": "2", "z": "2",
+    "S": "5", "s": "5",
+    "B": "8",
+    "g": "9", "q": "9",
+    "b": "6",
+})
+
+
+def _normalize_ocr_digits(text: str) -> str | None:
+    """치수처럼 보이는(숫자 과반) 토큰의 글자↔숫자 오인식 보정.
+
+    예: "50O"→"500", "44OO"→"4400". 방 라벨('KITCHEN' 등 숫자 비율 낮음)은 제외.
+    보정이 일어난 경우만 결과 반환, 아니면 None.
+    """
+    if not text:
+        return None
+    s = text.strip()
+    alnum = [c for c in s if c.isalnum()]
+    if not alnum:
+        return None
+    digit_ratio = sum(c.isdigit() for c in alnum) / len(alnum)
+    if digit_ratio < 0.5:  # 숫자가 과반 아니면 치수로 안 봄 → 라벨 오변환 방지
+        return None
+    normalized = s.translate(_OCR_DIGIT_MAP)
+    return normalized if normalized != s else None
+
+
 def parse_dimension_to_meters(text: str) -> ParsedDimension | None:
-    """OCR 텍스트에서 미터 단위 길이 추출. 인식 안되면 None.
+    """OCR 텍스트 → 미터 길이. raw 실패 시 숫자 오인식 보정 후 재시도.
 
     인식 규칙:
-      - "3500mm" / "350cm" / "3.5m" → 명시된 단위로 직접 변환 (confidence=1.0)
-      - "3,500" → 한국 도면 mm 표기로 가정 (confidence=0.5)
+      - "3500mm" / "350cm" / "3.5m" → 명시 단위 직접 변환 (confidence=1.0)
+      - "3,500" → 한국 도면 mm 가정 (confidence=0.5)
       - "3.5" → m 가정 (confidence=0.5)
-      - 단순 정수 (e.g. "350") → 단위 추정 위험 → 거부
+      - "3500" → mm 가정 (confidence=0.3)
+      - 위 모두 실패 + 숫자 과반이면 O→0 등 보정 후 재시도 (confidence ×0.8, "_ocrfix")
     """
+    if not text or not isinstance(text, str):
+        return None
+    parsed = _parse_dimension_raw(text)
+    if parsed is not None:
+        return parsed
+    fixed = _normalize_ocr_digits(text)
+    if fixed is not None:
+        parsed = _parse_dimension_raw(fixed)
+        if parsed is not None:
+            return ParsedDimension(
+                meters=parsed.meters,
+                confidence=round(parsed.confidence * 0.8, 3),
+                unit_hint=parsed.unit_hint + "_ocrfix",
+            )
+    return None
+
+
+def _parse_dimension_raw(text: str) -> ParsedDimension | None:
+    """보정 없이 원문 그대로 파싱 (parse_dimension_to_meters 내부용)."""
     if not text or not isinstance(text, str):
         return None
 
@@ -275,6 +326,186 @@ def match_dimensions_to_walls(
 
 
 @dataclass
+class IntervalScalePair:
+    """인접한 두 OCR 치수 텍스트의 중심 사이 픽셀 거리 ↔ 평균 meters 페어.
+
+    수식: 두 인접 치수 라벨 (m1, m2) 사이 텍스트 중심 픽셀 거리 (dx) 는
+      dx = (segment1_px + segment2_px) / 2
+         = (m1 + m2) / 2  *  pixels_per_meter
+    따라서:
+      implied_scale_m_per_px = (m1 + m2) / (2 * dx)
+    """
+    text_a: str
+    text_b: str
+    meters_a: float
+    meters_b: float
+    bbox_a: tuple[float, float, float, float]
+    bbox_b: tuple[float, float, float, float]
+    center_distance_px: float
+    orientation: str  # "horizontal" / "vertical"
+    implied_scale_m_per_px: float
+    parse_confidence_avg: float
+
+    def to_dict(self) -> dict:
+        return {
+            "text_a": self.text_a,
+            "text_b": self.text_b,
+            "meters_a": round(self.meters_a, 4),
+            "meters_b": round(self.meters_b, 4),
+            "bbox_a": [round(v, 2) for v in self.bbox_a],
+            "bbox_b": [round(v, 2) for v in self.bbox_b],
+            "center_distance_px": round(self.center_distance_px, 2),
+            "orientation": self.orientation,
+            "implied_scale_m_per_px": round(self.implied_scale_m_per_px, 6),
+            "parse_confidence_avg": round(self.parse_confidence_avg, 3),
+        }
+
+
+def find_dimension_interval_pairs(
+    entries,  # list[OCREntry]
+    same_line_tolerance_px: float = 60.0,
+    min_center_distance_px: float = 20.0,
+) -> list[IntervalScalePair]:
+    """치수 OCR 들을 같은 dimension line 끼리 그룹핑 → 인접 쌍에서 scale 추출.
+
+    1. 각 entry 의 bbox 방향(H/V)으로 분리
+    2. H 그룹: y_center 가 비슷한 (±tolerance) 항목끼리 같은 라인. x_center 로 정렬.
+    3. 같은 라인의 인접한 두 항목 (a, b) → 중심 거리 dx → implied_scale 계산
+    4. V 그룹: 마찬가지로 x_center 비슷, y_center 정렬
+
+    좌표계 독립: entries 의 bbox 가 어느 space (source_image / roi_image) 에 있든
+    동일 space 안에서 dx 비교만 하므로 변환 불필요.
+    """
+    pairs: list[IntervalScalePair] = []
+
+    horizontal: list = []
+    vertical: list = []
+    for e in entries or []:
+        parsed = parse_dimension_to_meters(e.text)
+        if parsed is None or parsed.meters <= 0:
+            continue
+        bbox = e.bbox
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        # 가로로 길면 H, 세로로 길면 V (정사각형 가까우면 H 우선)
+        if w >= h:
+            horizontal.append((e, parsed, bbox))
+        else:
+            vertical.append((e, parsed, bbox))
+
+    def _process(group, axis: str):
+        """axis = 'h' (수평 dimension line, x 따라 정렬) or 'v' (수직, y 따라)."""
+        if len(group) < 2:
+            return
+        if axis == "h":
+            # 같은 라인: y_center 끼리 비슷. 정렬은 x_center.
+            key_along = lambda b: (b[0] + b[2]) / 2  # x_center
+            key_across = lambda b: (b[1] + b[3]) / 2  # y_center
+            orient = "horizontal"
+        else:
+            key_along = lambda b: (b[1] + b[3]) / 2  # y_center
+            key_across = lambda b: (b[0] + b[2]) / 2  # x_center
+            orient = "vertical"
+
+        # 같은 라인끼리 모으기 (across 좌표를 tolerance 단위로 양자화 → 버킷)
+        buckets: dict[int, list] = {}
+        for item in group:
+            _e, _p, bbox = item
+            across = key_across(bbox)
+            bucket_key = int(round(across / same_line_tolerance_px))
+            buckets.setdefault(bucket_key, []).append(item)
+
+        for bucket_items in buckets.values():
+            if len(bucket_items) < 2:
+                continue
+            # along 좌표 기준 정렬
+            bucket_items.sort(key=lambda it: key_along(it[2]))
+            # 인접 쌍 walk
+            for i in range(len(bucket_items) - 1):
+                ea, pa, ba = bucket_items[i]
+                eb, pb, bb = bucket_items[i + 1]
+                ca = key_along(ba)
+                cb = key_along(bb)
+                dx = cb - ca
+                if dx < min_center_distance_px:
+                    continue
+                # 부호 검증 (정렬돼 있으므로 양수여야 함)
+                if dx <= 0:
+                    continue
+                m_avg_half = (pa.meters + pb.meters) / 2.0
+                if m_avg_half <= 0:
+                    continue
+                implied = m_avg_half / dx
+                pairs.append(
+                    IntervalScalePair(
+                        text_a=ea.text,
+                        text_b=eb.text,
+                        meters_a=pa.meters,
+                        meters_b=pb.meters,
+                        bbox_a=tuple(float(v) for v in ba),  # type: ignore[arg-type]
+                        bbox_b=tuple(float(v) for v in bb),  # type: ignore[arg-type]
+                        center_distance_px=float(dx),
+                        orientation=orient,
+                        implied_scale_m_per_px=float(implied),
+                        parse_confidence_avg=(pa.confidence + pb.confidence) / 2.0,
+                    )
+                )
+
+    _process(horizontal, "h")
+    _process(vertical, "v")
+
+    if pairs:
+        logger.info(
+            "dimension intervals: %d pairs (h=%d, v=%d)",
+            len(pairs),
+            sum(1 for p in pairs if p.orientation == "horizontal"),
+            sum(1 for p in pairs if p.orientation == "vertical"),
+        )
+    return pairs
+
+
+def estimate_scale_from_intervals(
+    pairs: list[IntervalScalePair],
+    min_pairs: int = 2,
+    mad_factor: float = 3.0,
+) -> "ScaleEstimate | None":
+    """tick-interval pairs 에서 median + MAD outlier 제거로 scale 추정.
+
+    `min_pairs=2` 가 기본 — 인접 페어가 2 개만 있어도 시도. 잘못된 단위 추정은 MAD 가
+    걸러주는 구조라 wall-length 매칭보다 페어 적어도 안정적.
+    """
+    valid = [p for p in pairs if p.implied_scale_m_per_px > 0]
+    if len(valid) < min_pairs:
+        return None
+
+    vals = sorted(p.implied_scale_m_per_px for p in valid)
+    n = len(vals)
+    med = vals[n // 2] if n % 2 == 1 else 0.5 * (vals[n // 2 - 1] + vals[n // 2])
+    abs_dev = sorted(abs(v - med) for v in vals)
+    mad = abs_dev[n // 2] if n % 2 == 1 else 0.5 * (abs_dev[n // 2 - 1] + abs_dev[n // 2])
+
+    if mad == 0:
+        kept = valid
+    else:
+        kept = [p for p in valid if abs(p.implied_scale_m_per_px - med) <= mad_factor * mad]
+        if len(kept) < min_pairs:
+            kept = valid
+
+    kept_vals = sorted(p.implied_scale_m_per_px for p in kept)
+    k = len(kept_vals)
+    final = kept_vals[k // 2] if k % 2 == 1 else 0.5 * (kept_vals[k // 2 - 1] + kept_vals[k // 2])
+
+    return ScaleEstimate(
+        scale_m_per_px=float(final),
+        pair_count=len(kept),
+        median=float(med),
+        mad=float(mad),
+        outliers_dropped=len(valid) - len(kept),
+        used_pairs=[p.to_dict() for p in kept],
+    )
+
+
+@dataclass
 class ScaleEstimate:
     scale_m_per_px: float
     pair_count: int
@@ -282,6 +513,8 @@ class ScaleEstimate:
     mad: float                 # median absolute deviation
     outliers_dropped: int
     used_pairs: list[dict] = field(default_factory=list)
+    # 어떤 방법으로 추정했는지 추적 — "tick_interval" 우선, fallback 시 "wall_length"
+    method: str = "tick_interval"
 
     def to_dict(self) -> dict:
         return {
@@ -291,6 +524,7 @@ class ScaleEstimate:
             "mad": round(self.mad, 6),
             "outliers_dropped": self.outliers_dropped,
             "used_pairs": list(self.used_pairs),
+            "method": self.method,
         }
 
 
@@ -335,6 +569,136 @@ def estimate_scale_from_matches(
         mad=float(mad),
         outliers_dropped=len(valid) - len(kept),
         used_pairs=[m.to_dict() for m in kept],
+        method="wall_length",
+    )
+
+
+@dataclass
+class _ScaleCandidate:
+    scale: float
+    baseline_px: float
+    source: str
+
+    def to_dict(self) -> dict:
+        return {
+            "scale_m_per_px": round(self.scale, 6),
+            "baseline_px": round(self.baseline_px, 1),
+            "source": self.source,
+        }
+
+
+def _build_dimension_chains(
+    entries, same_line_tolerance_px: float = 60.0
+) -> dict[str, list[list[tuple[float, float]]]]:
+    """같은 치수선 버킷별 [(center_along, meters), ...] (along 정렬) 체인.
+
+    반환: {"horizontal": [chain, ...], "vertical": [chain, ...]} (각 chain 은 라벨 2개+).
+    """
+    horiz: list[tuple[float, float, float]] = []
+    vert: list[tuple[float, float, float]] = []
+    for e in entries or []:
+        p = parse_dimension_to_meters(e.text)
+        if p is None or p.meters <= 0:
+            continue
+        x1, y1, x2, y2 = e.bbox
+        cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+        if (x2 - x1) >= (y2 - y1):
+            horiz.append((cx, cy, p.meters))   # along=x, across=y
+        else:
+            vert.append((cy, cx, p.meters))    # along=y, across=x
+
+    def _chains(items: list[tuple[float, float, float]]) -> list[list[tuple[float, float]]]:
+        buckets: dict[int, list[tuple[float, float]]] = {}
+        for along, across, m in items:
+            k = int(round(across / same_line_tolerance_px))
+            buckets.setdefault(k, []).append((along, m))
+        out = []
+        for b in buckets.values():
+            if len(b) >= 2:
+                b.sort(key=lambda t: t[0])
+                out.append(b)
+        return out
+
+    return {"horizontal": _chains(horiz), "vertical": _chains(vert)}
+
+
+def estimate_scale_crossvalidated(
+    entries,
+    walls: Sequence[Sequence[float]] | None = None,
+    *,
+    agree_ratio: float = 0.18,
+    same_line_tolerance_px: float = 60.0,
+) -> ScaleEstimate | None:
+    """긴 기준선 후보들을 cluster 합의로 교차검증한 robust scale.
+
+    짧은 인접 tick(노이즈 큼) 대신 **긴 기준선** 후보를 모아 서로 검증한다:
+      - 체인 전체 span: 한 치수선의 첫~마지막 라벨 중심 사이 거리 (긴 baseline)
+      - 벽 외곽 anchor: (해당 방향 최대 치수) ÷ (해당 방향 외곽 벽 픽셀 간격)
+    가장 많은 후보가 동의(±agree_ratio)하는 cluster 의 median 을 채택 → 이상치 자동 배제.
+    후보 없으면 None (호출자가 tick-interval 로 fallback).
+    """
+    cands: list[_ScaleCandidate] = []
+    chains = _build_dimension_chains(entries, same_line_tolerance_px)
+
+    # (B) 체인 전체 span — 첫~마지막 라벨 중심 사이 미터/픽셀.
+    for orient, chlist in chains.items():
+        for chain in chlist:
+            if len(chain) < 2:
+                continue
+            d_px = chain[-1][0] - chain[0][0]
+            if d_px <= 0:
+                continue
+            # 첫 중심~마지막 중심 사이 미터 = 전체합 − 첫/마지막 세그먼트 절반
+            meters = sum(m for _, m in chain) - chain[0][1] / 2.0 - chain[-1][1] / 2.0
+            if meters > 0:
+                cands.append(_ScaleCandidate(meters / d_px, d_px, f"chain_{orient[0]}"))
+
+    # (A) 벽 외곽 + 해당 방향 최대 치수 (전체 외곽 치수로 가정).
+    if walls:
+        vx = [(w[0] + w[2]) / 2.0 for w in walls if _wall_orientation(w) == "vertical"]
+        hy = [(w[1] + w[3]) / 2.0 for w in walls if _wall_orientation(w) == "horizontal"]
+        h_dims = [m for ch in chains["horizontal"] for _, m in ch]
+        v_dims = [m for ch in chains["vertical"] for _, m in ch]
+        if len(vx) >= 2 and h_dims:
+            ext = max(vx) - min(vx)
+            if ext > 0:
+                cands.append(_ScaleCandidate(max(h_dims) / ext, ext, "wall_h"))
+        if len(hy) >= 2 and v_dims:
+            ext = max(hy) - min(hy)
+            if ext > 0:
+                cands.append(_ScaleCandidate(max(v_dims) / ext, ext, "wall_v"))
+
+    if not cands:
+        return None
+
+    # cluster 합의: 동의 후보 가장 많은 값 중심 (동률이면 baseline 긴 쪽).
+    best_cluster: list[_ScaleCandidate] = []
+    best_key: tuple[int, float] = (-1, -1.0)
+    for c in cands:
+        nb = [d for d in cands if abs(d.scale - c.scale) <= agree_ratio * c.scale]
+        key = (len(nb), c.baseline_px)
+        if key > best_key:
+            best_key = key
+            best_cluster = nb
+
+    scales = sorted(c.scale for c in best_cluster)
+    n = len(scales)
+    final = scales[n // 2] if n % 2 else 0.5 * (scales[n // 2 - 1] + scales[n // 2])
+    devs = sorted(abs(s - final) for s in scales)
+    mad = devs[n // 2] if n % 2 else 0.5 * (devs[n // 2 - 1] + devs[n // 2])
+
+    logger.info(
+        "scale crossval: %d 후보 → cluster %d개 동의, scale=%.6f m/px (mad=%.6f)",
+        len(cands), len(best_cluster), final, mad,
+    )
+    return ScaleEstimate(
+        scale_m_per_px=float(final),
+        pair_count=len(best_cluster),
+        median=float(final),
+        mad=float(mad),
+        outliers_dropped=len(cands) - len(best_cluster),
+        used_pairs=[c.to_dict() for c in best_cluster],
+        method="anchored_crossval",
     )
 
 
@@ -384,3 +748,271 @@ def dimension_alignment_score(
     if parsed_count == 0:
         return 0.0
     return float(matched_count / parsed_count)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 구간(span) 해석 — 치수선 세그먼트를 "그리드 사이 거리" 로 보고 벽/방에 부착
+# ─────────────────────────────────────────────────────────────────────────
+# 건축 도면의 치수선 세그먼트(예: 1480, 3340...)는 개별 벽 길이가 아니라 인접한
+# 두 그리드(=수직/수평 벽) 사이 거리다. 치수 텍스트는 자기 세그먼트의 중앙에 오므로
+# scale(m/px) 을 알면 각 세그먼트의 픽셀 양끝(tick)을 복원할 수 있고, 그 tick 을
+# 가장 가까운 수직/수평 벽에 스냅하면 "이 구간은 어느 두 벽 사이" 인지 알 수 있다.
+@dataclass
+class DimensionSpan:
+    orientation: str               # 측정 축: "horizontal"(x거리) / "vertical"(y거리)
+    meters: float
+    text: str
+    axis_lo: float                 # 측정축 픽셀 시작 (H=x, V=y) — tick
+    axis_hi: float                 # 측정축 픽셀 끝
+    perp: float                    # dimension line 의 perp 좌표 (참고용)
+    boundary_lo_wall: int | None   # axis_lo 쪽 경계 벽 idx (H→수직벽, V→수평벽)
+    boundary_hi_wall: int | None   # axis_hi 쪽 경계 벽 idx
+    parse_confidence: float
+
+    def to_dict(self) -> dict:
+        return {
+            "orientation": self.orientation,
+            "meters": round(self.meters, 4),
+            "text": self.text,
+            "axis_lo": round(self.axis_lo, 2),
+            "axis_hi": round(self.axis_hi, 2),
+            "perp": round(self.perp, 2),
+            "boundary_lo_wall": self.boundary_lo_wall,
+            "boundary_hi_wall": self.boundary_hi_wall,
+            "parse_confidence": round(self.parse_confidence, 3),
+        }
+
+
+def _walls_extent(walls: Sequence[Sequence[float]]) -> float:
+    xs: list[float] = []
+    ys: list[float] = []
+    for w in walls:
+        xs.extend((w[0], w[2]))
+        ys.extend((w[1], w[3]))
+    if not xs:
+        return 0.0
+    return max(max(xs) - min(xs), max(ys) - min(ys))
+
+
+def _nearest_wall_index(
+    wall_mids: Sequence[tuple[int, float]], target: float, tol: float
+) -> int | None:
+    """(idx, mid_coord) 목록에서 target 에 가장 가까운 벽 idx (거리 ≤ tol)."""
+    best_idx: int | None = None
+    best_d = tol
+    for idx, mid in wall_mids:
+        d = abs(mid - target)
+        if d <= best_d:
+            best_d = d
+            best_idx = idx
+    return best_idx
+
+
+def build_dimension_spans(
+    entries,  # list[OCREntry]
+    scale_m_per_px: float,
+    walls: Sequence[Sequence[float]],
+    *,
+    same_line_tol_px: float = 60.0,
+    wall_snap_ratio: float = 0.035,
+    min_wall_snap_px: float = 20.0,
+) -> list[DimensionSpan]:
+    """치수 OCR + scale + 벽 → 구간(span) 리스트.
+
+    각 치수 텍스트를 자기 세그먼트의 중앙으로 보고 scale 로 픽셀 길이를 복원,
+    양끝 tick 을 그 측정 방향의 경계 벽(H→수직벽, V→수평벽)에 스냅한다.
+    """
+    if not entries or not scale_m_per_px or scale_m_per_px <= 0 or not walls:
+        return []
+
+    # (orientation, meters, center_axis, perp, conf, text)
+    items: list[tuple[str, float, float, float, float, str]] = []
+    for e in entries:
+        parsed = parse_dimension_to_meters(e.text)
+        if parsed is None:
+            continue
+        orient = _bbox_orientation(e.bbox)
+        cx = (e.bbox[0] + e.bbox[2]) / 2.0
+        cy = (e.bbox[1] + e.bbox[3]) / 2.0
+        if orient == "horizontal":
+            items.append(("horizontal", parsed.meters, cx, cy, parsed.confidence, str(e.text)))
+        else:
+            items.append(("vertical", parsed.meters, cy, cx, parsed.confidence, str(e.text)))
+    if not items:
+        return []
+
+    vwalls = [
+        (i, (w[0] + w[2]) / 2.0) for i, w in enumerate(walls)
+        if _wall_orientation(w) == "vertical"
+    ]
+    hwalls = [
+        (i, (w[1] + w[3]) / 2.0) for i, w in enumerate(walls)
+        if _wall_orientation(w) == "horizontal"
+    ]
+    snap_tol = max(min_wall_snap_px, _walls_extent(walls) * wall_snap_ratio)
+
+    spans: list[DimensionSpan] = []
+    for orient in ("horizontal", "vertical"):
+        group = [it for it in items if it[0] == orient]
+        if not group:
+            continue
+        # 같은 dimension line 끼리 묶기 (perp 좌표 클러스터)
+        group.sort(key=lambda it: it[3])
+        chains: list[list] = []
+        cur = [group[0]]
+        for it in group[1:]:
+            if abs(it[3] - cur[-1][3]) <= same_line_tol_px:
+                cur.append(it)
+            else:
+                chains.append(cur)
+                cur = [it]
+        chains.append(cur)
+
+        boundary_walls = vwalls if orient == "horizontal" else hwalls
+        for chain in chains:
+            chain.sort(key=lambda it: it[2])  # 측정축 정렬
+            for (_, meters, center, perp, conf, text) in chain:
+                seg_px = meters / scale_m_per_px
+                lo = center - seg_px / 2.0
+                hi = center + seg_px / 2.0
+                spans.append(
+                    DimensionSpan(
+                        orientation=orient,
+                        meters=meters,
+                        text=text,
+                        axis_lo=lo,
+                        axis_hi=hi,
+                        perp=perp,
+                        boundary_lo_wall=_nearest_wall_index(boundary_walls, lo, snap_tol),
+                        boundary_hi_wall=_nearest_wall_index(boundary_walls, hi, snap_tol),
+                        parse_confidence=conf,
+                    )
+                )
+    if spans:
+        logger.info(
+            "dimension spans: %d 구간 (H=%d, V=%d)",
+            len(spans),
+            sum(1 for s in spans if s.orientation == "horizontal"),
+            sum(1 for s in spans if s.orientation == "vertical"),
+        )
+    return spans
+
+
+def attach_spans_to_walls(
+    spans: Sequence[DimensionSpan], walls: Sequence[Sequence[float]]
+) -> dict[int, dict]:
+    """각 경계 벽에 인접 구간 부착.
+
+    벽 좌표 증가측(오른쪽/아래)에 붙는 구간 = `span_after_m`,
+    감소측(왼쪽/위)에 붙는 구간 = `span_before_m`.
+    같은 측에 여러 구간이 잡히면 parse_confidence 높은 것 유지.
+
+    반환: `{wall_idx: {"span_before_m": .., "span_after_m": .., "*_conf": ..}}`
+    """
+    result: dict[int, dict] = {}
+
+    def _put(wall_idx: int | None, key: str, sp: DimensionSpan) -> None:
+        if wall_idx is None:
+            return
+        d = result.setdefault(wall_idx, {})
+        conf_key = f"{key}_conf"
+        if key in d and d.get(conf_key, 0.0) >= sp.parse_confidence:
+            return
+        d[key] = round(sp.meters, 3)
+        d[conf_key] = round(sp.parse_confidence, 3)
+        d[f"{key}_text"] = sp.text
+
+    for sp in spans:
+        # boundary_lo 벽 기준: 구간은 그 벽의 좌표 증가측에 위치 → after
+        _put(sp.boundary_lo_wall, "span_after_m", sp)
+        # boundary_hi 벽 기준: 구간은 그 벽의 좌표 감소측에 위치 → before
+        _put(sp.boundary_hi_wall, "span_before_m", sp)
+    return result
+
+
+def _best_iou_span(
+    spans: Sequence[DimensionSpan], lo: float, hi: float, min_iou: float = 0.5
+) -> DimensionSpan | None:
+    """구간들 중 [lo,hi] 와 **양 끝이 가장 일치**하는 것 (IoU ≥ min_iou).
+
+    단순 겹침이 아니라 IoU 라서, 짧은 대상([100,200])에 전체 치수([0,1000]) 가
+    매칭되는 오류를 방지한다 (전체 치수는 IoU 가 낮아 탈락).
+    """
+    target_len = max(1.0, hi - lo)
+    best: DimensionSpan | None = None
+    best_iou = min_iou
+    for sp in spans:
+        inter = max(0.0, min(hi, sp.axis_hi) - max(lo, sp.axis_lo))
+        union = max(hi, sp.axis_hi) - min(lo, sp.axis_lo)
+        if union <= 0:
+            continue
+        iou = inter / union
+        if iou >= best_iou:
+            best_iou = iou
+            best = sp
+    _ = target_len  # (가독성용 — 길이 자체는 IoU 에 내포)
+    return best
+
+
+def attach_wall_lengths_parallel(
+    spans: Sequence[DimensionSpan], walls: Sequence[Sequence[float]]
+) -> dict[int, dict]:
+    """각 벽에 **평행한** 치수(벽 자기 길이)를 IoU 매칭으로 부착.
+
+    세로벽 ↔ 세로 치수(y 범위), 가로벽 ↔ 가로 치수(x 범위). 벽의 자기 범위와
+    양 끝이 일치하는 치수를 그 벽의 '도면 길이' 로 본다.
+      - 내벽: 단일 세그먼트에 매칭
+      - 외벽: 전체(합계) 치수에 매칭 (범위가 같으니 IoU 최대)
+
+    반환: `{wall_idx: {"meters": .., "text": .., "parse_confidence": ..}}`
+    """
+    vspans = [s for s in spans if s.orientation == "vertical"]
+    hspans = [s for s in spans if s.orientation == "horizontal"]
+    result: dict[int, dict] = {}
+    for idx, w in enumerate(walls):
+        orient = _wall_orientation(w)
+        if orient == "vertical":
+            lo, hi = sorted((w[1], w[3]))   # y 범위
+            sp = _best_iou_span(vspans, lo, hi)
+        elif orient == "horizontal":
+            lo, hi = sorted((w[0], w[2]))   # x 범위
+            sp = _best_iou_span(hspans, lo, hi)
+        else:
+            sp = None
+        if sp is not None:
+            result[idx] = {
+                "meters": round(sp.meters, 3),
+                "text": sp.text,
+                "parse_confidence": round(sp.parse_confidence, 3),
+            }
+    return result
+
+
+def attach_spans_to_rooms(
+    spans: Sequence[DimensionSpan], rooms: Sequence[dict]
+) -> dict[int, dict]:
+    """각 방 bbox 의 가로/세로 범위에 **양 끝이 일치**하는 구간을 width/height 로 부착.
+
+    반환: `{room_idx: {"width_m": .., "height_m": ..}}` (매칭된 축만 채움)
+    """
+    hspans = [s for s in spans if s.orientation == "horizontal"]
+    vspans = [s for s in spans if s.orientation == "vertical"]
+    result: dict[int, dict] = {}
+    for ridx, room in enumerate(rooms):
+        pts = room.get("points") or []
+        xs = [p[0] for p in pts if len(p) >= 2]
+        ys = [p[1] for p in pts if len(p) >= 2]
+        if not xs or not ys:
+            continue
+        d: dict = {}
+        w = _best_iou_span(hspans, min(xs), max(xs))
+        if w is not None:
+            d["width_m"] = round(w.meters, 3)
+            d["width_text"] = w.text
+        h = _best_iou_span(vspans, min(ys), max(ys))
+        if h is not None:
+            d["height_m"] = round(h.meters, 3)
+            d["height_text"] = h.text
+        if d:
+            result[ridx] = d
+    return result

--- a/backend/app/services/wall_extraction_helpers/dimension_matching.py
+++ b/backend/app/services/wall_extraction_helpers/dimension_matching.py
@@ -671,15 +671,15 @@ def estimate_scale_crossvalidated(
     if not cands:
         return None
 
-    # cluster 합의: 동의 후보 가장 많은 값 중심 (동률이면 baseline 긴 쪽).
-    best_cluster: list[_ScaleCandidate] = []
-    best_key: tuple[int, float] = (-1, -1.0)
-    for c in cands:
-        nb = [d for d in cands if abs(d.scale - c.scale) <= agree_ratio * c.scale]
-        key = (len(nb), c.baseline_px)
-        if key > best_key:
-            best_key = key
-            best_cluster = nb
+    # anchor = 가장 신뢰할 후보. 벽 외곽(wall_*)을 최우선 — (전체 치수 ÷ 건물 픽셀폭)이라
+    # baseline 이 가장 길고 단일 고신뢰 치수에 기반. 없으면 baseline 가장 긴 후보.
+    # anchor 와 동의(±agree_ratio)하는 것만 모아 median → 짧고 noisy 한 chain 들이
+    # 다수(수)로 anchor 를 이기지 못하게 함 (사용자 의도: "전체 치수를 anchor로").
+    wall_cands = [c for c in cands if c.source.startswith("wall")]
+    anchor = max(wall_cands or cands, key=lambda c: c.baseline_px)
+    best_cluster = [
+        c for c in cands if abs(c.scale - anchor.scale) <= agree_ratio * anchor.scale
+    ]
 
     scales = sorted(c.scale for c in best_cluster)
     n = len(scales)
@@ -955,19 +955,24 @@ def _best_iou_span(
 
 
 def attach_wall_lengths_parallel(
-    spans: Sequence[DimensionSpan], walls: Sequence[Sequence[float]]
+    spans: Sequence[DimensionSpan],
+    walls: Sequence[Sequence[float]],
+    scale_m_per_px: float | None = None,
+    *,
+    length_tol: float = 0.12,
 ) -> dict[int, dict]:
-    """각 벽에 **평행한** 치수(벽 자기 길이)를 IoU 매칭으로 부착.
+    """각 벽에 길이 부착 — 평행 치수(도면값) + scale 로 계산한 실제 길이로 검증.
 
-    세로벽 ↔ 세로 치수(y 범위), 가로벽 ↔ 가로 치수(x 범위). 벽의 자기 범위와
-    양 끝이 일치하는 치수를 그 벽의 '도면 길이' 로 본다.
-      - 내벽: 단일 세그먼트에 매칭
-      - 외벽: 전체(합계) 치수에 매칭 (범위가 같으니 IoU 최대)
+    세로벽 ↔ 세로 치수(y 범위), 가로벽 ↔ 가로 치수(x 범위) IoU 매칭. 단, **매칭된
+    치수가 벽의 실제 길이(픽셀×scale)와 ±length_tol 안에서 일치할 때만** 도면값으로
+    인정 → "거의 full-width 내벽이 전체 치수(17,500)에 과매칭"되는 오류 차단.
+    일치 안 하면 계산 길이만 표시(source="computed").
 
-    반환: `{wall_idx: {"meters": .., "text": .., "parse_confidence": ..}}`
+    반환: `{wall_idx: {"meters", "text"(도면값일 때만), "source": "dimension"|"computed"}}`
     """
     vspans = [s for s in spans if s.orientation == "vertical"]
     hspans = [s for s in spans if s.orientation == "horizontal"]
+    has_scale = bool(scale_m_per_px and scale_m_per_px > 0)
     result: dict[int, dict] = {}
     for idx, w in enumerate(walls):
         orient = _wall_orientation(w)
@@ -978,12 +983,27 @@ def attach_wall_lengths_parallel(
             lo, hi = sorted((w[0], w[2]))   # x 범위
             sp = _best_iou_span(hspans, lo, hi)
         else:
-            sp = None
-        if sp is not None:
+            continue
+
+        computed_m = (hi - lo) * scale_m_per_px if has_scale else None  # type: ignore[operator]
+
+        # 도면 치수가 실제 길이와 충분히 일치하면 도면값 채택.
+        if sp is not None and (
+            computed_m is None
+            or abs(sp.meters - computed_m) <= length_tol * computed_m
+        ):
             result[idx] = {
                 "meters": round(sp.meters, 3),
                 "text": sp.text,
+                "source": "dimension",
                 "parse_confidence": round(sp.parse_confidence, 3),
+            }
+        elif computed_m is not None and computed_m > 0:
+            # 도면 치수 없거나 불일치 → scale 계산 길이만.
+            result[idx] = {
+                "meters": round(computed_m, 3),
+                "text": None,
+                "source": "computed",
             }
     return result
 

--- a/backend/app/services/wall_extraction_helpers/dimension_matching.py
+++ b/backend/app/services/wall_extraction_helpers/dimension_matching.py
@@ -657,8 +657,16 @@ def estimate_scale_crossvalidated(
     if walls:
         vx = [(w[0] + w[2]) / 2.0 for w in walls if _wall_orientation(w) == "vertical"]
         hy = [(w[1] + w[3]) / 2.0 for w in walls if _wall_orientation(w) == "horizontal"]
-        h_dims = [m for ch in chains["horizontal"] for _, m in ch]
-        v_dims = [m for ch in chains["vertical"] for _, m in ch]
+        # max 치수는 **파싱된 모든 치수**에서 — 전체 외곽 치수(예 17,500/9,700)는 자기
+        # 줄에 혼자라 체인(라벨 2개+)에 안 들어가므로 chains 만 보면 빠짐 → scale 급감 버그.
+        h_dims: list[float] = []
+        v_dims: list[float] = []
+        for e in entries or []:
+            p = parse_dimension_to_meters(e.text)
+            if p is None or p.meters <= 0:
+                continue
+            x1b, y1b, x2b, y2b = e.bbox
+            (h_dims if (x2b - x1b) >= (y2b - y1b) else v_dims).append(p.meters)
         if len(vx) >= 2 and h_dims:
             ext = max(vx) - min(vx)
             if ext > 0:

--- a/backend/app/services/wall_extraction_helpers/ocr.py
+++ b/backend/app/services/wall_extraction_helpers/ocr.py
@@ -51,9 +51,14 @@ def detect_text_entries(image_path: Path) -> list[OCREntry]:
         return []
 
     try:
-        # detail=1 → bbox + text + confidence
-        # paragraph=False → 각 단어 단위
-        results = reader.readtext(str(image_path), detail=1, paragraph=False)
+        import cv2
+        img = cv2.imread(str(image_path))
+        if img is None:
+            logger.warning("OCR: 이미지 디코드 실패 %s", image_path)
+            return []
+        rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        # 전체는 0° 1번, 좌/우 여백 strip 만 회전 OCR(세로 치수). rotation_info 전체 대비 비용↓.
+        results = _ocr_margin_rotation(reader, rgb)
     except Exception as exc:
         logger.warning("OCR 실행 실패: %s", exc)
         return []
@@ -76,8 +81,80 @@ def detect_text_entries(image_path: Path) -> list[OCREntry]:
             confidence = 0.0
         entries.append(OCREntry(bbox=bbox, text=str(text), confidence=confidence))
 
+    entries = _dedupe_entries(entries)
     logger.info("OCR detected %d text entries from %s", len(entries), image_path.name)
     return entries
+
+
+def _readtext_strip(reader, rgb, x0: int, x1: int, rotate_code):
+    """좌/우 strip 회전 OCR → (source 좌표 4pts, text, conf). 좌표 역매핑 포함."""
+    import cv2
+    strip = rgb[:, x0:x1]
+    strip_h, strip_w = strip.shape[:2]
+    rotated = cv2.rotate(strip, rotate_code)
+    out = []
+    for entry in reader.readtext(rotated, detail=1, paragraph=False):
+        if len(entry) < 3:
+            continue
+        pts, text, conf = entry[0], entry[1], entry[2]
+        try:
+            mapped = []
+            for p in pts:
+                rx, ry = float(p[0]), float(p[1])
+                if rotate_code == cv2.ROTATE_90_CLOCKWISE:
+                    sx, sy = ry, (strip_h - 1) - rx
+                else:  # ROTATE_90_COUNTERCLOCKWISE
+                    sx, sy = (strip_w - 1) - ry, rx
+                mapped.append((sx + x0, sy))
+        except (TypeError, IndexError):
+            continue
+        out.append((mapped, text, conf))
+    return out
+
+
+def _ocr_margin_rotation(reader, rgb, *, strip_ratio: float = 0.16, min_strip_px: int = 40):
+    """전체 0° OCR + 좌/우 여백 strip 회전 OCR. detail=1 과 동일 shape 반환."""
+    import cv2
+    results: list = []
+    for entry in reader.readtext(rgb, detail=1, paragraph=False):
+        if len(entry) >= 3:
+            results.append((entry[0], entry[1], entry[2]))
+    h, w = rgb.shape[:2]
+    sw = min(w, max(min_strip_px, int(w * strip_ratio)))
+    strips = [(0, sw)]
+    if w - sw > sw:
+        strips.append((w - sw, w))
+    for (x0, x1) in strips:
+        for code in (cv2.ROTATE_90_CLOCKWISE, cv2.ROTATE_90_COUNTERCLOCKWISE):
+            try:
+                results.extend(_readtext_strip(reader, rgb, x0, x1, code))
+            except Exception as exc:
+                logger.warning("strip OCR 실패: %s", exc)
+    return results
+
+
+def _bbox_iou(a, b) -> float:
+    ix1, iy1 = max(a[0], b[0]), max(a[1], b[1])
+    ix2, iy2 = min(a[2], b[2]), min(a[3], b[3])
+    iw, ih = max(0, ix2 - ix1), max(0, iy2 - iy1)
+    inter = iw * ih
+    if inter <= 0:
+        return 0.0
+    area_a = max(0, a[2] - a[0]) * max(0, a[3] - a[1])
+    area_b = max(0, b[2] - b[0]) * max(0, b[3] - b[1])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _dedupe_entries(entries: list[OCREntry], iou_thr: float = 0.4) -> list[OCREntry]:
+    """겹치는 OCR 결과 중 confidence 높은 것만 유지 (0°/회전 패스 중복 제거)."""
+    ordered = sorted(entries, key=lambda e: e.confidence, reverse=True)
+    kept: list[OCREntry] = []
+    for e in ordered:
+        if any(_bbox_iou(e.bbox, k.bbox) > iou_thr for k in kept):
+            continue
+        kept.append(e)
+    return kept
 
 
 def detect_text_bboxes(image_path: Path) -> list[tuple[int, int, int, int]]:

--- a/backend/app/services/wall_extraction_helpers/threshold_scoring.py
+++ b/backend/app/services/wall_extraction_helpers/threshold_scoring.py
@@ -34,6 +34,7 @@ class ThresholdScore:
     noise_penalty: float
     dimension_alignment: float
     total: float
+    coverage: float = 0.0  # wall 픽셀 비율 (뚱뚱할수록 감점)
 
     def to_dict(self) -> dict:
         """JSON 직렬화용 (응답 / summary_json 영속화)."""
@@ -45,6 +46,7 @@ class ThresholdScore:
             "ocr_penalty": round(self.ocr_penalty, 4),
             "noise_penalty": round(self.noise_penalty, 4),
             "dimension_alignment": round(self.dimension_alignment, 4),
+            "coverage": round(self.coverage, 4),
             "total": round(self.total, 4),
         }
 
@@ -125,11 +127,14 @@ def score_threshold(
     text_mask: np.ndarray | None,
     dim_entries=None,
     weights: tuple[float, float, float, float, float, float] = (1.0, 1.0, 1.0, 1.0, 0.5, 1.0),
+    coverage_weight: float = 0.0,
 ) -> ThresholdScore:
     """단일 threshold 평가.
 
     weights: (line_alignment, connectivity, orthogonal, ocr_penalty, noise_penalty,
     dimension_alignment). 디폴트는 dim_alignment 도 line_alignment 와 동급 1.0.
+
+    coverage: wall 픽셀 비율 (진단용으로 기록). coverage_weight=0 이면 점수에 영향 없음.
     """
     wall_mask = (prob_map > threshold).astype(np.uint8) * 255
 
@@ -138,6 +143,7 @@ def score_threshold(
     orth = _orthogonal_score(wall_mask)
     ocr_p = _ocr_penalty(wall_mask, text_mask) if text_mask is not None else 0.0
     np_pen = _noise_penalty(wall_mask)
+    coverage = float((wall_mask > 0).mean())
     dim = 0.0
     if dim_entries:
         # 지연 import — dimension_matching 이 ocr 모듈을 거치지 않도록.
@@ -149,7 +155,7 @@ def score_threshold(
     w_la, w_cc, w_orth, w_ocr, w_np, w_dim = weights
     total = (
         w_la * la + w_cc * cc + w_orth * orth + w_dim * dim
-        - w_ocr * ocr_p - w_np * np_pen
+        - w_ocr * ocr_p - w_np * np_pen - coverage_weight * coverage
     )
 
     return ThresholdScore(
@@ -160,6 +166,7 @@ def score_threshold(
         ocr_penalty=ocr_p,
         noise_penalty=np_pen,
         dimension_alignment=dim,
+        coverage=coverage,
         total=total,
     )
 

--- a/backend/scripts/inspect_dimension_ocr.py
+++ b/backend/scripts/inspect_dimension_ocr.py
@@ -1,0 +1,252 @@
+"""dimension_matching OCR/파싱 진단 스크립트.
+
+"dimension_matching 에 넘어가는 OCR 값이 얼마나 좋은지" 를 한눈에 보기 위한 도구.
+OCR raw 값 → parse_dimension_to_meters 해석 → scale 추정 → (선택) span 까지 표로 출력.
+
+OCR 소스 3가지 (백엔드 env 에 easyocr 없어도 ②③ 으로 검사 가능):
+
+  # ① 실제 도면 이미지로 라이브 OCR (easyocr 설치 필요)
+  python scripts/inspect_dimension_ocr.py --image path/to/floorplan.png
+
+  # ② 실행 결과 summary_json (summary_json.wall_postprocess.dimension_matches)
+  python scripts/inspect_dimension_ocr.py --summary-json path/to/summary.json
+
+  # ③ OCR entries JSON ([{"text","bbox":[x1,y1,x2,y2],"confidence"}, ...])
+  python scripts/inspect_dimension_ocr.py --entries-json path/to/entries.json
+
+  # ④ OCR 없이 파서만 빠르게 점검 (내장 샘플 + 직접 텍스트)
+  python scripts/inspect_dimension_ocr.py --demo
+  python scripts/inspect_dimension_ocr.py --text "3,500" --text "3.5m" --text "350cm"
+
+선택: --walls-json [[x1,y1,x2,y2], ...] 을 주면 span/평행 길이 매칭까지 출력.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Windows 콘솔(cp949)에서 한글 깨짐 방지 — UTF-8 강제.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except Exception:
+    pass
+
+# backend 루트를 import 경로에 추가 (이 파일은 backend/scripts/ 에 있음).
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from app.services.wall_extraction_helpers import dimension_matching as dm  # noqa: E402
+from app.services.wall_extraction_helpers.ocr import OCREntry  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# OCR entry 로딩 (소스별)
+# ─────────────────────────────────────────────────────────────────────────
+def _entries_from_image(image_path: Path) -> list[OCREntry]:
+    """easyocr 로 라이브 OCR. 미설치 시 친절한 에러."""
+    try:
+        from app.services.wall_extraction_helpers import ocr
+    except Exception as exc:  # pragma: no cover
+        sys.exit(f"OCR 모듈 import 실패: {exc}")
+    try:
+        import easyocr  # noqa: F401
+    except ImportError:
+        sys.exit(
+            "easyocr 가 설치돼 있지 않습니다. 이미지 라이브 OCR 대신\n"
+            "  --summary-json / --entries-json 으로 운영에서 넘어온 값을 검사하거나\n"
+            "  pip install easyocr 후 다시 시도하세요."
+        )
+    if not image_path.exists():
+        sys.exit(f"이미지 없음: {image_path}")
+    return ocr.detect_text_entries(image_path)
+
+
+def _coerce_entry(d: dict) -> OCREntry | None:
+    bbox = d.get("bbox") or []
+    if len(bbox) != 4:
+        return None
+    try:
+        return OCREntry(
+            bbox=tuple(int(round(float(v))) for v in bbox),  # type: ignore[arg-type]
+            text=str(d.get("text", "")),
+            confidence=float(d.get("confidence", d.get("ocr_confidence", 0.0)) or 0.0),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _entries_from_entries_json(path: Path) -> list[OCREntry]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        sys.exit("entries-json 은 [{text,bbox,confidence}, ...] 형태여야 합니다.")
+    out = [_coerce_entry(d) for d in data if isinstance(d, dict)]
+    return [e for e in out if e is not None]
+
+
+def _entries_from_summary_json(path: Path) -> list[OCREntry]:
+    """summary_json.wall_postprocess 의 dimension_matches/ocr_entries 에서 복원."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    wp = (data.get("wall_postprocess") or data.get("summary_json", {}).get("wall_postprocess")
+          if isinstance(data, dict) else None) or {}
+    raw = wp.get("dimension_matches") or wp.get("ocr_entries") or []
+    out = [_coerce_entry(d) for d in raw if isinstance(d, dict)]
+    return [e for e in out if e is not None]
+
+
+def _entries_from_texts(texts: list[str]) -> list[OCREntry]:
+    """텍스트만 줄 때 — bbox 는 더미(가로 라벨로 가정). 파서 점검용."""
+    entries = []
+    for i, t in enumerate(texts):
+        # 가로 라벨 가정한 더미 bbox (x 간격만 벌려 둠).
+        x = 100 + i * 200
+        entries.append(OCREntry(bbox=(x, 50, x + 60, 70), text=t, confidence=0.99))
+    return entries
+
+
+_DEMO_TEXTS = [
+    "3,500", "3.5m", "350cm", "3500", "17,500", "17500",
+    "방", "Kitchen", "1/80", "9,700", "2.3", "abc", "12",
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 리포트
+# ─────────────────────────────────────────────────────────────────────────
+def _print_ocr_table(entries: list[OCREntry]) -> None:
+    print("\n[1] OCR raw entries  (dimension_matching 에 넘어가는 값)")
+    print("-" * 88)
+    print(f"{'#':>3}  {'text':<16} {'ocr_conf':>8}  {'orient':<10} {'bbox (x1,y1,x2,y2)':<26}")
+    print("-" * 88)
+    for i, e in enumerate(entries):
+        orient = dm._bbox_orientation(e.bbox)
+        bbox_s = f"({e.bbox[0]},{e.bbox[1]},{e.bbox[2]},{e.bbox[3]})"
+        print(f"{i:>3}  {e.text!r:<16} {e.confidence:>8.3f}  {orient:<10} {bbox_s:<26}")
+    print(f"\n총 {len(entries)} 개 OCR 항목")
+
+
+def _print_parse_table(entries: list[OCREntry]) -> None:
+    print("\n[2] 치수 파싱  (parse_dimension_to_meters)")
+    print("-" * 88)
+    print(f"{'#':>3}  {'text':<16} {'parsed_m':>10} {'parse_conf':>10}  {'unit_hint':<12} note")
+    print("-" * 88)
+    parsed_n = 0
+    conf_buckets = {1.0: 0, 0.5: 0, 0.3: 0}
+    for i, e in enumerate(entries):
+        p = dm.parse_dimension_to_meters(e.text)
+        if p is None:
+            print(f"{i:>3}  {e.text!r:<16} {'-':>10} {'-':>10}  {'-':<12} 치수 아님")
+            continue
+        parsed_n += 1
+        conf_buckets[p.confidence] = conf_buckets.get(p.confidence, 0) + 1
+        print(f"{i:>3}  {e.text!r:<16} {p.meters:>10.4f} {p.confidence:>10.2f}  {p.unit_hint:<12}")
+    print(
+        f"\n파싱 성공 {parsed_n}/{len(entries)}  "
+        f"(신뢰도 1.0(단위명시)={conf_buckets.get(1.0,0)}, "
+        f"0.5(comma/decimal)={conf_buckets.get(0.5,0)}, "
+        f"0.3(맨숫자추정)={conf_buckets.get(0.3,0)})"
+    )
+
+
+def _print_scale(entries: list[OCREntry], walls: list | None = None) -> None:
+    print("\n[3] scale 추정  (tick-interval vs 교차검증)")
+    print("-" * 88)
+    pairs = dm.find_dimension_interval_pairs(entries)
+    if not pairs:
+        print("인접 치수 페어 없음 — 같은 치수선 위 텍스트가 2개 미만이거나 파싱 실패.")
+        return
+    for p in pairs:
+        print(
+            f"  {p.text_a!r:>10} ↔ {p.text_b!r:<10} "
+            f"{p.orientation:<10} dx={p.center_distance_px:>7.1f}px "
+            f"→ {p.implied_scale_m_per_px:.6f} m/px"
+        )
+    est = dm.estimate_scale_from_intervals(pairs)
+    if est is None:
+        print("\n→ tick-interval scale 추정 실패 (유효 페어 부족 / 분산 큼).")
+    else:
+        print(
+            f"\n→ tick-interval scale = {est.scale_m_per_px:.6f} m/px  "
+            f"(페어 {est.pair_count}개, median={est.median:.6f}, "
+            f"mad={est.mad:.6f}, outlier {est.outliers_dropped}개 제외)"
+        )
+
+    # 교차검증(anchored) — 긴 기준선 cluster 합의 (walls 있으면 외곽 anchor 도 포함)
+    cv = dm.estimate_scale_crossvalidated(entries, walls)
+    if cv is not None:
+        print(
+            f"→ 교차검증 scale  = {cv.scale_m_per_px:.6f} m/px  "
+            f"(동의 {cv.pair_count}개, mad={cv.mad:.6f}, "
+            f"이상치 {cv.outliers_dropped}개 배제) ★ 더 안정적"
+        )
+        for c in cv.used_pairs:
+            print(f"     ✓ {c['source']:<8} baseline={c['baseline_px']:>7.0f}px → {c['scale_m_per_px']:.6f}")
+
+
+def _print_spans(entries: list[OCREntry], walls: list[list[float]], scale: float) -> None:
+    print("\n[4] span / 평행 길이 매칭  (walls + scale 제공 시)")
+    print("-" * 88)
+    spans = dm.build_dimension_spans(entries, scale, walls)
+    if not spans:
+        print("span 생성 안 됨 (치수/스케일/벽 부족).")
+        return
+    for s in spans:
+        print(
+            f"  {s.text!r:>10} {s.orientation:<10} "
+            f"axis {s.axis_lo:>7.1f}~{s.axis_hi:<7.1f} "
+            f"경계벽 lo={s.boundary_lo_wall} hi={s.boundary_hi_wall}  {s.meters:.3f}m"
+        )
+    wlen = dm.attach_wall_lengths_parallel(spans, walls)
+    print("\n  벽 평행 길이:")
+    for idx, v in sorted(wlen.items()):
+        print(f"    wall[{idx}] = {v['meters']:.3f} m  ({v['text']})")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+def main() -> None:
+    ap = argparse.ArgumentParser(description="dimension_matching OCR/파싱 진단")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--image", type=Path, help="도면 이미지 (easyocr 라이브 OCR)")
+    src.add_argument("--summary-json", type=Path, help="실행 결과 summary_json")
+    src.add_argument("--entries-json", type=Path, help="OCR entries JSON")
+    src.add_argument("--demo", action="store_true", help="내장 샘플 텍스트로 파서 점검")
+    src.add_argument("--text", action="append", default=[], help="직접 텍스트 (반복 가능)")
+    ap.add_argument("--walls-json", type=Path, help="[[x1,y1,x2,y2],...] (span 매칭용)")
+    ap.add_argument("--scale", type=float, help="m/px (없으면 OCR tick-interval 추정값 사용)")
+    args = ap.parse_args()
+
+    if args.image:
+        entries = _entries_from_image(args.image)
+    elif args.summary_json:
+        entries = _entries_from_summary_json(args.summary_json)
+    elif args.entries_json:
+        entries = _entries_from_entries_json(args.entries_json)
+    elif args.demo:
+        entries = _entries_from_texts(_DEMO_TEXTS)
+    else:
+        entries = _entries_from_texts(args.text)
+
+    if not entries:
+        sys.exit("OCR entry 가 0개입니다. 소스를 확인하세요.")
+
+    walls = json.loads(args.walls_json.read_text(encoding="utf-8")) if args.walls_json else None
+
+    _print_ocr_table(entries)
+    _print_parse_table(entries)
+    _print_scale(entries, walls)
+
+    if walls is not None:
+        scale = args.scale
+        if scale is None:
+            est = dm.estimate_scale_from_intervals(dm.find_dimension_interval_pairs(entries))
+            scale = est.scale_m_per_px if est else None
+        if not scale or scale <= 0:
+            print("\n[4] span 생략 — scale 없음 (--scale 로 직접 지정 가능).")
+        else:
+            _print_spans(entries, walls, float(scale))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/inspect_wall_extraction.py
+++ b/backend/scripts/inspect_wall_extraction.py
@@ -1,0 +1,178 @@
+"""벽 추출 디버그 — U-Net prob map + 여러 threshold + 선탐지(Hough) 비교.
+
+"외벽이 어느 threshold에서 끊기는지 / 선탐지는 어떤지" 를 눈+숫자로 확인하는 도구.
+prob map(.npy)을 직접 불러와 분석 (백엔드/AI 실행·로그 불필요):
+
+  - 확률 분포 + threshold 별 커버리지(%)
+  - threshold 후보별 점수표 (line_alignment/connectivity/orthogonal/ocr_penalty/...)
+  - threshold 별 **마스크 오버레이 PNG** 저장 → 외벽이 어디서 끊기는지 눈으로
+  - **선탐지(Hough) 오버레이 PNG** → U-Net 없이 선만으로의 결과
+  - 실제 추출기 1회 실행 → 선택된 threshold + 최종 벽 오버레이
+
+사용 (backend 디렉토리에서):
+  # prob map 자동 탐색(가장 최근) + 이미지 지정
+  python scripts/inspect_wall_extraction.py --image data/uploads/xxx.jpg --auto-prob
+
+  # prob map 직접 지정
+  python scripts/inspect_wall_extraction.py --image data/uploads/xxx.jpg --prob path/to/wall_prob.npy
+
+오버레이는 기본 ./wall_debug/ 에 저장됩니다 (--out 으로 변경).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except Exception:
+    pass
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+import cv2  # noqa: E402
+import numpy as np  # noqa: E402
+
+from app.services.wall_extraction import wall_extractor  # noqa: E402
+from app.services.wall_extraction_helpers import (  # noqa: E402
+    line_detection,
+    ocr,
+    threshold_scoring,
+)
+from app.services.wall_extraction_helpers import dimension_matching as dm  # noqa: E402
+
+# AI 서버가 prob map 을 저장하는 위치 (repo 루트 기준).
+_UNET_OUT = _BACKEND_ROOT.parents[1] / "rf-service" / "apps" / "ai_api" / "data" / "output" / "unet"
+
+
+def _find_latest_prob() -> Path | None:
+    if not _UNET_OUT.exists():
+        return None
+    npys = list(_UNET_OUT.rglob("*_wall_prob.npy"))
+    if not npys:
+        return None
+    return max(npys, key=lambda p: p.stat().st_mtime)
+
+
+def _overlay_mask(bgr: np.ndarray, mask: np.ndarray, color=(0, 0, 255), alpha=0.5) -> np.ndarray:
+    """mask>0 영역을 color 로 덧칠한 오버레이."""
+    out = bgr.copy()
+    layer = out.copy()
+    layer[mask > 0] = color
+    return cv2.addWeighted(layer, alpha, out, 1 - alpha, 0)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="벽 추출 threshold/선탐지 디버그")
+    ap.add_argument("--image", type=Path, required=True, help="원본 도면 이미지")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--prob", type=Path, help="U-Net prob map (.npy)")
+    g.add_argument("--auto-prob", action="store_true", help="가장 최근 prob map 자동 탐색")
+    ap.add_argument("--out", type=Path, default=Path("wall_debug"), help="오버레이 저장 폴더")
+    ap.add_argument("--no-ocr", action="store_true", help="OCR text_mask 생략(빠름)")
+    args = ap.parse_args()
+
+    if not args.image.exists():
+        sys.exit(f"이미지 없음: {args.image}")
+    prob_path = args.prob if args.prob else _find_latest_prob()
+    if prob_path is None or not prob_path.exists():
+        sys.exit(f"prob map 없음: {prob_path} (--prob 로 직접 지정하세요)")
+    print(f"이미지   : {args.image}")
+    print(f"prob map : {prob_path}")
+
+    bgr = cv2.imread(str(args.image))
+    if bgr is None:
+        sys.exit("이미지 디코드 실패")
+    h_img, w_img = bgr.shape[:2]
+
+    prob = np.load(str(prob_path)).astype(np.float32)
+    print(f"prob shape={prob.shape}, image shape=({h_img},{w_img})")
+    # 실제 파이프라인처럼 prob 를 이미지 좌표계로 resize
+    if prob.shape[:2] != (h_img, w_img):
+        prob = cv2.resize(prob, (w_img, h_img), interpolation=cv2.INTER_LINEAR)
+        print("  → prob 를 이미지 크기로 resize 함")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    # ── [1] 확률 분포 + threshold 별 커버리지 ───────────────────────────
+    print("\n[1] 확률 분포")
+    print(f"  min={prob.min():.3f} max={prob.max():.3f} mean={prob.mean():.3f}")
+    print("  threshold 별 wall 픽셀 비율:")
+    for t in threshold_scoring.DEFAULT_THRESHOLDS:
+        cov = float((prob > t).mean()) * 100
+        print(f"    >{t:.2f} : {cov:5.2f}%")
+
+    # ── [2] 선탐지(Hough) ────────────────────────────────────────────
+    print("\n[2] 선탐지 (Hough wall 후보)")
+    segs = line_detection.detect_line_segments(args.image)
+    print(f"  검출된 H/V 선분: {len(segs)} 개")
+    line_mask = (
+        line_detection.build_line_mask(segs, (h_img, w_img), thickness=3)
+        if len(segs) > 0 else None
+    )
+    line_ov = bgr.copy()
+    for x1, y1, x2, y2 in segs:
+        cv2.line(line_ov, (int(x1), int(y1)), (int(x2), int(y2)), (0, 200, 0), 2)
+    cv2.imwrite(str(args.out / "lines_hough.png"), line_ov)
+    print(f"  → 저장: {args.out / 'lines_hough.png'}")
+
+    # ── [3] OCR text_mask (선택) ─────────────────────────────────────
+    text_mask = None
+    dim_entries: list = []
+    if not args.no_ocr:
+        try:
+            entries = ocr.detect_text_entries(args.image)
+            confident = [e.bbox for e in entries if e.confidence >= 0.5]
+            text_mask = (
+                ocr.build_text_mask(confident, (h_img, w_img), pad=3) if confident else None
+            )
+            dim_entries = [e for e in entries if dm.parse_dimension_to_meters(e.text)]
+            print(f"\n[3] OCR: 전체 {len(entries)}개, text_mask(conf>=0.5) {len(confident)}개")
+        except Exception as exc:
+            print(f"\n[3] OCR 생략(실패): {exc}")
+
+    # ── [4] threshold 후보별 점수 ────────────────────────────────────
+    print("\n[4] threshold 후보 점수 (높을수록 좋음; ocr_p/np 는 감점)")
+    print("-" * 92)
+    print(f"{'thr':>5} {'total':>8} {'line':>7} {'conn':>7} {'orth':>7} {'dim':>7} {'ocr_p':>7} {'noise':>7}")
+    print("-" * 92)
+    best_thr, scores = threshold_scoring.pick_best_threshold(
+        prob, line_mask=line_mask, text_mask=text_mask, dim_entries=dim_entries,
+    )
+    for s in scores:
+        mark = " ★best" if abs(s.threshold - best_thr) < 1e-6 else ""
+        print(
+            f"{s.threshold:>5.2f} {s.total:>8.3f} {s.line_alignment:>7.3f} "
+            f"{s.connectivity:>7.3f} {s.orthogonal:>7.3f} {s.dimension_alignment:>7.3f} "
+            f"{s.ocr_penalty:>7.3f} {s.noise_penalty:>7.3f}{mark}"
+        )
+    print(f"\n  → 선택된 threshold = {best_thr:.2f}")
+
+    # ── [5] threshold 별 "실제 추출 벽" 비교 ─────────────────────────
+    # raw 마스크(prob>t, 빨강) + 그 threshold 로 벡터화한 최종 벽(파랑) 을 한 장에.
+    # 외벽이 어느 threshold 에서 한 줄로 이어지고/끊기는지 눈으로 비교.
+    print("\n[5] threshold 별 추출 결과 (raw 마스크=빨강, 벡터화 벽=파랑)")
+    for t in threshold_scoring.DEFAULT_THRESHOLDS:
+        r = wall_extractor.execute_from_prob_map(
+            prob_path, threshold=float(t), image_path=args.image,
+        )
+        mask = (prob > t).astype(np.uint8) * 255
+        ov = _overlay_mask(bgr, mask, color=(0, 0, 255), alpha=0.30)
+        for x1, y1, x2, y2 in r.walls:
+            cv2.line(ov, (int(x1), int(y1)), (int(x2), int(y2)), (255, 0, 0), 3)
+        tag = f"{t:.2f}".replace(".", "")
+        star = "_BEST" if abs(t - best_thr) < 1e-6 else ""
+        cv2.imwrite(str(args.out / f"thr_{tag}{star}.png"), ov)
+        cov = float((prob > t).mean()) * 100
+        print(f"    thr={t:.2f}: 벽 {len(r.walls):>3}개  (커버리지 {cov:5.2f}%)"
+              + ("  ★ scorer 선택" if abs(t - best_thr) < 1e-6 else ""))
+    print(f"  → {args.out}/thr_*.png  (파일명에 BEST = scorer 가 고른 값)")
+    print("\n  외벽이 끊기면: 더 낮은 threshold 의 thr_*.png 에서 이어지는지 보세요.")
+    print("  거기서 이어지는데 BEST 가 높게 잡혔다면 → ocr_penalty 가 threshold 를 올린 것.")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -224,22 +224,49 @@ function getRealWidthM(draft: SceneDraft): number | null {
 }
 
 /**
- * real_width_m + 이미지 natural 비율로 이미지의 실제 미터 크기 계산.
- * real_width_m 은 summary_json 우선, 없으면 localStorage 캐시(source_asset_id ?? floor_id 키).
- * → promote 후 version-as-draft (summary_json={}) 에서도 캐시로 복원 → viewBox 안정.
- * 둘 중 하나라도 없으면 null → fallback 으로 도형 bounds 기준 viewBox 사용.
+ * summary_json 의 scale_ratio_m_per_px 조회. geom 변환에 쓴 최종 scale (m/px).
+ * 벽 좌표가 `pixel × scale_ratio` 로 미터화됐으므로, 같은 scale 로 이미지를 놓으면
+ * 벽과 정확히 정렬됨. OCR 추정/기본 fallback 무관하게 백엔드가 항상 기록.
+ */
+function getScaleRatioMPerPx(draft: SceneDraft): number | null {
+  const summary = (draft.summary_json ?? {}) as {
+    scale_ratio_m_per_px?: number;
+  };
+  const v = summary.scale_ratio_m_per_px;
+  if (typeof v === 'number' && v > 0) return v;
+  return null;
+}
+
+/**
+ * 이미지의 실제 미터 크기 계산. 두 가지 소스:
+ *   1. scale_ratio_m_per_px (신규, 권장): imageDims_px × scale → 벽과 동일 좌표계 정렬.
+ *   2. real_width_m (legacy): 사용자가 입력하던 도면 가로폭. 옛 draft 호환용.
+ * 둘 다 없으면 null → fallback 으로 도형 bounds 기준 viewBox 사용.
  */
 function deriveImageExtent(
   draft: SceneDraft,
   imageDims: { w: number; h: number } | null,
 ): { w: number; h: number } | null {
   if (!imageDims || imageDims.w <= 0) return null;
+
+  // 1순위: scale_ratio (이미지 픽셀 × m/px = 미터 크기). 벽과 정확히 겹침.
+  const scaleRatio = getScaleRatioMPerPx(draft);
+  if (scaleRatio != null) {
+    return {
+      w: imageDims.w * scaleRatio,
+      h: imageDims.h * scaleRatio,
+    };
+  }
+
+  // 2순위 (legacy): real_width_m. 옛 draft / version-as-draft 캐시 호환.
   const realWidthM = getRealWidthM(draft);
-  if (realWidthM == null) return null;
-  return {
-    w: realWidthM,
-    h: realWidthM * (imageDims.h / imageDims.w),
-  };
+  if (realWidthM != null) {
+    return {
+      w: realWidthM,
+      h: realWidthM * (imageDims.h / imageDims.w),
+    };
+  }
+  return null;
 }
 
 const DRAG_THRESHOLD_M = 0.05;

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -333,9 +333,10 @@ function WallDimensionSection({
       }
     | null;
 
-  // 평행 치수(벽 자기 길이) — 세로벽↔세로치수, 가로벽↔가로치수 IoU 매칭 결과.
+  // 평행 치수(벽 자기 길이) — 세로벽↔세로치수, 가로벽↔가로치수 매칭 + scale 검증 결과.
+  // source: "dimension"(도면 치수와 일치) | "computed"(scale 계산 길이).
   const dimLength = (meta.dimension_length ?? null) as
-    | { meters?: number; text?: string; parse_confidence?: number }
+    | { meters?: number; text?: string; source?: string; parse_confidence?: number }
     | null;
 
   // 입력값 초기값: user_meters 우선, 없으면 OCR parsed_meters.
@@ -393,7 +394,7 @@ function WallDimensionSection({
       {dimLength?.meters != null && (
         <div className="rounded-md border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
           <div className="flex items-center justify-between gap-2">
-            <span>도면 길이 (평행 치수)</span>
+            <span>{dimLength.source === 'computed' ? '추정 길이 (scale 계산)' : '도면 길이 (평행 치수)'}</span>
             <span className="font-mono text-foreground">
               {dimLength.meters.toFixed(2)} m
               {dimLength.text ? ` (${dimLength.text})` : ''}

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -333,6 +333,11 @@ function WallDimensionSection({
       }
     | null;
 
+  // 평행 치수(벽 자기 길이) — 세로벽↔세로치수, 가로벽↔가로치수 IoU 매칭 결과.
+  const dimLength = (meta.dimension_length ?? null) as
+    | { meters?: number; text?: string; parse_confidence?: number }
+    | null;
+
   // 입력값 초기값: user_meters 우선, 없으면 OCR parsed_meters.
   const initialInput =
     dim?.user_meters != null
@@ -383,6 +388,18 @@ function WallDimensionSection({
         <p className="rounded-md border border-dashed bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground">
           이 벽에 자동 매칭된 도면 치수가 없습니다. 아래에 직접 입력해 보정할 수 있어요.
         </p>
+      )}
+
+      {dimLength?.meters != null && (
+        <div className="rounded-md border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+          <div className="flex items-center justify-between gap-2">
+            <span>도면 길이 (평행 치수)</span>
+            <span className="font-mono text-foreground">
+              {dimLength.meters.toFixed(2)} m
+              {dimLength.text ? ` (${dimLength.text})` : ''}
+            </span>
+          </div>
+        </div>
       )}
 
       <div className="flex items-center gap-2">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -95,8 +95,12 @@ export default function DashboardPage() {
   const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
   const localImage = useLocalFloorplanImage(floorId);
-  const backgroundImageUrl =
-    assetUrlQuery.data?.url ?? localImage ?? null;
+  // 절대 http(s) 자산 URL 만 <image> 에서 직접 로드. local 모드 `/assets/{id}/raw`
+  // 상대경로는 origin/인증 문제로 못 써서 localStorage 캐시로 fallback.
+  const assetUrl = assetUrlQuery.data?.url ?? null;
+  const usableAssetUrl =
+    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
+  const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
 
   return (
     <div className="relative h-full overflow-auto p-6">

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -177,8 +177,13 @@ export default function EditorPage() {
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
   // 3순위: 사용자가 업로드한 파일을 base64 로 캐시해둔 로컬 이미지 (백엔드 미지원 우회).
   const localImage = useLocalFloorplanImage(floorId);
-  const backgroundImageUrl =
-    assetUrlQuery.data?.url ?? localImage ?? null;
+  // 자산 URL 은 <image href> 에서 직접 로드 가능한 절대 http(s) 만 사용.
+  // local 모드의 `/assets/{id}/raw` 같은 상대경로는 (a) 프론트 origin 기준이라 백엔드를
+  // 못 가리키고 (b) JWT 인증 헤더를 못 실어서 못 씀 → localStorage 캐시(base64) 로 fallback.
+  const assetUrl = assetUrlQuery.data?.url ?? null;
+  const usableAssetUrl =
+    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
+  const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
   const editingScene: SceneDraft | null = baseScene;
   const resolvedSelected = useMemo<SelectedEntityResolved | null>(() => {
     const scene = editingScene;


### PR DESCRIPTION
## 개요
도면 분석 과정에서 발생하던 벽 추출하는 과정의 안정성을 개선

문제 상황:
기존에는 U-Net probability map만으로 벽 후보를 추출한 뒤 후처리하는 흐름이어서, 도면마다 선 굵기,해상도,치수선,문/창 위치에 따라 결과가 불안정했다. 
특히 낮은 threshold에서 잡힌 벽 후보가 후속 skeleton/confidence 단계에서 다시 제거되거나, 문/창 때문에 벽이 끊겨 방 polygon이 닫히지 않는 문제가 있었다

이번 PR에서는 벽 추출 단계에서 사용하는 기준을 일관되게 만들고, OCR/line/dimension 정보를 보조 신호로 활용하여 well sement 추가

## 변경 사항
### 1. Wall extraction 기준 일관화
- probability map에서 선택된 threshold를 mask 생성뿐 아니라 skeletonization과 confidence filtering에도 동일하게 적용
- 기존처럼 mask 단계에서는 통과했지만 후속 confidence gate에서 다시 제거되는 이중 필터링 문제를 줄였다
- 도면별로 선택된 threshold와 실제 벽 선분 추출 기준이 일치하도록 정리

### 2. Probability map과 원본 이미지 좌표계 정렬
- 모델이 반환한 probability map 해상도와 원본 도면 이미지 해상도가 다를 때, 벽 좌표가 배경 이미지와 어긋날 수 있었다.
- source image 크기를 기준으로 probability map을 정렬하고, 정렬 여부를 metadata에 남기도록 변경
- 디버깅을 위해 `prob_shape`, `image_shape`, `coord_resized`, `coord_aligned` 정보를 postprocess metadata에 포함

### 3. OCR / line priors 기반 threshold 판단 보강
- AI 서버 또는 백엔드에서 얻은 OCR/line priors를 wall threshold scoring에 활용할 수 있도록 정리
- 치수 텍스트, 치수선, 일반 선분을 구분하여 벽 후보 판단에 반영.
- `dimension_line`으로 분류된 선분은 벽 후보 점수 계산에서 제외하여, 치수선이 벽으로 오탐되는 문제를 줄였다
- AI 서버가 priors를 제공한 경우와 백엔드 fallback을 사용한 경우를 metadata로 구분할 수 있게 했습니다.

### 4. 벽 전처리 morphology 안정화
- 기존의 큰 사각형 close 연산은 가까운 평행벽이나 내부 벽을 과도하게 합칠 수 있었다
- 수평/수직 방향 close를 분리 적용하여, 벽 안의 작은 끊김은 메우되 서로 다른 벽이 과하게 합쳐지는 문제를 줄였다
- 짧은 노이즈 제거, H/V 정렬, endpoint snapping, 중복 line merge 흐름도 함께 정리

### 5. 문/창 위치를 활용한 방 폐합 보강 (동작이 잘 되는지는 검증 필요)
- 문/창 bbox는 실제로 벽 위에 존재하는 구조물이므로, 해당 위치를 “벽이 지나가는 증거”로 활용
- U-Net 결과에서 문/창 부근 벽이 끊겨 polygonize가 실패하는 경우를 보완하기 위해, 방 추출 입력에만 사용하는 임시 wall segment를 합성
- 이 synthetic segment는 영속 wall로 저장하지 않고, room extraction 보조 입력으로만 사용하도록 분리

### 6. 치수선 tick 기반 누락 칸막이 보강 (동작이 잘 되는지는 검증 필요)
- 치수선 tick과 직교 벽 endpoint가 함께 존재하는 경우, 누락된 내부 칸막이 벽의 가능성이 높다고 보고 보조 segment를 합성
- 단순히 tick만 보고 벽을 만드는 것이 아니라, 직교벽 끝점이라는 추가 증거가 있을 때만 생성하도록 게이팅을 적용
- 과분할 위험을 줄이면서 방 polygon 폐합률을 높이기 위한 보조 로직

### 7. 방 타입/표시명 정보 확장
- 객체 탐지 결과를 기반으로 방의 의미 정보를 담을 수 있도록 Room schema에 `type`, `name` 필드를 추가
- 예를 들어 화장실 객체가 포함된 방은 `type: "bathroom"`, `name: "화장실"`처럼 표현
- 프론트엔드 editor/canvas/property panel에서도 변경된 room metadata를 다룰 수 있도록 반영

### 8. 디버깅 및 실험 관리 개선
- wall extraction 과정의 threshold, OCR, line, coordinate alignment 관련 metadata를 강화
- wall extraction 실험 산출물이 Git에 포함되지 않도록 `backend/wall_debug/`를 `.gitignore`에 추가


## 테스트 체크리스트
- [x] 도면 업로드 후 wall extraction 결과가 배경 이미지와 좌표상 어긋나지 않는지 확인
- [ ] 선택된 threshold가 mask, skeleton, confidence filter에 일관되게 적용되는지 확인
- [ ] 치수선이 벽 후보로 과하게 반영되지 않는지 확인
- [ ] 문/창 주변에서 방 polygon이 정상적으로 닫히는지 확인
- [ ] 화장실 객체가 포함된 방의 `type`, `name`이 정상 반영되는지 확인
- [ ] synthetic wall segment가 영속 wall 데이터로 저장되지 않는지 확인
