### PR TITLE
fix: 실측 GP 히트맵 align — scene 벽 bbox 기준 + PNG chrome 제거 + 시뮬 reset 시 A…

### DIFF
--- a/backend/app/services/rf/measurement_estimation/heatmap.py
+++ b/backend/app/services/rf/measurement_estimation/heatmap.py
@@ -33,35 +33,27 @@ def _render_to_png(
     colorbar_label: str,
     overlay_points: list[tuple[float, float]] | None = None,
 ) -> bytes:
-    """grid + 컬러맵 → PNG bytes. 좌표축 = 미터."""
+    """grid → 컬러맵 적용한 raw PNG bytes (chrome 없음).
+
+    프론트가 PNG 전체를 bounds 사각형에 stretch 하기 때문에 축/제목/컬러바 같은
+    matplotlib chrome 이 박히면 데이터 영역이 어긋남. axes 만 figure 전체에 깔고
+    축 끄기 + padding 0 으로 저장 — PNG 한 픽셀이 grid 한 셀.
+    """
     H, W = grid.shape
-    # 도면 비율 그대로 (figsize 약간 조정)
-    aspect = (xs[-1] - xs[0]) / max(ys[-1] - ys[0], 1e-6)
-    fig_h = 6
-    fig_w = max(4.0, min(16.0, fig_h * aspect))
-    fig, ax = plt.subplots(figsize=(fig_w, fig_h), dpi=120)
-    im = ax.imshow(
+    fig = plt.figure(figsize=(W / 100.0, H / 100.0), dpi=100, frameon=False)
+    ax = fig.add_axes((0.0, 0.0, 1.0, 1.0))
+    ax.set_axis_off()
+    ax.imshow(
         grid,
-        extent=(xs[0], xs[-1], ys[-1], ys[0]),  # y 뒤집기 — top_left 원점
         cmap=cmap,
         vmin=vmin,
         vmax=vmax,
         interpolation="bilinear",
         aspect="auto",
     )
-    if overlay_points:
-        pxs = [p[0] for p in overlay_points]
-        pys = [p[1] for p in overlay_points]
-        ax.scatter(pxs, pys, s=8, c="white", edgecolors="black", linewidths=0.5, alpha=0.8)
-    ax.set_xlabel("x (m)")
-    ax.set_ylabel("y (m)")
-    ax.set_title(title)
-    cb = plt.colorbar(im, ax=ax, shrink=0.85)
-    cb.set_label(colorbar_label)
-    plt.tight_layout()
 
     buf = io.BytesIO()
-    fig.savefig(buf, format="png")
+    fig.savefig(buf, format="png", pad_inches=0)
     plt.close(fig)
     return buf.getvalue()
 

--- a/backend/app/services/rf/measurement_service.py
+++ b/backend/app/services/rf/measurement_service.py
@@ -183,6 +183,58 @@ def _floorplan_info_from_asset(db: Session, asset_id: str | None) -> FloorplanIn
     )
 
 
