### PR TITLE
fix: 시뮬 reset + RF status 필터 + calibration AP키/status normalize + 과거 …

### DIFF
--- a/backend/app/schemas/calibration_run.py
+++ b/backend/app/schemas/calibration_run.py
@@ -5,7 +5,9 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.core.enums import normalize_job_status
 
 
 class CalibrationRunCreate(BaseModel):
@@ -33,6 +35,14 @@ class CalibrationRunResponse(BaseModel):
     error_heatmap_url: Optional[str] = None
     created_at: datetime
     finished_at: Optional[datetime] = None
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _normalize_status(cls, v: Any) -> Any:
+        """내부 status(completed/queued) → API 표기(succeeded/pending). 프론트 폴링 종료 인식용."""
+        if isinstance(v, str):
+            return normalize_job_status(v)
+        return v
 
 
 class CalibrationRunUpdate(BaseModel):

--- a/backend/app/services/rf/calibration_worker/runner.py
+++ b/backend/app/services/rf/calibration_worker/runner.py
@@ -151,9 +151,10 @@ def _load_aps(
 
     if fallback_request_json:
         for entry in fallback_request_json.get("access_points") or []:
-            pos = entry.get("position") or entry
-            x = pos.get("x") if isinstance(pos, dict) else None
-            y = pos.get("y") if isinstance(pos, dict) else None
+            pos = entry.get("position") if isinstance(entry.get("position"), dict) else entry
+            # 프론트는 x_m/y_m, 옛 흐름은 x/y, position:{x,y} 등 — 다 받아줌.
+            x = pos.get("x_m", pos.get("x")) if isinstance(pos, dict) else None
+            y = pos.get("y_m", pos.get("y")) if isinstance(pos, dict) else None
             if x is None or y is None:
                 continue
             aps.append(AccessPoint(

--- a/backend/app/services/rf/rf_run_service.py
+++ b/backend/app/services/rf/rf_run_service.py
@@ -176,8 +176,17 @@ def list_by_floor(
     base = select(RfRun).where(RfRun.floor_id == str(floor_id))
     count_stmt = select(func.count(RfRun.id)).where(RfRun.floor_id == str(floor_id))
     if status is not None:
-        base = base.where(RfRun.status == status)
-        count_stmt = count_stmt.where(RfRun.status == status)
+        # 프론트는 API 표기(succeeded/pending)로 필터하는데 DB 는 내부값(done/completed/queued)
+        # 으로 저장 → 역매핑해서 IN 필터. (응답 normalize 의 역방향)
+        _api_to_internal: dict[str, list[str]] = {
+            "succeeded": ["done", "completed", "succeeded"],
+            "pending": ["queued", "pending"],
+            "running": ["running"],
+            "failed": ["failed"],
+        }
+        internal_statuses = _api_to_internal.get(status, [status])
+        base = base.where(RfRun.status.in_(internal_statuses))
+        count_stmt = count_stmt.where(RfRun.status.in_(internal_statuses))
 
     total = db.execute(count_stmt).scalar() or 0
     rows = (

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -11,7 +11,7 @@ import {
   Trash2,
   Wifi,
 } from 'lucide-react';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import { useCreateRfRun, useFloorRfRuns, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
@@ -88,6 +88,22 @@ export default function SimulationPage() {
     !activeRunSceneVersionId ||
     !currentVersion ||
     activeRunSceneVersionId === currentVersion.id;
+
+  // 활성 run(과거/자동복원 포함)의 AP 를 캔버스에 복원 — 결과 화면에 AP 마커가 보이도록.
+  // (aps state 는 사용자가 직접 찍은 것만 담기는데, 과거 run 을 불러올 땐 비어 있어 마커가 안 떴음)
+  useEffect(() => {
+    const aps_raw = (rfRunPoll.rfRun?.request_json?.['access_points'] ?? []) as Array<
+      Record<string, unknown>
+    >;
+    if (!Array.isArray(aps_raw) || aps_raw.length === 0) return;
+    const restored: PlacedAp[] = aps_raw.map((a, i) => ({
+      id: String(a['id'] ?? `ap${i + 1}`),
+      x_m: Number(a['x_m'] ?? a['x'] ?? 0),
+      y_m: Number(a['y_m'] ?? a['y'] ?? 0),
+      z_m: Number(a['z_m'] ?? a['z'] ?? 2.5),
+    }));
+    setAps(restored);
+  }, [rfRunPoll.rfRun]);
   // 백엔드가 RfMapResponse 에 presigned `url` 을 자동 채워주므로 (PR #70)
   // /rf-jobs 별도 호출 없이 /maps 응답 하나로 heatmap URL + bounds 둘 다 처리.
   const heatmapMap = useMemo(() => {
@@ -142,6 +158,7 @@ export default function SimulationPage() {
   const handleReset = () => {
     setPickedRunId(null);
     setResetCleared(true);
+    setAps([]); // 배치 화면으로 돌아가면 새로 찍도록 초기화
   };
 
   const handleAddAp = (ap: PlacedAp) => setAps((prev) => [...prev, ap]);


### PR DESCRIPTION
## 변경 사항

### 백엔드
- `CalibrationRunResponse.status` 에 normalize validator 추가 — 내부 표기(`completed`/`queued`) 를 API 표기(`succeeded`/`pending`) 로 변환해 프론트가 폴링 종료를 인식하도록 함.
- calibration worker fallback AP 로딩에서 좌표 키를 `x_m`/`y_m` (프론트), `x`/`y` (옛 흐름), `position:{x,y}` 모두 호환되게 수정.
- `list_by_floor` 의 status 필터에 역매핑 추가 — 프론트가 `succeeded` 로 필터해도 DB 의 `done`/`completed` 와 매칭되도록 `IN` 필터로 변환.

### 프론트
- `SimulationPage` "다시 실행" 시 배치된 AP 도 같이 초기화하도록 `setAps([])` 추가.
- 활성 run 의 `request_json.access_points` 를 캔버스 `aps` state 로 복원하는 `useEffect` 추가 — 과거 run 을 열었을 때 AP 마커가 보이지 않던 문제 해결.

## 테스트
- [ ] calibration 실행 후 프론트가 완료 상태를 정상 인식하는지 확인
- [ ] 시뮬 이력에서 과거 run 클릭 시 히트맵 + AP 마커가 같이 뜨는지 확인
- [ ] "다시 실행" 후 캔버스가 비어 있는 상태로 돌아오는지 확인