### PR TITLE
[Refactor] 스케일 보정을 단일 bulk 엔드포인트로 통합

### DIFF
--- a/backend/app/core/geom.py
+++ b/backend/app/core/geom.py
@@ -39,3 +39,17 @@ def wkb_to_geojson(geom: Any) -> Optional[dict[str, Any]]:
     if geom is None:
         return None
     return mapping(to_shape(geom))
+
+
+def scale_wkb(geom: Any, factor: float) -> Optional[WKBElement]:
+    """SceneDraft 전체 비례 재스케일용 — geometry 좌표 × factor (origin=0,0).
+
+    좌표 origin 이 도면 top-left 라 (0,0) 기준 곱셈만으로 충분.
+    NULL 통과 (요청 못 받는 컬럼도 안전).
+    """
+    if geom is None:
+        return None
+    from shapely.affinity import scale as shapely_scale
+    shp = to_shape(geom)
+    scaled = shapely_scale(shp, xfact=factor, yfact=factor, origin=(0, 0))
+    return from_shape(scaled, srid=0)

--- a/backend/app/routers/scene_drafts.py
+++ b/backend/app/routers/scene_drafts.py
@@ -15,6 +15,7 @@ from app.schemas.pagination import PaginatedResponse
 from app.schemas.scene_draft import (
     SceneDraftCreateRequest,
     SceneDraftDetailResponse,
+    SceneDraftRescaleRequest,
     SceneDraftSummaryResponse,
     SceneDraftUpdateRequest,
 )