+def _bounds_from_scene_walls(db: Session, floor_id: str) -> FloorBoundsDTO | None:
+    """Confirmed scene 의 벽/개구부 좌표로 bbox 계산.
+
+    프론트 MeasurementCanvas 의 viewBox 도 같은 (walls + openings) 기준으로 잡힘.
+    히트맵 PNG 가 도면 위에 정확히 깔리려면 같은 좌표계 bounds 가 필요.
+    confirmed scene 이 없거나 벽이 0개면 None — 호출측에서 다음 fallback 사용.
+    """
+    from app.core.geom import wkb_to_geojson
+    from app.models.opening import Opening
+    from app.models.wall import Wall
+
+    scene = db.execute(
+        select(SceneVersion)
+        .where(
+            SceneVersion.floor_id == floor_id,
+            SceneVersion.is_confirmed.is_(True),
+        )
+        .order_by(SceneVersion.version_no.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if scene is None:
+        return None
+
+    minx = miny = float("inf")
+    maxx = maxy = float("-inf")
+    for w in db.execute(
+        select(Wall).where(Wall.scene_version_id == scene.id)
+    ).scalars().all():
+        gj = wkb_to_geojson(w.centerline_geom)
+        if not gj or gj.get("type") != "LineString":
+            continue
+        for x, y in gj["coordinates"]:
+            if x < minx: minx = x
+            if y < miny: miny = y
+            if x > maxx: maxx = x
+            if y > maxy: maxy = y
+    for o in db.execute(
+        select(Opening).where(Opening.scene_version_id == scene.id)
+    ).scalars().all():
+        gj = wkb_to_geojson(o.line_geom)
+        if not gj or gj.get("type") != "LineString":
+            continue
+        for x, y in gj["coordinates"]:
+            if x < minx: minx = x
+            if y < miny: miny = y
+            if x > maxx: maxx = x
+            if y > maxy: maxy = y
+    if minx == float("inf"):
+        return None
+    return FloorBoundsDTO(min_x=minx, min_y=miny, max_x=maxx, max_y=maxy)
+
+
 def _bounds_from_floorplan(floorplan: FloorplanInfoDTO) -> FloorBoundsDTO:
     if (
         floorplan.width_px is None
@@ -617,10 +669,13 @@ def estimate_session_coverage(
             400,
         )
 
-    # bounds — floor 의 floorplan 메타데이터 → 없으면 측정점 bbox
-    asset = _latest_floorplan_asset(db, str(session_row.floor_id))
-    floorplan = _floorplan_info_from_asset(db, asset.id if asset else None)
-    bounds_dto = _bounds_from_floorplan(floorplan)
+    # bounds — confirmed scene 의 벽/개구부 bbox 우선 (프론트 캔버스가 이 좌표계로 도면을 그림).
+    # 도면 이미지 픽셀 bounds 는 scene 좌표계와 어긋날 수 있어 후순위.
+    bounds_dto = _bounds_from_scene_walls(db, str(session_row.floor_id))
+    if bounds_dto is None:
+        asset = _latest_floorplan_asset(db, str(session_row.floor_id))
+        floorplan = _floorplan_info_from_asset(db, asset.id if asset else None)
+        bounds_dto = _bounds_from_floorplan(floorplan)
     if bounds_dto.max_x <= 0 or bounds_dto.max_y <= 0:
         # fallback: 측정점 bbox + 1m 마진
         xs = [p[0] for p in points]

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -158,7 +158,8 @@ export default function SimulationPage() {
   const handleReset = () => {
     setPickedRunId(null);
     setResetCleared(true);
-    setAps([]); // 배치 화면으로 돌아가면 새로 찍도록 초기화
+    // AP 위치는 유지 — 보정 후 동일 배치로 재시뮬하는 케이스가 많음.
+    // 새로 찍고 싶으면 캔버스에서 개별 삭제하면 됨.
   };
 
   const handleAddAp = (ap: PlacedAp) => setAps((prev) => [...prev, ap]);


### PR DESCRIPTION
## Summary
실측 GP 히트맵이 도면과 어긋나는 문제 2건과, 시뮬 "다시 실행" 시 AP 위치가 사라지는 UX 문제를 함께 수정한다.

## Changes

### 1. 히트맵 bounds 를 scene 벽 좌표계로 맞춘다 (`measurement_service.py`)
기존엔 도면 이미지 픽셀 (`width_px × scale_m_per_px`) 로 bounds 를 계산해서 반환한다. 하지만 프론트 `MeasurementCanvas` 의 viewBox 는 scene 의 walls + openings 좌표계로 잡힌다. 도면 이미지가 (0,0) 원점이 아니거나 픽셀-meter scale 이 어긋난 floor 에서 히트맵이 좌상단으로 밀려서 표시된다.

`_bounds_from_scene_walls(db, floor_id)` 헬퍼를 추가하고, `estimate_session_coverage` 의 bounds 선택 순서를 다음과 같이 바꾼다:

1. confirmed scene 의 walls + openings bbox (캔버스와 동일 좌표계)
2. floorplan 이미지 bbox (기존 동작)
3. 측정점 bbox + 1m 마진 (마지막 fallback)

### 2. 히트맵 PNG 에서 matplotlib chrome 을 제거한다 (`heatmap.py`)
`plt.subplots()` + 제목/축/컬러바/`tight_layout()` 으로 PNG 를 저장하면 데이터 영역이 이미지 안에서 한참 안쪽으로 들어간다. 프론트는 PNG 전체를 bounds 사각형에 stretch 하므로 데이터 위치가 어긋나서 표시된다.

`fig.add_axes((0,0,1,1))` + `set_axis_off()` + `pad_inches=0` 으로 raw 히트맵만 저장하도록 바꾼다. PNG 한 픽셀이 grid 한 셀에 정확히 대응한다.

### 3. 시뮬 "다시 실행" 시 AP 위치를 유지한다 (`SimulationPage.tsx`)
기존 `handleReset` 은 `setAps([])` 로 AP 를 초기화한다. 보정 후 동일 배치로 재시뮬하는 흐름이 흔한데, AP 를 매번 새로 찍으면 위치가 살짝 달라져서 calibration 의 의미가 흐려진다.

`setAps([])` 만 제거한다. 새로 찍고 싶으면 캔버스에서 개별 삭제하면 된다.

## Test plan
- [x] 측정 페이지에서 보간 실행 → 히트맵이 벽/도형 위에 정확히 깔리는지 확인
- [x] 시뮬 결과 화면 → "다시 실행" 클릭 → AP 마커 유지되는지 확인
- [x] 보정 → 재시뮬 흐름에서 동일 AP 배치로 재실행 가능한지 확인