@@ -98,6 +99,28 @@ def patch_scene_draft(
         scene_draft_id,
         current_user,
         scale_ratio_m_per_px=payload.scale_ratio_m_per_px,
+        scale_source=payload.scale_source,
+    )
+
+
+@router.post(
+    "/{scene_draft_id}/rescale",
+    response_model=SceneDraftDetailResponse,
+    summary="SceneDraft 전체 비례 재스케일 (단일 트랜잭션)",
+)
+def rescale_scene_draft(
+    payload: SceneDraftRescaleRequest,
+    scene_draft_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SceneDraftDetailResponse:
+    # walls·openings·rooms·objects + dependent metadata + summary scale_ratio 를 한 번에 ×factor.
+    # 프론트의 N-PATCH 패턴을 단일 요청으로 통합 (대규모 도면에서 클라이언트 폭주 방지).
+    return scene_draft_service.rescale_scene_draft(
+        db,
+        scene_draft_id,
+        current_user,
+        factor=payload.factor,
         scale_source=payload.scale_source,
     )
 

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -53,10 +53,11 @@ class SceneDraftRescaleRequest(BaseModel):
     백엔드가 walls·openings·rooms·objects geometry 및 dependent metadata 를 일괄 곱하고,
     summary_json.scale_ratio_m_per_px 도 같이 ×factor.
 
-    factor: 실측값 / 현재 도형 길이. 1.0 이면 no-op. 범위 (0.001, 1000) 강제.
+    factor: 실측값 / 현재 도형 길이. 1.0 이면 no-op. 범위 [0.001, 1000] 강제.
+            DTO 단에서 막아 422 로 일찍 거절 + Swagger 문서에 명시.
     scale_source: 보통 "manual_rescale" — summary.wall_postprocess.scale_source 에 기록.
     """
-    factor: float
+    factor: float = Field(ge=0.001, le=1000.0)
     scale_source: str | None = None
 
 

--- a/backend/app/schemas/scene_draft.py
+++ b/backend/app/schemas/scene_draft.py
@@ -46,6 +46,20 @@ class SceneDraftUpdateRequest(BaseModel):
     scale_source: str | None = None
 
 
+class SceneDraftRescaleRequest(BaseModel):
+    """POST /scene-drafts/{id}/rescale — 한 트랜잭션 안에서 draft 전체 비례 재스케일.
+
+    프론트에서 entity 별로 PATCH 를 N번 보내던 흐름을 단일 요청으로 통합.
+    백엔드가 walls·openings·rooms·objects geometry 및 dependent metadata 를 일괄 곱하고,
+    summary_json.scale_ratio_m_per_px 도 같이 ×factor.
+
+    factor: 실측값 / 현재 도형 길이. 1.0 이면 no-op. 범위 (0.001, 1000) 강제.
+    scale_source: 보통 "manual_rescale" — summary.wall_postprocess.scale_source 에 기록.
+    """
+    factor: float
+    scale_source: str | None = None
+
+
 class AnalyzeFromAssetRequest(BaseModel):
     """POST /assets/{asset_id}/analyze 본문.
 

--- a/backend/app/services/scene/scene_draft_service.py
+++ b/backend/app/services/scene/scene_draft_service.py
@@ -633,10 +633,11 @@ def rescale_scene_draft(
 
     factor 범위: 0.001 ≤ factor ≤ 1000. 1.0 근처면 no-op 으로 현재 상태만 반환.
     """
+    # DTO Field 가 이미 [0.001, 1000] 막지만 서비스 단에서도 한 번 더 — 내부 호출 안전망.
     if not (0.001 <= factor <= 1000.0):
         raise AppError(
             ErrorCode.INVALID_REQUEST_BODY,
-            f"factor must be in (0.001, 1000), got {factor}",
+            f"factor must be in [0.001, 1000], got {factor}",
             status_code=400,
         )
 
@@ -670,7 +671,15 @@ def rescale_scene_draft(
             wp["scale_source"] = scale_source
             summary["wall_postprocess"] = wp
             scene_draft.summary_json = summary
-            db.commit()
+            try:
+                db.commit()
+            except SQLAlchemyError as exc:
+                db.rollback()
+                raise AppError(
+                    ErrorCode.SCENE_DRAFT_SAVE_FAILED,
+                    f"Failed to update scene draft summary: {exc}",
+                    500,
+                ) from exc
         return get_scene_draft(db, scene_draft_id, current_user)
 
     f = float(factor)
@@ -738,7 +747,17 @@ def rescale_scene_draft(
         summary["wall_postprocess"] = wp
     scene_draft.summary_json = summary
 
-    db.commit()
+    # 1~5 모든 mutation 은 in-memory ORM 상태만 변경 — commit 에서 한 트랜잭션으로 flush.
+    # 실패 시 좌표·metadata·summary 가 부분 적용되지 않게 전체 rollback (save_scene_draft 와 동일 패턴).
+    try:
+        db.commit()
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise AppError(
+            ErrorCode.SCENE_DRAFT_SAVE_FAILED,
+            f"Failed to persist scene draft rescale: {exc}",
+            500,
+        ) from exc
     return get_scene_draft(db, scene_draft_id, current_user)
 
 

--- a/backend/app/services/scene/scene_draft_service.py
+++ b/backend/app/services/scene/scene_draft_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, selectinload
 from app.schemas.pagination import PaginatedResponse
 
 from app.core.errors import AppError, ErrorCode
-from app.core.geom import wkb_to_geojson
+from app.core.geom import scale_wkb, wkb_to_geojson
 from app.core.settings import (
     DEFAULT_DRAFT_ANALYSIS_METHOD,
     DEFAULT_DRAFT_FLOOR_NAME,
@@ -607,6 +607,138 @@ def update_scene_draft_summary(
     scene_draft.summary_json = summary
     db.commit()
     db.refresh(scene_draft)
+    return get_scene_draft(db, scene_draft_id, current_user)
+
+
+def rescale_scene_draft(
+    db: Session,
+    scene_draft_id: str,
+    current_user: User,
+    *,
+    factor: float,
+    scale_source: str | None = None,
+) -> SceneDraftDetailResponse:
+    """한 트랜잭션 안에서 SceneDraft 전체를 비례 재스케일 (한 벽/문 실측 기반).
+
+    프론트에서 entity 별 PATCH 를 N 번 보내던 흐름을 단일 요청으로 통합:
+      - walls.centerline_geom / polygon_geom × factor
+        + metadata.dimension_length.meters / dimension_match.parsed_meters / user_meters × factor
+        (matched_wall_px_len 은 픽셀이라 안 건드림)
+      - openings.line_geom / polygon_geom × factor, width_m × factor
+        (height_m 은 수직 방향이라 안 건드림)
+      - rooms.polygon_geom / centroid_geom × factor
+      - objects.point_geom × factor, metadata.width_m / height_m × factor
+      - summary_json.scale_ratio_m_per_px × factor (있을 때),
+        summary_json.wall_postprocess.scale_source = scale_source (있을 때)
+
+    factor 범위: 0.001 ≤ factor ≤ 1000. 1.0 근처면 no-op 으로 현재 상태만 반환.
+    """
+    if not (0.001 <= factor <= 1000.0):
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            f"factor must be in (0.001, 1000), got {factor}",
+            status_code=400,
+        )
+
+    scene_draft = (
+        db.query(SceneDraft)
+        .join(Project, SceneDraft.project_id == Project.id)
+        .filter(
+            SceneDraft.id == scene_draft_id,
+            Project.owner_user_id == current_user.id,
+        )
+        .options(
+            selectinload(SceneDraft.draft_rooms),
+            selectinload(SceneDraft.draft_walls),
+            selectinload(SceneDraft.draft_openings),
+            selectinload(SceneDraft.draft_objects),
+        )
+        .first()
+    )
+    if scene_draft is None:
+        raise AppError(
+            ErrorCode.SCENE_DRAFT_NOT_FOUND,
+            "Scene draft not found.",
+            status_code=404,
+        )
+
+    if abs(factor - 1.0) < 1e-9:
+        # no-op (입력 = 현재 길이) — summary 만 갱신 (사용자가 source 만 바꾸려는 경우 대비).
+        if scale_source is not None:
+            summary = dict(scene_draft.summary_json or {})
+            wp = dict(summary.get("wall_postprocess") or {})
+            wp["scale_source"] = scale_source
+            summary["wall_postprocess"] = wp
+            scene_draft.summary_json = summary
+            db.commit()
+        return get_scene_draft(db, scene_draft_id, current_user)
+
+    f = float(factor)
+
+    # 1) walls
+    for w in scene_draft.draft_walls:
+        if w.centerline_geom is not None:
+            w.centerline_geom = scale_wkb(w.centerline_geom, f)
+        if w.polygon_geom is not None:
+            w.polygon_geom = scale_wkb(w.polygon_geom, f)
+        # metadata 의 표시용 길이 — 옛 도면 길이가 패널에 그대로 보이지 않도록 같이 갱신.
+        meta = dict(w.metadata_json or {})
+        dl = meta.get("dimension_length")
+        if isinstance(dl, dict):
+            dl = dict(dl)
+            if isinstance(dl.get("meters"), (int, float)):
+                dl["meters"] = float(dl["meters"]) * f
+            meta["dimension_length"] = dl
+        dm = meta.get("dimension_match")
+        if isinstance(dm, dict):
+            dm = dict(dm)
+            for k in ("parsed_meters", "user_meters"):
+                v = dm.get(k)
+                if isinstance(v, (int, float)):
+                    dm[k] = float(v) * f
+            meta["dimension_match"] = dm
+        w.metadata_json = meta
+
+    # 2) openings — width_m 은 Numeric(Decimal). height_m 은 안 건드림 (수직).
+    from decimal import Decimal
+    for o in scene_draft.draft_openings:
+        if o.line_geom is not None:
+            o.line_geom = scale_wkb(o.line_geom, f)
+        if o.polygon_geom is not None:
+            o.polygon_geom = scale_wkb(o.polygon_geom, f)
+        if o.width_m is not None:
+            o.width_m = (Decimal(o.width_m) * Decimal(str(f))).quantize(Decimal("0.001"))
+
+    # 3) rooms
+    for r in scene_draft.draft_rooms:
+        if r.polygon_geom is not None:
+            r.polygon_geom = scale_wkb(r.polygon_geom, f)
+        if r.centroid_geom is not None:
+            r.centroid_geom = scale_wkb(r.centroid_geom, f)
+
+    # 4) objects — metadata.width_m / height_m 은 floor-plane 박스 크기 → 같이 곱.
+    for ob in scene_draft.draft_objects:
+        if ob.point_geom is not None:
+            ob.point_geom = scale_wkb(ob.point_geom, f)
+        meta = dict(ob.metadata_json or {})
+        for k in ("width_m", "height_m"):
+            v = meta.get(k)
+            if isinstance(v, (int, float)):
+                meta[k] = float(v) * f
+        ob.metadata_json = meta
+
+    # 5) summary scale_ratio + scale_source
+    summary = dict(scene_draft.summary_json or {})
+    old_scale = summary.get("scale_ratio_m_per_px")
+    if isinstance(old_scale, (int, float)) and old_scale > 0:
+        summary["scale_ratio_m_per_px"] = float(old_scale) * f
+    if scale_source is not None:
+        wp = dict(summary.get("wall_postprocess") or {})
+        wp["scale_source"] = scale_source
+        summary["wall_postprocess"] = wp
+    scene_draft.summary_json = summary
+
+    db.commit()
     return get_scene_draft(db, scene_draft_id, current_user)
 
 

--- a/frontend/src/api/scene-draft.ts
+++ b/frontend/src/api/scene-draft.ts
@@ -75,12 +75,11 @@ export const sceneDraftApi = {
       .post<SceneDraft>(`/floors/${floorId}/scene-drafts`, { source_mode: 'manual' })
       .then((r) => r.data),
 
-  // PATCH /scene-drafts/{id} — summary_json 일부(scale_ratio_m_per_px 등) 갱신.
-  // 사용자가 한 벽/문/창 실측값으로 전체 재스케일할 때 좌표 PATCH 들과 묶여 호출.
-  patch: (
-    id: UUID,
-    body: { scale_ratio_m_per_px?: number; scale_source?: string },
-  ) => api.patch<SceneDraft>(`/scene-drafts/${id}`, body).then((r) => r.data),
+  // POST /scene-drafts/{id}/rescale — 한 트랜잭션 안에서 draft 전체를 factor 만큼 비례 재스케일.
+  // walls·openings·rooms·objects 의 geometry + 종속 metadata + summary.scale_ratio 를 일괄 갱신.
+  // 프론트가 entity 별로 PATCH N번 보내던 패턴을 단일 요청으로 통합.
+  rescale: (id: UUID, body: { factor: number; scale_source?: string }) =>
+    api.post<SceneDraft>(`/scene-drafts/${id}/rescale`, body).then((r) => r.data),
 
   // §6.5 DELETE /scene-drafts/{id}
   remove: (id: UUID) => api.delete<void>(`/scene-drafts/${id}`).then((r) => r.data),

--- a/frontend/src/hooks/use-scene-draft.ts
+++ b/frontend/src/hooks/use-scene-draft.ts
@@ -94,18 +94,22 @@ export function useCreateEmptyDraft() {
 }
 
 /**
- * PATCH /scene-drafts/{id} — summary 일부(scale_ratio_m_per_px / scale_source) 갱신.
- * 사용자가 한 벽·문/창 실측값으로 전체 재스케일할 때 좌표 PATCH 들과 묶여 호출됨.
- * 성공 시 draft detail 캐시는 무효화 (좌표 PATCH 들도 같은 캐시 무효화하므로 한 번에 refetch).
+ * POST /scene-drafts/{id}/rescale — draft 전체를 factor 만큼 비례 재스케일.
+ * 백엔드가 한 트랜잭션으로 walls·openings·rooms·objects geometry 와 종속 metadata,
+ * summary.scale_ratio 를 일괄 ×factor 처리. 프론트는 단일 요청만 보내고
+ * 응답으로 draft detail 캐시를 1회 무효화.
  */
-export function usePatchSceneDraft() {
+export function useRescaleSceneDraft() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (vars: {
-      id: UUID;
-      body: { scale_ratio_m_per_px?: number; scale_source?: string };
-    }) => sceneDraftApi.patch(vars.id, vars.body),
-    onSuccess: (_data, vars) => {
+    mutationFn: (vars: { id: UUID; factor: number; scaleSource?: string }) =>
+      sceneDraftApi.rescale(vars.id, {
+        factor: vars.factor,
+        ...(vars.scaleSource ? { scale_source: vars.scaleSource } : {}),
+      }),
+    onSuccess: (data, vars) => {
+      // 응답이 갱신된 detail 이라 캐시에 직접 채우고 invalidate (좌표·summary 한 번에 반영).
+      qc.setQueryData(['scene-draft', vars.id], data);
       qc.invalidateQueries({ queryKey: ['scene-draft', vars.id] });
     },
     onError: (err) => {

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -8,7 +8,7 @@ import {
   useCreateEmptyDraft,
   useDeleteSceneDraft,
   useDraftsForFloor,
-  usePatchSceneDraft,
+  useRescaleSceneDraft,
   useSceneDraft,
 } from '@/hooks/use-scene-draft';
 import { useFloorplanJob } from '@/hooks/use-floorplan-job';
@@ -72,7 +72,7 @@ export default function EditorPage() {
   const createEmptyDraft = useCreateEmptyDraft();
   const promote = usePromoteDraft();
   const removeDraft = useDeleteSceneDraft();
-  const patchSceneDraft = usePatchSceneDraft();
+  const rescaleSceneDraft = useRescaleSceneDraft();
   const patchEntity = usePatchDraftEntity();
   const deleteEntity = useDeleteDraftEntity();
   const createEntity = useCreateDraftEntity();
@@ -570,10 +570,10 @@ export default function EditorPage() {
   /**
    * 선택된 벽/문/창의 실측값(m)을 기준으로 도면 전체를 비례 스케일.
    * - factor = targetMeters / 현재 도형 길이(centerline_geom 또는 line_geom).
-   * - 모든 벽 centerline_geom, 문/창 line_geom + width_m, 방 polygon_geom,
-   *   가구 point_geom + metadata width_m/height_m 에 factor 곱.
-   * - SceneDraft.summary_json.scale_ratio_m_per_px *= factor, scale_source='manual_rescale'.
-   * - Undo 한 번에 되돌리기 어렵고 (N 개 엔티티 분산 변경) → skipHistory + 확인 다이얼로그.
+   * - 백엔드 POST /scene-drafts/{id}/rescale 단일 호출 — walls·openings·rooms·objects
+   *   geometry 와 종속 metadata(dimension_length, dimension_match, object size 등)
+   *   + summary.scale_ratio 까지 한 트랜잭션 안에서 ×factor.
+   * - 프론트가 N-PATCH 보내던 패턴을 1요청으로 통합 → 큰 도면에서 네트워크·캐시 폭주 방지.
    */
   const handleScaleAll = (targetMeters: number) => {
     if (!selectedRef || (selectedRef.kind !== 'wall' && selectedRef.kind !== 'opening')) return;
@@ -595,7 +595,7 @@ export default function EditorPage() {
       return len;
     };
 
-    // 1) 소스 엔티티의 현재 길이
+    // 소스 엔티티의 현재 길이로 factor 계산
     let currentLength: number | null = null;
     if (selectedRef.kind === 'wall') {
       const wall = activeDraft.walls.find((w) => w.id === selectedRef.id);
@@ -633,112 +633,16 @@ export default function EditorPage() {
     );
     if (!ok) return;
 
-    const scaleXY = (x: number, y: number): [number, number] => [x * factor, y * factor];
-
-    // 2) walls: centerline_geom 좌표 + 표시용 metadata 길이도 같이 × factor.
-    //    (PropertiesPanel 은 metadata.dimension_length.meters / dimension_match.parsed_meters
-    //     를 "도면 길이" 로 보여줘서, 좌표만 갱신하면 패널에 옛 값이 계속 보임.)
-    //    matched_wall_px_len 은 픽셀이라 안 건드림. user_meters 도 사용자 입력 truth 이므로
-    //    같은 factor 로 같이 옮겨 일관성 유지.
-    for (const w of activeDraft.walls) {
-      const g = parseGeometry(w.centerline_geom);
-      if (g?.type !== 'LineString') continue;
-      const scaled = {
-        type: 'LineString' as const,
-        coordinates: g.coordinates.map(([x, y]) => scaleXY(x, y)),
-      };
-      const meta = (w.metadata_json ?? {}) as Record<string, unknown>;
-      const newMeta: Record<string, unknown> = { ...meta };
-      const dimLen = meta.dimension_length as { meters?: number } | undefined;
-      if (dimLen && typeof dimLen.meters === 'number') {
-        newMeta.dimension_length = { ...dimLen, meters: dimLen.meters * factor };
-      }
-      const dimMatch = meta.dimension_match as
-        | { parsed_meters?: number; user_meters?: number | null }
-        | undefined;
-      if (dimMatch) {
-        const nextDim: Record<string, unknown> = { ...dimMatch };
-        if (typeof dimMatch.parsed_meters === 'number') {
-          nextDim.parsed_meters = dimMatch.parsed_meters * factor;
-        }
-        if (typeof dimMatch.user_meters === 'number') {
-          nextDim.user_meters = dimMatch.user_meters * factor;
-        }
-        newMeta.dimension_match = nextDim;
-      }
-      runPatch(
-        'wall',
-        w.id,
-        { centerline_geom: scaled, metadata_json: newMeta },
-        { silent: true, skipHistory: true },
-      );
-    }
-    // 3) openings: line_geom 좌표 + width_m
-    for (const o of activeDraft.openings) {
-      const g = parseGeometry(o.line_geom);
-      const patch: Record<string, unknown> = {};
-      if (g?.type === 'LineString') {
-        patch.line_geom = {
-          type: 'LineString',
-          coordinates: g.coordinates.map(([x, y]) => scaleXY(x, y)),
-        };
-      }
-      const ow = Number(o.width_m);
-      if (Number.isFinite(ow) && ow > 0) {
-        patch.width_m = (ow * factor).toFixed(3);
-      }
-      if (Object.keys(patch).length > 0) {
-        runPatch('opening', o.id, patch, { silent: true, skipHistory: true });
-      }
-    }
-    // 4) rooms: polygon_geom 좌표
-    for (const r of activeDraft.rooms) {
-      const g = parseGeometry(r.polygon_geom);
-      if (g?.type !== 'Polygon') continue;
-      const scaled = {
-        type: 'Polygon' as const,
-        coordinates: g.coordinates.map((ring) => ring.map(([x, y]) => scaleXY(x, y))),
-      };
-      runPatch('room', r.id, { polygon_geom: scaled }, { silent: true, skipHistory: true });
-    }
-    // 5) objects: point_geom + metadata width_m/height_m
-    for (const obj of activeDraft.objects) {
-      const g = parseGeometry(obj.point_geom);
-      const meta = (obj.metadata_json ?? {}) as Record<string, unknown>;
-      const patch: Record<string, unknown> = {};
-      if (g?.type === 'Point') {
-        const [x, y] = g.coordinates;
-        patch.point_geom = { type: 'Point', coordinates: scaleXY(x, y) };
-      }
-      const curW = typeof meta.width_m === 'number' ? meta.width_m : null;
-      const curH = typeof meta.height_m === 'number' ? meta.height_m : null;
-      if (curW != null || curH != null) {
-        patch.metadata_json = {
-          ...meta,
-          ...(curW != null ? { width_m: curW * factor } : {}),
-          ...(curH != null ? { height_m: curH * factor } : {}),
-        };
-      }
-      if (Object.keys(patch).length > 0) {
-        runPatch('object', obj.id, patch, { silent: true, skipHistory: true });
-      }
-    }
-    // 6) SceneDraft summary scale_ratio: 픽셀↔미터 일관성 유지를 위해 같은 factor 곱.
-    const summary = (activeDraft.summary_json ?? {}) as Record<string, unknown>;
-    const oldScale = Number(summary.scale_ratio_m_per_px);
-    const newScale =
-      Number.isFinite(oldScale) && oldScale > 0 ? oldScale * factor : undefined;
-    patchSceneDraft.mutate({
-      id: activeDraft.id,
-      body: {
-        ...(newScale != null ? { scale_ratio_m_per_px: newScale } : {}),
-        scale_source: 'manual_rescale',
+    rescaleSceneDraft.mutate(
+      { id: activeDraft.id, factor, scaleSource: 'manual_rescale' },
+      {
+        onSuccess: () => {
+          toast.info(
+            '도면 전체를 재스케일했습니다',
+            `${factor.toFixed(3)}× — ${currentLength.toFixed(2)} m → ${targetMeters.toFixed(2)} m`,
+          );
+        },
       },
-    });
-
-    toast.info(
-      '도면 전체를 재스케일했습니다',
-      `${factor.toFixed(3)}× — ${currentLength.toFixed(2)} m → ${targetMeters.toFixed(2)} m`,
     );
   };
 


### PR DESCRIPTION
## 개요
기존 프론트엔드에서 벽, 문, 방, 객체를 각각 여러 번 PATCH 요청으로 갱신
(네트워크 요청이 많아지고, 중간 요청 실패 시 일부 엔티티만 스케일이 바뀌는 불일치 위험)
이번 PR에서 `POST /scene-drafts/{scene_draft_id}/rescale` 엔드포인트를 추가하여, ScenceDraft 전체 스케일 보정을 백엔드 단일 요청으로 처리하도록 리팩토링

## 변경 사항
### 1. `scale_wkb()` 유틸 및 `SceneDraftRescaleRequest` DTO 추가
- WKB geometry를 `(0,0)` 기준으로 `factor`만큼 비례 확대/축소
- 도면 좌표계가 top-left origin 기반이므로 전체 좌표에 동일 factor를 곱하는 방식으로 처리
- `factor`: 실측값/현재 도형 길이, `scale_source`: 예:`manual_rescale`

### 2. `POST /scene-draft/{scence_draft_id}`
- 프론트에서 여러 엔티티별 PATCH를 보내던 흐름을 단일 요청으로 통합
- 응답은 갱신된 `SceneDraftDetailResponse`를 반환

### 3. `rescale_scene_draft()` 서비스 로직 추가
- 하나의 트랜잭션 안에서 geom 관련 항목을 모두 일괄 보정

## 테스트
- [x] 벽을 선택하고 실측 길이를 입력한 뒤 전체 도면이 정상적으로 재스케일되는지 확인
- [x] 문/창을 선택하고 실측 폭을 입력한 뒤 전체 도면이 정상적으로 재스케일되는지 확인