### PR TITLE
[Refactor] RF 시뮬레이션 기본 설정 단일화 및 Local ai_api 백엔드 연결

### DIFF
--- a/backend/app/core/rf_defaults.py
+++ b/backend/app/core/rf_defaults.py
@@ -1,0 +1,68 @@
+"""RF 시뮬레이션 디폴트 하이퍼파라미터 — 한 곳에서 조정.
+
+`RfSimulationParams` (요청 스키마) 의 Field default 가 이 모듈의 상수를 참조.
+프론트엔드가 안 보내는 모든 필드가 여기 값으로 채워진다.
+
+## 설계 의도
+
+- **5GHz 실내 Wi-Fi 기준** (project memory: 5GHz/20dBm/refraction=true 의도)
+- **CPU dev 빠른 preview** 가 1차 — max_depth/samples 는 약간 보수적
+- ai_api `SimulationConfig` 디폴트와 일관성 유지 (불일치 시 web-platform 값이 강제)
+
+## 정확도 ↑ 가 필요하면 (예: 논문/시연용)
+
+```python
+DEFAULT_MAX_DEPTH = 6              # 3 → 6  (반사 더 깊게)
+DEFAULT_SAMPLES_PER_TX = 500_000   # 100k → 500k (Sionna 권장)
+DEFAULT_RESOLUTION_M = 0.25        # 0.5 → 0.25 (셀 4배)
+```
+
+각각 CPU 에서 분 단위 → 십분대로 늘 수 있음. GPU 환경이면 부담 적음.
+
+## 디폴트 ↔ ai_api SimulationConfig 매핑
+
+| 여기 (web-platform)         | ai_api 도메인                              |
+|---------------------------- |-------------------------------------------|
+| DEFAULT_FREQUENCY_HZ        | PhysicalConfig.frequency_ghz × 1e9         |
+| DEFAULT_TX_POWER_DBM        | PhysicalConfig.tx_power_dbm               |
+| DEFAULT_MAX_DEPTH           | SolverConfig.max_depth                     |
+| DEFAULT_SAMPLES_PER_TX      | SolverConfig.samples_per_tx                |
+| DEFAULT_SEED                | SolverConfig.seed                          |
+
+(propagation: los/specular/refraction true, diffuse/diffraction false 는 ai_api 쪽에서 결정)
+"""
+from __future__ import annotations
+
+# ============================================================
+# 물리값 — 결과의 의미를 결정 (사용자가 UI 에서 바꿀 만한 값)
+# ============================================================
+# Wi-Fi 5 / 6 (5GHz band). 2.4GHz 가 필요하면 요청에서 override.
+DEFAULT_FREQUENCY_HZ: float = 5.0e9
+
+# 일반 indoor AP (~100mW). FCC indoor 5GHz 상한 30dBm/1W.
+DEFAULT_TX_POWER_DBM: float = 20.0
+
+
+# ============================================================
+# 측정 grid — 결과 해상도
+# ============================================================
+# 0.5m × 0.5m 셀. 0.25 로 낮추면 grid 4배 → CPU 시간 ~4배.
+DEFAULT_RESOLUTION_M: float = 0.25
+
+# 측정면 높이 (m). 1.0 = 책상/허리, 1.2~1.5 = 핸드폰 사용 평균.
+DEFAULT_MEASUREMENT_PLANE_Z_M: float = 1.0
+
+
+# ============================================================
+# Sionna RT solver — 속도 vs 정확도 트레이드오프
+# ============================================================
+# Ray 추적 최대 반사 횟수. 3 = direct + 3 bounce (CPU 빠른 preview).
+# Sionna 권장 5~6. 실내 다중경로 중요한 환경에선 5 이상 권장.
+DEFAULT_MAX_DEPTH: int = 6
+
+# TX 당 ray 수. 100k = CPU 수십초. 500k = Sionna 권장, CPU 분 단위.
+# 적으면 RSSI 가 노이지 (값이 cell 간 들쭉날쭉).
+DEFAULT_SAMPLES_PER_TX: int = 500_000
+
+# Monte Carlo 시드 — 재현성용.
+DEFAULT_SEED: int = 42

--- a/backend/app/core/rf_defaults.py
+++ b/backend/app/core/rf_defaults.py
@@ -1,35 +1,26 @@
-"""RF 시뮬레이션 디폴트 하이퍼파라미터 — 한 곳에서 조정.
+"""RF 시뮬레이션 디폴트 하이퍼파라미터 — **유일한 source of truth**.
 
-`RfSimulationParams` (요청 스키마) 의 Field default 가 이 모듈의 상수를 참조.
-프론트엔드가 안 보내는 모든 필드가 여기 값으로 채워진다.
+이 모듈만 보면 시뮬 동작이 결정된다. 다른 어디에 디폴트 박지 말 것:
+  - frontend `SimulationPage.tsx` 는 `simulation: {}` 빈 객체 전송 (override 안 함)
+  - web-platform `RfSimulationParams` 디폴트 가 여길 import 해서 채움
+  - ai_api 호출 페이로드 빌더 (`rf_backend_local._build_sionna_request_payload`) 가
+    여기 값을 명시적으로 모두 보냄 → ai_api `SimulationConfig` 디폴트는 fallback 일 뿐
 
-## 설계 의도
+## ai_api `SimulationConfig` 와의 관계
 
-- **5GHz 실내 Wi-Fi 기준** (project memory: 5GHz/20dBm/refraction=true 의도)
-- **CPU dev 빠른 preview** 가 1차 — max_depth/samples 는 약간 보수적
-- ai_api `SimulationConfig` 디폴트와 일관성 유지 (불일치 시 web-platform 값이 강제)
+ai_api 의 `simulation_config.py` 의 디폴트들은 **/internal/sionna/run 을 직접 호출하는
+다른 클라이언트** (테스트/CLI 등) 용 fallback. web-platform 경로에선 이 파일의 값이 강제.
+혼선 방지 위해 두 파일은 **같은 값으로 유지** 권장.
 
-## 정확도 ↑ 가 필요하면 (예: 논문/시연용)
+## 정확도 ↑ vs 속도 ↑ 가이드
 
-```python
-DEFAULT_MAX_DEPTH = 6              # 3 → 6  (반사 더 깊게)
-DEFAULT_SAMPLES_PER_TX = 500_000   # 100k → 500k (Sionna 권장)
-DEFAULT_RESOLUTION_M = 0.25        # 0.5 → 0.25 (셀 4배)
-```
-
-각각 CPU 에서 분 단위 → 십분대로 늘 수 있음. GPU 환경이면 부담 적음.
-
-## 디폴트 ↔ ai_api SimulationConfig 매핑
-
-| 여기 (web-platform)         | ai_api 도메인                              |
-|---------------------------- |-------------------------------------------|
-| DEFAULT_FREQUENCY_HZ        | PhysicalConfig.frequency_ghz × 1e9         |
-| DEFAULT_TX_POWER_DBM        | PhysicalConfig.tx_power_dbm               |
-| DEFAULT_MAX_DEPTH           | SolverConfig.max_depth                     |
-| DEFAULT_SAMPLES_PER_TX      | SolverConfig.samples_per_tx                |
-| DEFAULT_SEED                | SolverConfig.seed                          |
-
-(propagation: los/specular/refraction true, diffuse/diffraction false 는 ai_api 쪽에서 결정)
+| 효과 큼순 | 변수 | 빠름값 | 정확값 | 비고 |
+|----|----|----|----|----|
+| 1 | `DEFAULT_DIFFRACTION`        | False | True   | 가장자리 회절. 켜면 ×2~10 느림 |
+| 2 | `DEFAULT_DIFFUSE_REFLECTION` | False | True   | 거친 표면 산란. 켜면 ×5~50 |
+| 3 | `DEFAULT_SAMPLES_PER_TX`     | 100k  | 2M+    | ray 수. 선형 |
+| 4 | `DEFAULT_RESOLUTION_M`       | 0.5   | 0.1    | grid 셀. 면적 inverse-square |
+| 5 | `DEFAULT_MAX_DEPTH`          | 3     | 10+    | bounce 깊이. 대부분 ray 가 일찍 죽어서 효과 제한적 |
 """
 from __future__ import annotations
 
@@ -54,11 +45,32 @@ DEFAULT_MEASUREMENT_PLANE_Z_M: float = 1.0
 
 
 # ============================================================
+# Propagation mechanisms — 어떤 전파 메커니즘을 모델링할지
+# ============================================================
+# 직접 시선 path. 끄면 RX 가 AP 를 직접 못 봄 (벽 너머만 시뮬).
+DEFAULT_LOS: bool = True
+
+# 벽 거울 반사. 끄면 multipath 거의 사라짐.
+DEFAULT_SPECULAR_REFLECTION: bool = True
+
+# 매질 통과 (벽 안 흡수 + 굴절). 실내 시뮬에 중요.
+DEFAULT_REFRACTION: bool = True
+
+# 거친 표면 산란 — Monte Carlo 서브샘플링 발생. 켜면 ×5~50 느려짐.
+# 실내에선 효과 작아서 보통 False, 정확도 ↑ 시연시 True.
+DEFAULT_DIFFUSE_REFLECTION: bool = True
+
+# 가장자리 회절 — edge detection 비용 ↑↑. 켜면 ×2~10 느려짐.
+# 구석/문틈 신호 누설 정확하게 잡으려면 True. 빠른 preview 면 False.
+DEFAULT_DIFFRACTION: bool = True
+
+
+# ============================================================
 # Sionna RT solver — 속도 vs 정확도 트레이드오프
 # ============================================================
 # Ray 추적 최대 반사 횟수. 3 = direct + 3 bounce (CPU 빠른 preview).
 # Sionna 권장 5~6. 실내 다중경로 중요한 환경에선 5 이상 권장.
-DEFAULT_MAX_DEPTH: int = 6
+DEFAULT_MAX_DEPTH: int = 10
 
 # TX 당 ray 수. 100k = CPU 수십초. 500k = Sionna 권장, CPU 분 단위.
 # 적으면 RSSI 가 노이지 (값이 cell 간 들쭉날쭉).

--- a/backend/app/routers/rf/rf_jobs.py
+++ b/backend/app/routers/rf/rf_jobs.py
@@ -112,8 +112,12 @@ def _to_response(job: Job) -> RfJobResponse:
 
 
 def _build_output_uri(s3_uri: str | None) -> RfJobOutputUri | None:
+    """s3://... → presigned URL, http(s)://... → 그대로 url 채움 (local backend)."""
     if not s3_uri:
         return None
+    if s3_uri.startswith("http://") or s3_uri.startswith("https://"):
+        # local backend: ai_api 가 직접 서빙하는 http URL — presigned 불필요
+        return RfJobOutputUri(s3_uri=s3_uri, url=s3_uri)
     try:
         url = sagemaker_rf_inference_service.presigned_url(s3_uri)
     except Exception:

--- a/backend/app/schemas/rf/rf_run.py
+++ b/backend/app/schemas/rf/rf_run.py
@@ -11,12 +11,17 @@ from typing import Literal
 
 from app.core.enums import normalize_job_status
 from app.core.rf_defaults import (
+    DEFAULT_DIFFRACTION,
+    DEFAULT_DIFFUSE_REFLECTION,
     DEFAULT_FREQUENCY_HZ,
+    DEFAULT_LOS,
     DEFAULT_MAX_DEPTH,
     DEFAULT_MEASUREMENT_PLANE_Z_M,
+    DEFAULT_REFRACTION,
     DEFAULT_RESOLUTION_M,
     DEFAULT_SAMPLES_PER_TX,
     DEFAULT_SEED,
+    DEFAULT_SPECULAR_REFLECTION,
     DEFAULT_TX_POWER_DBM,
 )
 
@@ -39,17 +44,26 @@ class RfSimulationParams(BaseModel):
     """RF 시뮬 파라미터. 모든 필드 optional — 미지정 시 `app/core/rf_defaults.py` 값 적용.
 
     프론트엔드는 사용자가 명시적으로 정한 값만 보내면 됨 (예: AP 가 정해진 frequency band).
-    Solver 하이퍼파라미터 (max_depth, samples_per_tx 등) 는 보통 backend 디폴트 그대로.
+    Solver/propagation 하이퍼파라미터는 보통 backend 디폴트 그대로.
     """
     model_config = ConfigDict(extra="forbid")
 
+    # 물리값
     frequency_hz: float = Field(default=DEFAULT_FREQUENCY_HZ, gt=0)
     tx_power_dbm: float = DEFAULT_TX_POWER_DBM
+    # 측정 grid
     resolution_m: float = Field(default=DEFAULT_RESOLUTION_M, gt=0)
     measurement_plane_z_m: float = DEFAULT_MEASUREMENT_PLANE_Z_M
+    # Solver
     max_depth: int = Field(default=DEFAULT_MAX_DEPTH, ge=0)
     samples_per_tx: int = Field(default=DEFAULT_SAMPLES_PER_TX, ge=1000)
     seed: int = DEFAULT_SEED
+    # Propagation mechanisms — ai_api PropagationConfig 와 매핑.
+    los: bool = DEFAULT_LOS
+    specular_reflection: bool = DEFAULT_SPECULAR_REFLECTION
+    refraction: bool = DEFAULT_REFRACTION
+    diffuse_reflection: bool = DEFAULT_DIFFUSE_REFLECTION
+    diffraction: bool = DEFAULT_DIFFRACTION
 
 
 class RfRunCreate(BaseModel):

--- a/backend/app/schemas/rf/rf_run.py
+++ b/backend/app/schemas/rf/rf_run.py
@@ -7,7 +7,20 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, conlist, field_validator
 
+from typing import Literal
+
 from app.core.enums import normalize_job_status
+from app.core.rf_defaults import (
+    DEFAULT_FREQUENCY_HZ,
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MEASUREMENT_PLANE_Z_M,
+    DEFAULT_RESOLUTION_M,
+    DEFAULT_SAMPLES_PER_TX,
+    DEFAULT_SEED,
+    DEFAULT_TX_POWER_DBM,
+)
+
+RfBackend = Literal["sagemaker", "local"]
 
 
 # ============================================================
@@ -23,15 +36,20 @@ class AccessPointDTO(BaseModel):
 
 
 class RfSimulationParams(BaseModel):
+    """RF 시뮬 파라미터. 모든 필드 optional — 미지정 시 `app/core/rf_defaults.py` 값 적용.
+
+    프론트엔드는 사용자가 명시적으로 정한 값만 보내면 됨 (예: AP 가 정해진 frequency band).
+    Solver 하이퍼파라미터 (max_depth, samples_per_tx 등) 는 보통 backend 디폴트 그대로.
+    """
     model_config = ConfigDict(extra="forbid")
 
-    frequency_hz: float = Field(..., gt=0)
-    tx_power_dbm: float
-    resolution_m: float = Field(0.5, gt=0)
-    measurement_plane_z_m: float = 1.0
-    max_depth: int = Field(3, ge=0)
-    samples_per_tx: int = Field(100_000, ge=1000)
-    seed: int = 42
+    frequency_hz: float = Field(default=DEFAULT_FREQUENCY_HZ, gt=0)
+    tx_power_dbm: float = DEFAULT_TX_POWER_DBM
+    resolution_m: float = Field(default=DEFAULT_RESOLUTION_M, gt=0)
+    measurement_plane_z_m: float = DEFAULT_MEASUREMENT_PLANE_Z_M
+    max_depth: int = Field(default=DEFAULT_MAX_DEPTH, ge=0)
+    samples_per_tx: int = Field(default=DEFAULT_SAMPLES_PER_TX, ge=1000)
+    seed: int = DEFAULT_SEED
 
 
 class RfRunCreate(BaseModel):
@@ -50,6 +68,8 @@ class RfRunCreate(BaseModel):
     # 해당 scene_version 의 최신 completed CalibrationRun 보정값을 시뮬에 반영할지 (#88).
     # true(기본): 보정 적용 / false: raw 시뮬 (보정 전후 비교용).
     apply_calibration: bool = True
+    # 시뮬 실행 백엔드 선택. sagemaker(기본)=클라우드 async, local=로컬 ai_api 직접 호출.
+    backend: RfBackend = "sagemaker"
     # 옛 호출자 호환 (deprecated)
     request_json: Optional[dict[str, Any]] = None
 

--- a/backend/app/services/ai_api_client.py
+++ b/backend/app/services/ai_api_client.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 CALIBRATION_AI_API_VERIFY_ENV = "CALIBRATION_AI_API_VERIFY"
 AI_API_BASE_URL_ENV = "AI_API_BASE_URL"
+# Fallback env — 기존 .env 의 AI_SERVICE_URL 도 인식 (둘 다 같은 서버를 가리키는 의도).
+AI_SERVICE_URL_ENV = "AI_SERVICE_URL"
 AI_API_TIMEOUT_ENV = "AI_API_TIMEOUT_SECONDS"
 AI_API_DEFAULT_TIMEOUT = 600.0  # Sionna 한 회 ~ 분 단위
 
@@ -37,7 +39,15 @@ def is_closed_loop_verify_enabled() -> bool:
 
 
 def _base_url() -> str:
-    return os.getenv(AI_API_BASE_URL_ENV, "http://localhost:9100").rstrip("/")
+    # 1순위: AI_API_BASE_URL (전용 env)
+    # 2순위: AI_SERVICE_URL (web-platform .env 의 기존 키 — 같은 서버를 가리키므로 fallback)
+    # 3순위: localhost:9000 (ai_api 의 기본 포트)
+    raw = (
+        os.getenv(AI_API_BASE_URL_ENV)
+        or os.getenv(AI_SERVICE_URL_ENV)
+        or "http://localhost:9000"
+    )
+    return raw.rstrip("/")
 
 
 def _timeout() -> float:
@@ -45,6 +55,40 @@ def _timeout() -> float:
         return float(os.getenv(AI_API_TIMEOUT_ENV, str(AI_API_DEFAULT_TIMEOUT)))
     except ValueError:
         return AI_API_DEFAULT_TIMEOUT
+
+
+def run_sionna_simulation(
+    *,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """POST {AI_API_BASE_URL}/internal/sionna/run — SionnaRunRequestDto 형식.
+
+    호출자가 이미 ai_api 의 RequestDto 형식 (engine/scene/access_point/measurement_plane/...)
+    으로 payload 를 빌드해서 넘김. SageMaker 와 동등한 sync 호출이지만 Sionna 자체가
+    수십초~분 단위 블로킹이므로 백그라운드 thread 에서 호출하는 게 일반적.
+
+    예외: AiApiClientError (네트워크/HTTP/JSON 실패).
+    """
+    url = f"{_base_url()}/internal/sionna/run"
+    headers = {
+        "X-Internal-API-Key": INTERNAL_API_KEY,
+        "Content-Type": "application/json",
+    }
+    logger.info("ai_api call: POST %s (local sionna backend)", url)
+    try:
+        with httpx.Client(timeout=_timeout()) as client:
+            resp = client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPStatusError as exc:
+        body = exc.response.text[:500] if exc.response is not None else ""
+        raise AiApiClientError(
+            f"ai_api returned {exc.response.status_code}: {body}"
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise AiApiClientError(f"ai_api request failed: {exc}") from exc
+    except ValueError as exc:  # JSON decode
+        raise AiApiClientError(f"ai_api response not JSON: {exc}") from exc
 
 
 def run_sionna_with_correction(

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -1,0 +1,446 @@
+"""Local ai_api backend for RF simulate (alternative to SageMaker async).
+
+SageMaker 경로 대안: 로컬에서 띄운 ai_api 의 `/internal/sionna/run` 을 직접 호출.
+
+핵심 차이:
+  - SageMaker: submit 이 비동기로 S3 에 invoke, poll 로 결과 확인
+  - Local:     submit 이 백그라운드 thread 에 ai_api 호출을 띄움 (Sionna 자체는
+               분 단위 블로킹), 호출 완료 시 thread 가 직접 DB 업데이트.
+               poll_rf_job 은 DB status 만 읽으면 됨 (외부 호출 X).
+
+세션 관리: 백그라운드 thread 는 요청 세션을 못 쓰므로 `SessionLocal()` 로 새 세션 생성.
+
+결과 매핑 (SageMaker 결과 구조에 최대한 맞춤 — 프론트가 동일 응답 형태로 받음):
+  Job.result_json = {
+      "rf_run_id": ..., "backend": "local",
+      "heatmap_s3_uri": <imageUrl, http://...>,   # 같은 키 이름 재사용
+      "radio_map_s3_uri": None,                   # 로컬은 별도 file 없이 응답에 grid 포함
+      "radio_map_meta": {...},
+      "local_artifacts": { "imageUrl": ..., "sionna_run_id": ..., "paths": {...} },
+  }
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError, ErrorCode
+from app.db.session import SessionLocal
+from app.models import Job, RfRun, SceneVersion, User
+from app.models.rf_map import RfMap
+from app.services import ai_api_client
+
+logger = logging.getLogger(__name__)
+
+JOB_TYPE_RF_SIMULATE = "rf_simulate"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_DONE = "done"
+JOB_STATUS_FAILED = "failed"
+
+RF_BACKEND_LOCAL = "local"
+
+
+# ============================================================
+# Submit
+# ============================================================
+async def submit_via_local_ai_api(
+    db: Session,
+    *,
+    sv: SceneVersion,
+    scene_json: dict[str, Any],
+    access_points: list[dict[str, Any]],
+    simulation: dict[str, Any],
+    current_user: User,
+    run_type: str,
+    metadata: dict[str, Any] | None,
+    calibration_meta: dict[str, Any],
+) -> tuple[RfRun, Job]:
+    """RfRun + Job 행 즉시 생성 (status=running) → 백그라운드 thread 가 ai_api 호출.
+
+    submit 자체는 블로킹 없이 즉시 반환. UI 는 기존 SageMaker 폴링 흐름 그대로
+    /rf-jobs/{job_id} 를 폴링하면 됨 (poll_rf_job 이 local backend 분기 처리).
+    """
+    if not access_points:
+        raise AppError(
+            ErrorCode.INVALID_RF_RUN_STATUS,
+            "Local backend requires at least one access point.",
+            400,
+        )
+
+    payload = _build_sionna_request_payload(
+        scene_json=scene_json,
+        floor_id=str(sv.floor_id),
+        scene_version_id=str(sv.id),
+        access_points=access_points,
+        simulation=simulation,
+    )
+
+    now = _now_utc()
+    rf_run = RfRun(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        scene_version_id=sv.id,
+        run_type=run_type,
+        status=JOB_STATUS_RUNNING,
+        request_json={
+            "access_points": access_points,
+            "simulation": simulation,
+            "metadata": metadata or {},
+            "calibration": calibration_meta,
+            "backend": RF_BACKEND_LOCAL,
+        },
+        metrics_json={},
+    )
+
+    input_json: dict[str, Any] = {
+        "rf_run_id": None,
+        "scene_version_id": str(sv.id),
+        "access_points": access_points,
+        "simulation": simulation,
+        "requested_by": current_user.email,
+        "backend": RF_BACKEND_LOCAL,
+        "local": {
+            "ai_api_payload_summary": {
+                "walls": len(scene_json.get("walls") or []),
+                "rooms": len(scene_json.get("rooms") or []),
+                "primary_ap_id": access_points[0].get("id"),
+            },
+        },
+    }
+    job = Job(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        job_type=JOB_TYPE_RF_SIMULATE,
+        status=JOB_STATUS_RUNNING,
+        input_json=input_json,
+        result_json={},
+        started_at=now,
+    )
+
+    try:
+        db.add(rf_run)
+        db.flush()
+        input_json["rf_run_id"] = rf_run.id
+        job.input_json = input_json
+        db.add(job)
+        db.commit()
+        db.refresh(rf_run)
+        db.refresh(job)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise AppError(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Failed to persist RF simulation job (local backend): {exc}",
+            500,
+        ) from exc
+
+    job_id = str(job.id)
+    rf_run_id = str(rf_run.id)
+
+    thread = threading.Thread(
+        target=_background_run_ai_api,
+        kwargs={"job_id": job_id, "rf_run_id": rf_run_id, "payload": payload},
+        name=f"rf-local-{job_id[:8]}",
+        daemon=True,
+    )
+    thread.start()
+
+    logger.info(
+        "RF job submitted (local ai_api) job_id=%s rf_run_id=%s thread=%s",
+        job_id, rf_run_id, thread.name,
+    )
+    return rf_run, job
+
+
+# ============================================================
+# Background worker
+# ============================================================
+def _background_run_ai_api(
+    *, job_id: str, rf_run_id: str, payload: dict[str, Any]
+) -> None:
+    """Thread entry point: ai_api 호출 + 결과 DB 영속화 (성공/실패 분기)."""
+    try:
+        response = ai_api_client.run_sionna_simulation(payload=payload)
+    except ai_api_client.AiApiClientError as exc:
+        logger.warning(
+            "RF job %s: local ai_api call failed: %s", job_id, exc,
+        )
+        _persist_local_failure(job_id=job_id, rf_run_id=rf_run_id, message=str(exc))
+        return
+    except Exception as exc:  # pragma: no cover — 방어
+        logger.exception("RF job %s: unexpected error during local ai_api call", job_id)
+        _persist_local_failure(
+            job_id=job_id, rf_run_id=rf_run_id,
+            message=f"unexpected error: {exc}",
+        )
+        return
+
+    status = str(response.get("status") or "").lower()
+    if status != "succeeded":
+        detail = response.get("detail") or response.get("error") or "ai_api returned non-success status"
+        _persist_local_failure(
+            job_id=job_id, rf_run_id=rf_run_id,
+            message=f"ai_api status={status or 'unknown'}: {detail}",
+        )
+        return
+
+    _persist_local_success(job_id=job_id, rf_run_id=rf_run_id, response=response)
+
+
+def _persist_local_success(
+    *, job_id: str, rf_run_id: str, response: dict[str, Any]
+) -> None:
+    """ai_api 성공 응답 → Job/RfRun/RfMap 업데이트. 새 DB 세션 사용."""
+    db = SessionLocal()
+    try:
+        job = db.execute(
+            select(Job).where(Job.id == job_id).with_for_update()
+        ).scalar_one_or_none()
+        if job is None:
+            logger.warning("RF job %s missing on success persist", job_id)
+            return
+        if job.status != JOB_STATUS_RUNNING:
+            logger.info(
+                "RF job %s no longer running (status=%s), skipping persist",
+                job_id, job.status,
+            )
+            return
+
+        artifacts = response.get("artifacts") or {}
+        metrics = response.get("metrics") or {}
+        sionna_run_id = str(response.get("sionna_run_id") or "")
+        image_url = response.get("imageUrl") or artifacts.get("imageUrl")
+
+        radiomap = artifacts.get("radiomap") or {}
+        radio_map_meta = {
+            "grid_shape": radiomap.get("grid_shape"),
+            "bounds_m": radiomap.get("bounds_m"),
+            "cell_size_m": (artifacts.get("config") or {}).get("measurement_plane", {}).get("cell_size_m"),
+            "rss_dbm": artifacts.get("rssi") or metrics.get("rssi_summary"),
+            "coverage_summary": artifacts.get("coverage") or metrics.get("coverage_summary"),
+            "valid_cell_count": artifacts.get("valid_cell_count") or metrics.get("valid_cell_count"),
+            "valid_ratio": artifacts.get("valid_ratio") or metrics.get("valid_ratio"),
+            # heatmap PNG 와 동일한 색 스케일 (vmin/vmax) — 프론트 ColorLegend 에서 사용.
+            "color_scale": radiomap.get("color_scale"),
+        }
+
+        rf_run = db.execute(
+            select(RfRun).where(RfRun.id == rf_run_id)
+        ).scalar_one_or_none()
+        if rf_run is not None:
+            rf_run.status = JOB_STATUS_DONE
+            rf_run.metrics_json = {
+                "radio_map": radio_map_meta,
+                "runtime": {
+                    "mode": "local_ai_api",
+                    "sionna_run_id": sionna_run_id,
+                },
+                "config": artifacts.get("config") or {},
+            }
+            _create_local_rf_maps(db, rf_run, image_url=image_url, radio_map_meta=radio_map_meta)
+
+        job.status = JOB_STATUS_DONE
+        job.result_json = {
+            "rf_run_id": rf_run.id if rf_run is not None else None,
+            "backend": RF_BACKEND_LOCAL,
+            "heatmap_s3_uri": image_url,  # 같은 키 재사용 (http://... 값)
+            "radio_map_s3_uri": None,
+            "radio_map_meta": radio_map_meta,
+            "local_artifacts": {
+                "sionna_run_id": sionna_run_id,
+                "imageUrl": image_url,
+                "paths": {
+                    k: artifacts.get(k)
+                    for k in (
+                        "visualization_path",
+                        "valid_mask_path",
+                        "geometry_overlay_path",
+                        "geometry_debug_path",
+                        "runtime_result_path",
+                    )
+                    if artifacts.get(k)
+                },
+            },
+        }
+        job.error_message = None
+        job.finished_at = _now_utc()
+
+        db.commit()
+        logger.info(
+            "RF job %s done (local ai_api) sionna_run_id=%s image_url=%s",
+            job_id, sionna_run_id, image_url,
+        )
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.exception("Failed to persist local ai_api success for job %s: %s", job_id, exc)
+    finally:
+        db.close()
+
+
+def _persist_local_failure(
+    *, job_id: str, rf_run_id: str, message: str
+) -> None:
+    """ai_api 실패 → Job/RfRun status=failed. 새 DB 세션 사용."""
+    db = SessionLocal()
+    try:
+        job = db.execute(
+            select(Job).where(Job.id == job_id).with_for_update()
+        ).scalar_one_or_none()
+        if job is None:
+            logger.warning("RF job %s missing on failure persist", job_id)
+            return
+        if job.status != JOB_STATUS_RUNNING:
+            return
+
+        job.status = JOB_STATUS_FAILED
+        job.error_message = f"[local_ai_api] {message}"
+        job.result_json = {
+            "backend": RF_BACKEND_LOCAL,
+            "error": {
+                "backend_code": str(ErrorCode.INTERNAL_SERVER_ERROR),
+                "container_code": None,
+                "stage": "local_ai_api",
+                "message": message,
+                "retryable": True,
+                "details": {},
+            },
+        }
+        job.finished_at = _now_utc()
+
+        rf_run = db.execute(
+            select(RfRun).where(RfRun.id == rf_run_id)
+        ).scalar_one_or_none()
+        if rf_run is not None:
+            rf_run.status = JOB_STATUS_FAILED
+
+        db.commit()
+        logger.warning("RF job %s failed (local ai_api): %s", job_id, message)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.exception("Failed to persist local ai_api failure for job %s: %s", job_id, exc)
+    finally:
+        db.close()
+
+
+def _create_local_rf_maps(
+    db: Session, rf_run: RfRun, *, image_url: str | None, radio_map_meta: dict[str, Any]
+) -> None:
+    """heatmap RfMap row 1개 생성 (가능한 경우). SageMaker 경로의 _create_rf_map_rows 와 같은 의도."""
+    if not image_url:
+        return
+    cell_size_m = radio_map_meta.get("cell_size_m") or 0.5
+    try:
+        resolution_cm = max(1, int(round(float(cell_size_m) * 100)))
+    except (TypeError, ValueError):
+        resolution_cm = 50
+    metrics = {
+        "rss_dbm": radio_map_meta.get("rss_dbm") or {},
+        "coverage_summary": radio_map_meta.get("coverage_summary") or {},
+        "valid_cell_count": radio_map_meta.get("valid_cell_count"),
+        "valid_ratio": radio_map_meta.get("valid_ratio"),
+        "grid_shape": radio_map_meta.get("grid_shape"),
+        "color_scale": radio_map_meta.get("color_scale"),
+    }
+    db.add(
+        RfMap(
+            rf_run_id=rf_run.id,
+            map_type="heatmap",
+            resolution_cm=resolution_cm,
+            storage_url=image_url,
+            bounds_json=radio_map_meta.get("bounds_m") or {},
+            metrics_json=metrics,
+        )
+    )
+
+
+# ============================================================
+# Payload builder: web-platform scene_json → ai_api SionnaRunRequestDto
+# ============================================================
+def _build_sionna_request_payload(
+    *,
+    scene_json: dict[str, Any],
+    floor_id: str,
+    scene_version_id: str,
+    access_points: list[dict[str, Any]],
+    simulation: dict[str, Any],
+) -> dict[str, Any]:
+    """web-platform scene/simulation/AP 형식 → ai_api `/internal/sionna/run` body.
+
+    Local backend 는 ai_api 가 single-AP 모델이므로 첫 번째 AP 만 사용한다.
+    다중 AP 가 들어오면 첫 번째만 시뮬 (한계 — 추후 per-AP 반복 호출로 확장 가능).
+    """
+    walls = [
+        {
+            "id": f"w{i}",
+            "start_xy": [float(w["x1"]), float(w["y1"])],
+            "end_xy": [float(w["x2"]), float(w["y2"])],
+            "height_m": float(w.get("height") or 2.6),
+            "thickness_m": float(w.get("thickness") or 0.12),
+            "material_id": str(w.get("material") or "plasterboard"),
+        }
+        for i, w in enumerate(scene_json.get("walls") or [])
+    ]
+    rooms = [
+        {
+            "id": f"r{i}",
+            "polygon_xy": [[float(p[0]), float(p[1])] for p in (r.get("points") or [])],
+        }
+        for i, r in enumerate(scene_json.get("rooms") or [])
+    ]
+
+    primary_ap = access_points[0]
+    ap_id = str(primary_ap.get("id") or "ap0")
+    ap_position = [
+        float(primary_ap.get("x_m") or primary_ap.get("x") or 0.0),
+        float(primary_ap.get("y_m") or primary_ap.get("y") or 0.0),
+        float(primary_ap.get("z_m") or primary_ap.get("z") or 1.2),
+    ]
+
+    frequency_hz = float(simulation.get("frequency_hz") or 5e9)
+    frequency_ghz = frequency_hz / 1e9
+
+    return {
+        "engine": "sionna_rt",
+        "floor_id": floor_id,
+        "scene": {
+            "scene_id": scene_version_id,
+            "walls": walls,
+            "rooms": rooms,
+            "openings": [],
+            "furniture": [],
+        },
+        "access_point": {
+            "id": ap_id,
+            "position_m": ap_position,
+            "tx_power_dbm": float(simulation.get("tx_power_dbm")) if simulation.get("tx_power_dbm") is not None else None,
+            "frequency_ghz": frequency_ghz,
+        },
+        "measurement_plane": {
+            "z_m": float(simulation.get("measurement_plane_z_m") or 1.0),
+            "cell_size_m": float(simulation.get("resolution_m") or 0.5),
+        },
+        "simulation": {
+            "physical": {
+                "frequency_ghz": frequency_ghz,
+                "tx_power_dbm": float(simulation.get("tx_power_dbm") or 20.0),
+            },
+            "solver": {
+                "max_depth": int(simulation.get("max_depth") or 3),
+                "samples_per_tx": int(simulation.get("samples_per_tx") or 100_000),
+                "seed": int(simulation.get("seed") or 42),
+            },
+        },
+    }
+
+
+# ============================================================
+# Helpers
+# ============================================================
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -189,32 +189,38 @@ def _background_run_ai_api(
         sim_cfg.get("propagation"),
         payload.get("measurement_plane"),
     )
+    # try 범위를 호출 + 응답 파싱 + 영속화 전체로 확장 — 어디서 예외 나도 job 이
+    # running 으로 dangling 되지 않도록 (백그라운드 thread 가 silent 크래시 했을 때 폴링이
+    # 영원히 running 응답을 받게 되는 버그 방지).
     try:
         response = ai_api_client.run_sionna_simulation(payload=payload)
+        status = str(response.get("status") or "").lower()
+        if status != "succeeded":
+            detail = (
+                response.get("detail")
+                or response.get("error")
+                or "ai_api returned non-success status"
+            )
+            _persist_local_failure(
+                job_id=job_id, rf_run_id=rf_run_id,
+                message=f"ai_api status={status or 'unknown'}: {detail}",
+            )
+            return
+
+        _persist_local_success(job_id=job_id, rf_run_id=rf_run_id, response=response)
     except ai_api_client.AiApiClientError as exc:
         logger.warning(
             "RF job %s: local ai_api call failed: %s", job_id, exc,
         )
         _persist_local_failure(job_id=job_id, rf_run_id=rf_run_id, message=str(exc))
-        return
     except Exception as exc:  # pragma: no cover — 방어
+        # response 파싱 (KeyError/TypeError 등) 이나 _persist_local_success 내부에서
+        # 새 예외가 터질 수 있음. 그 경우도 반드시 failure 로 기록.
         logger.exception("RF job %s: unexpected error during local ai_api call", job_id)
         _persist_local_failure(
             job_id=job_id, rf_run_id=rf_run_id,
             message=f"unexpected error: {exc}",
         )
-        return
-
-    status = str(response.get("status") or "").lower()
-    if status != "succeeded":
-        detail = response.get("detail") or response.get("error") or "ai_api returned non-success status"
-        _persist_local_failure(
-            job_id=job_id, rf_run_id=rf_run_id,
-            message=f"ai_api status={status or 'unknown'}: {detail}",
-        )
-        return
-
-    _persist_local_success(job_id=job_id, rf_run_id=rf_run_id, response=response)
 
 
 def _persist_local_success(

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -31,6 +31,20 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
+from app.core.rf_defaults import (
+    DEFAULT_DIFFRACTION,
+    DEFAULT_DIFFUSE_REFLECTION,
+    DEFAULT_FREQUENCY_HZ,
+    DEFAULT_LOS,
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MEASUREMENT_PLANE_Z_M,
+    DEFAULT_REFRACTION,
+    DEFAULT_RESOLUTION_M,
+    DEFAULT_SAMPLES_PER_TX,
+    DEFAULT_SEED,
+    DEFAULT_SPECULAR_REFLECTION,
+    DEFAULT_TX_POWER_DBM,
+)
 from app.db.session import SessionLocal
 from app.models import Job, RfRun, SceneVersion, User
 from app.models.rf_map import RfMap
@@ -165,6 +179,16 @@ def _background_run_ai_api(
     *, job_id: str, rf_run_id: str, payload: dict[str, Any]
 ) -> None:
     """Thread entry point: ai_api 호출 + 결과 DB 영속화 (성공/실패 분기)."""
+    # 디버그: 어떤 simulation 설정으로 호출되는지 확인 — 3초 미만으로 끝나는 등 의심
+    # 상황에서 실제 적용된 값이 무엇인지 빠르게 검증하기 위한 단일 로그.
+    sim_cfg = payload.get("simulation") or {}
+    logger.info(
+        "RF job %s: sending to ai_api — solver=%s, propagation=%s, mp=%s",
+        job_id,
+        sim_cfg.get("solver"),
+        sim_cfg.get("propagation"),
+        payload.get("measurement_plane"),
+    )
     try:
         response = ai_api_client.run_sionna_simulation(payload=payload)
     except ai_api_client.AiApiClientError as exc:
@@ -402,8 +426,12 @@ def _build_sionna_request_payload(
         float(primary_ap.get("z_m") or primary_ap.get("z") or 1.2),
     ]
 
-    frequency_hz = float(simulation.get("frequency_hz") or 5e9)
+    # 모든 fallback 은 `app/core/rf_defaults.py` 에서 import — 같은 source of truth 유지.
+    # 정상 flow 에선 `RfSimulationParams.model_dump()` 가 디폴트 채워서 들어오므로
+    # .get(key, FALLBACK) 의 fallback 은 dead-code 지만, 직접 호출 시 안전망.
+    frequency_hz = float(simulation.get("frequency_hz") or DEFAULT_FREQUENCY_HZ)
     frequency_ghz = frequency_hz / 1e9
+    tx_power_dbm = float(simulation.get("tx_power_dbm") or DEFAULT_TX_POWER_DBM)
 
     return {
         "engine": "sionna_rt",
@@ -418,22 +446,34 @@ def _build_sionna_request_payload(
         "access_point": {
             "id": ap_id,
             "position_m": ap_position,
-            "tx_power_dbm": float(simulation.get("tx_power_dbm")) if simulation.get("tx_power_dbm") is not None else None,
+            "tx_power_dbm": tx_power_dbm,
             "frequency_ghz": frequency_ghz,
         },
         "measurement_plane": {
-            "z_m": float(simulation.get("measurement_plane_z_m") or 1.0),
-            "cell_size_m": float(simulation.get("resolution_m") or 0.5),
+            "z_m": float(simulation.get("measurement_plane_z_m") or DEFAULT_MEASUREMENT_PLANE_Z_M),
+            "cell_size_m": float(simulation.get("resolution_m") or DEFAULT_RESOLUTION_M),
         },
         "simulation": {
             "physical": {
                 "frequency_ghz": frequency_ghz,
-                "tx_power_dbm": float(simulation.get("tx_power_dbm") or 20.0),
+                "tx_power_dbm": tx_power_dbm,
             },
             "solver": {
-                "max_depth": int(simulation.get("max_depth") or 3),
-                "samples_per_tx": int(simulation.get("samples_per_tx") or 100_000),
-                "seed": int(simulation.get("seed") or 42),
+                "max_depth": int(simulation.get("max_depth") or DEFAULT_MAX_DEPTH),
+                "samples_per_tx": int(simulation.get("samples_per_tx") or DEFAULT_SAMPLES_PER_TX),
+                "seed": int(simulation.get("seed") or DEFAULT_SEED),
+            },
+            # Propagation — 항상 명시 전송. ai_api 디폴트로 fallback 안 함.
+            "propagation": {
+                "los": bool(simulation.get("los", DEFAULT_LOS)),
+                "specular_reflection": bool(
+                    simulation.get("specular_reflection", DEFAULT_SPECULAR_REFLECTION)
+                ),
+                "refraction": bool(simulation.get("refraction", DEFAULT_REFRACTION)),
+                "diffuse_reflection": bool(
+                    simulation.get("diffuse_reflection", DEFAULT_DIFFUSE_REFLECTION)
+                ),
+                "diffraction": bool(simulation.get("diffraction", DEFAULT_DIFFRACTION)),
             },
         },
     }

--- a/backend/app/services/rf/rf_job_service.py
+++ b/backend/app/services/rf/rf_job_service.py
@@ -36,6 +36,9 @@ JOB_STATUS_RUNNING = "running"
 JOB_STATUS_DONE = "done"
 JOB_STATUS_FAILED = "failed"
 
+RF_BACKEND_SAGEMAKER = "sagemaker"
+RF_BACKEND_LOCAL = "local"
+
 
 # ============================================================
 # Submit
@@ -50,14 +53,28 @@ async def submit_rf_simulation(
     run_type: str = "rf_simulate",
     metadata: dict[str, Any] | None = None,
     apply_calibration: bool = True,
+    backend: str = RF_BACKEND_SAGEMAKER,
 ) -> tuple[RfRun, Job]:
-    """SceneVersion 확인 + scene.json export + SageMaker submit + Job/RfRun row 생성.
+    """SceneVersion 확인 + scene.json export + 백엔드로 submit + Job/RfRun row 생성.
 
     apply_calibration=True 면 해당 scene_version 의 최신 completed CalibrationRun
     보정값을 scene_json/simulation 에 미리 반영한다 (#88).
 
+    backend:
+      - "sagemaker" (기본): S3 + invoke_endpoint_async, /rf-jobs/{id} 폴링으로 완료 확인
+      - "local":           로컬 ai_api `/internal/sionna/run` 호출 (백그라운드 thread).
+                            poll 은 DB status 만 읽음 — 외부 호출 X.
+
     반환: (rf_run, job) — 둘 다 commit 완료된 상태.
     """
+    if backend not in {RF_BACKEND_SAGEMAKER, RF_BACKEND_LOCAL}:
+        raise AppError(
+            ErrorCode.INVALID_RF_RUN_STATUS,
+            f"Unsupported RF backend: {backend!r}. "
+            f"Allowed: {RF_BACKEND_SAGEMAKER}, {RF_BACKEND_LOCAL}",
+            400,
+        )
+
     sv = _get_owned_scene_version(db, scene_version_id, current_user)
 
     # 1) scene.json 빌드 (DB → dict)
@@ -91,7 +108,47 @@ async def submit_rf_simulation(
                     "summary": summary,
                 }
 
-    # 2) SageMaker submit (블록 X)
+    if backend == RF_BACKEND_LOCAL:
+        from app.services.rf.rf_backend_local import submit_via_local_ai_api
+
+        return await submit_via_local_ai_api(
+            db,
+            sv=sv,
+            scene_json=scene_json,
+            access_points=access_points,
+            simulation=simulation,
+            current_user=current_user,
+            run_type=run_type,
+            metadata=metadata,
+            calibration_meta=calibration_meta,
+        )
+
+    return await _submit_via_sagemaker(
+        db,
+        sv=sv,
+        scene_json=scene_json,
+        access_points=access_points,
+        simulation=simulation,
+        current_user=current_user,
+        run_type=run_type,
+        metadata=metadata,
+        calibration_meta=calibration_meta,
+    )
+
+
+async def _submit_via_sagemaker(
+    db: Session,
+    *,
+    sv: SceneVersion,
+    scene_json: dict[str, Any],
+    access_points: list[dict[str, Any]],
+    simulation: dict[str, Any],
+    current_user: User,
+    run_type: str,
+    metadata: dict[str, Any] | None,
+    calibration_meta: dict[str, Any],
+) -> tuple[RfRun, Job]:
+    """SageMaker async backend: scene/input 을 S3 에 올리고 invoke_endpoint_async."""
     submit_result = await sagemaker_rf_inference_service.submit(
         scene_json=scene_json,
         project_id=str(sv.project_id),
@@ -108,7 +165,6 @@ async def submit_rf_simulation(
 
     now = _now_utc()
 
-    # 3) RfRun row
     rf_run = RfRun(
         project_id=sv.project_id,
         floor_id=sv.floor_id,
@@ -120,17 +176,18 @@ async def submit_rf_simulation(
             "simulation": simulation,
             "metadata": metadata or {},
             "calibration": calibration_meta,
+            "backend": RF_BACKEND_SAGEMAKER,
         },
         metrics_json={},
     )
 
-    # 4) Job row (input_json 에 sagemaker meta 보관 — AI 패턴과 동일)
     input_json: dict[str, Any] = {
         "rf_run_id": None,  # rf_run.id 는 flush 후 채움
         "scene_version_id": str(sv.id),
         "access_points": access_points,
         "simulation": simulation,
         "requested_by": current_user.email,
+        "backend": RF_BACKEND_SAGEMAKER,
         "sagemaker": {
             "inference_id": submit_result.sagemaker_inference_id,
             "scene_s3_uri": submit_result.scene_s3_uri,
@@ -168,7 +225,7 @@ async def submit_rf_simulation(
         ) from exc
 
     logger.info(
-        "RF job submitted job_id=%s rf_run_id=%s sagemaker_inference_id=%s",
+        "RF job submitted (sagemaker) job_id=%s rf_run_id=%s sagemaker_inference_id=%s",
         job.id, rf_run.id, submit_result.sagemaker_inference_id,
     )
     return rf_run, job
@@ -212,6 +269,7 @@ async def retry_rf_job(
 
     metadata = input_meta.get("metadata") or {}
     metadata["retry_of_job_id"] = str(job.id)
+    original_backend = input_meta.get("backend") or RF_BACKEND_SAGEMAKER
 
     return await submit_rf_simulation(
         db,
@@ -220,6 +278,7 @@ async def retry_rf_job(
         simulation=simulation,
         current_user=current_user,
         metadata=metadata,
+        backend=original_backend,
     )
 
 
@@ -229,13 +288,22 @@ async def poll_rf_job(
     job_id: str,
     current_user: User,
 ) -> Job:
-    """RF Job 조회 + (running 이면 S3 확인) + 완료/실패 시 본 트랜잭션에서 마무리.
+    """RF Job 조회 + 완료/실패 시 본 트랜잭션에서 마무리.
 
-    AI 패턴과 동일: race-safe 를 위해 finalize 직전 row lock + status 재확인.
+    backend 별 분기:
+      - sagemaker: running 이면 S3 확인 후 완료/실패 처리 (race-safe row lock + status 재확인)
+      - local:     백그라운드 thread 가 직접 DB 를 업데이트하므로 DB read 만 함.
     """
     job = _get_owned_rf_job_or_404(db, job_id, current_user)
 
     if job.status != JOB_STATUS_RUNNING:
+        return job
+
+    backend = (job.input_json or {}).get("backend") or RF_BACKEND_SAGEMAKER
+    if backend == RF_BACKEND_LOCAL:
+        # 백그라운드 thread 가 완료시 DB 직접 업데이트 — 폴링은 단순 read.
+        # 세션 캐시 회피 위해 refresh.
+        db.refresh(job)
         return job
 
     sagemaker_meta = (job.input_json or {}).get("sagemaker") or {}

--- a/backend/app/services/rf/rf_run_service.py
+++ b/backend/app/services/rf/rf_run_service.py
@@ -92,7 +92,7 @@ async def create_rf_run(
     """
     sv = _get_owned_scene_version(db, payload.scene_version_id, user)
 
-    # 새 흐름: SageMaker async 호출
+    # 새 흐름: backend 선택형 (sagemaker async 또는 local ai_api)
     if payload.access_points and payload.simulation:
         from app.services.rf.rf_job_service import submit_rf_simulation
 
@@ -105,6 +105,7 @@ async def create_rf_run(
             run_type=payload.run_type or "rf_simulate",
             metadata=payload.metadata,
             apply_calibration=payload.apply_calibration,
+            backend=payload.backend,
         )
         summary = _to_response(rf_run)
         return RfRunCreatedResponse(**summary.model_dump(), job_id=job.id)
@@ -207,9 +208,13 @@ def list_by_floor(
 
 
 def _rf_map_to_response(m: RfMap) -> RfMapResponse:
-    """storage_url 이 s3:// 면 presigned URL 도 같이 채워서 반환."""
+    """storage_url 이 s3:// 면 presigned URL, http(s):// (local backend) 면 그대로 url 채움."""
     resp = RfMapResponse.model_validate(m, from_attributes=True)
-    if m.storage_url and m.storage_url.startswith("s3://"):
+    if not m.storage_url:
+        return resp
+    if m.storage_url.startswith("http://") or m.storage_url.startswith("https://"):
+        return resp.model_copy(update={"url": m.storage_url})
+    if m.storage_url.startswith("s3://"):
         from app.services import _s3
         try:
             resp = resp.model_copy(update={"url": _s3.presigned_get_url(m.storage_url)})

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,14 @@
+import logging
+
+# 앱 로거 활성화 — `logger = logging.getLogger(__name__)` 로 만든 logger.info() 가
+# 콘솔에 보이도록. uvicorn 자체 INFO 와는 별개 (uvicorn 은 자체 로거 사용).
+# force=True: uvicorn 이 이미 root logger 에 handler 를 박았을 경우 덮어쓰기.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    force=True,
+)
+
 from fastapi import FastAPI, Request
 from app.routers.experiments import router as experiments_router
 from app.routers.health import router as health_router

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -20,6 +20,12 @@ import {
   loadCachedViewBox as loadCachedViewBoxShared,
   viewBoxCacheKey as viewBoxCacheKeyShared,
 } from './viewbox-cache';
+import {
+  deriveImageExtent as deriveImageExtentShared,
+  saveCachedRealWidth,
+  saveCachedScaleRatio,
+  useImageNaturalDimensions,
+} from './floorplan-image-extent';
 import type { EditorTool } from '@/stores/editor-store';
 
 interface Bounds {
@@ -141,129 +147,23 @@ function resolveInitialViewBox(draft: SceneDraft): ViewBox {
 }
 
 /**
- * 이미지를 비동기 로드해서 naturalWidth/Height 반환. URL 바뀌면 null 로 리셋.
- * presigned URL 의 만료/갱신 시에도 동작.
- */
-function useImageNaturalDimensions(
-  url: string | null | undefined,
-): { w: number; h: number } | null {
-  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
-  useEffect(() => {
-    setDims(null);
-    if (!url) return;
-    const img = new Image();
-    img.crossOrigin = 'anonymous';
-    let cancelled = false;
-    img.onload = () => {
-      if (!cancelled && img.naturalWidth > 0 && img.naturalHeight > 0) {
-        setDims({ w: img.naturalWidth, h: img.naturalHeight });
-      }
-    };
-    img.onerror = () => {
-      if (!cancelled) setDims(null);
-    };
-    img.src = url;
-    return () => {
-      cancelled = true;
-    };
-  }, [url]);
-  return dims;
-}
-
-// real_width_m 를 localStorage 에 캐싱.
-// 분석 직후 draft 의 summary_json.storage.real_width_m 가 있을 때 저장 →
-// 이후 promote 되어 SceneVersion 으로 바뀌면 (summary_json={}) 이 캐시에서 복원.
-// → 확정 직후에도 imageExtent 가 살아있어 viewBox 가 안 흔들림.
-//
-// 저장은 source_asset_id / floor_id 둘 다 키로 → 백엔드가 둘 중 한쪽만 채워주는
-// 응답이어도 lookup 성공. 같은 floor 에 여러 도면이 올라가는 경우는 실무상 없음.
-const REAL_WIDTH_CACHE_PREFIX = 'asset-real-width-m:v1:';
-
-function loadCachedRealWidth(key: string): number | null {
-  try {
-    const raw = localStorage.getItem(REAL_WIDTH_CACHE_PREFIX + key);
-    if (!raw) return null;
-    const v = Number(raw);
-    return Number.isFinite(v) && v > 0 ? v : null;
-  } catch {
-    return null;
-  }
-}
-
-function saveCachedRealWidth(key: string, w: number): void {
-  try {
-    localStorage.setItem(REAL_WIDTH_CACHE_PREFIX + key, String(w));
-  } catch {
-    // 캐시 실패는 무시 — 기능적 영향 없음 (summary_json 있을 때만 안 흔들림).
-  }
-}
-
-/**
- * draft 의 summary_json (있으면) 또는 캐시에서 real_width_m 조회. 순수함수.
- * 캐시 lookup 은 source_asset_id / floor_id 양쪽 키를 모두 시도 — 백엔드가 draft 와
- * version 에서 source_asset_id 를 다르게 (한쪽 null) 응답하는 경우에도 hit.
- */
-function getRealWidthM(draft: SceneDraft): number | null {
-  const summary = (draft.summary_json ?? {}) as {
-    storage?: { real_width_m?: number };
-  };
-  const fromSummary = summary.storage?.real_width_m;
-  if (typeof fromSummary === 'number' && fromSummary > 0) return fromSummary;
-  if (draft.source_asset_id) {
-    const v = loadCachedRealWidth(draft.source_asset_id);
-    if (v != null) return v;
-  }
-  if (draft.floor_id) {
-    const v = loadCachedRealWidth(draft.floor_id);
-    if (v != null) return v;
-  }
-  return null;
-}
-
-/**
- * summary_json 의 scale_ratio_m_per_px 조회. geom 변환에 쓴 최종 scale (m/px).
- * 벽 좌표가 `pixel × scale_ratio` 로 미터화됐으므로, 같은 scale 로 이미지를 놓으면
- * 벽과 정확히 정렬됨. OCR 추정/기본 fallback 무관하게 백엔드가 항상 기록.
- */
-function getScaleRatioMPerPx(draft: SceneDraft): number | null {
-  const summary = (draft.summary_json ?? {}) as {
-    scale_ratio_m_per_px?: number;
-  };
-  const v = summary.scale_ratio_m_per_px;
-  if (typeof v === 'number' && v > 0) return v;
-  return null;
-}
-
-/**
- * 이미지의 실제 미터 크기 계산. 두 가지 소스:
- *   1. scale_ratio_m_per_px (신규, 권장): imageDims_px × scale → 벽과 동일 좌표계 정렬.
- *   2. real_width_m (legacy): 사용자가 입력하던 도면 가로폭. 옛 draft 호환용.
- * 둘 다 없으면 null → fallback 으로 도형 bounds 기준 viewBox 사용.
+ * draft 의 summary_json 을 floorplan-image-extent util 이 받는 shape 로 변환.
+ * 캐시 lookup 키 (source_asset_id / floor_id) 도 같이 묶어서 1회 함수 호출로 처리.
  */
 function deriveImageExtent(
   draft: SceneDraft,
   imageDims: { w: number; h: number } | null,
 ): { w: number; h: number } | null {
-  if (!imageDims || imageDims.w <= 0) return null;
-
-  // 1순위: scale_ratio (이미지 픽셀 × m/px = 미터 크기). 벽과 정확히 겹침.
-  const scaleRatio = getScaleRatioMPerPx(draft);
-  if (scaleRatio != null) {
-    return {
-      w: imageDims.w * scaleRatio,
-      h: imageDims.h * scaleRatio,
-    };
-  }
-
-  // 2순위 (legacy): real_width_m. 옛 draft / version-as-draft 캐시 호환.
-  const realWidthM = getRealWidthM(draft);
-  if (realWidthM != null) {
-    return {
-      w: realWidthM,
-      h: realWidthM * (imageDims.h / imageDims.w),
-    };
-  }
-  return null;
+  const summary = (draft.summary_json ?? {}) as {
+    storage?: { real_width_m?: number };
+    scale_ratio_m_per_px?: number;
+  };
+  return deriveImageExtentShared(imageDims, {
+    realWidthM: summary.storage?.real_width_m ?? null,
+    scaleRatioMPerPx: summary.scale_ratio_m_per_px ?? null,
+    sourceAssetId: draft.source_asset_id ?? null,
+    floorId: draft.floor_id ?? null,
+  });
 }
 
 const DRAG_THRESHOLD_M = 0.05;
@@ -750,18 +650,27 @@ export function DraftSceneCanvas({
   // 이미지 크기는 유지 → "도면 위에 그렸을 때 그림+도면 크기 저장 + 화면에 안 늘어남".
   // 이미지가 없거나 real_width_m 가 없으면 fallback 으로 캐시된 도형 bounds viewBox.
   const imageDims = useImageNaturalDimensions(backgroundImageUrl ?? null);
-  // 부수효과: draft 의 summary_json 에 real_width_m 이 있으면 캐시에 저장.
-  // 이후 promote → version-as-draft (summary_json={}) 가 되면 이 캐시로 복원 → viewBox 안정.
-  // source_asset_id 와 floor_id 두 키 모두로 저장 — 백엔드 응답이 둘 중 하나만
+  // 부수효과: draft 의 summary_json 에 있는 real_width_m / scale_ratio_m_per_px 를
+  // 캐시에 저장. 이후 promote → version-as-draft (summary_json={}) 가 되어도 캐시로
+  // 복원되어 viewBox + image 배치가 안 흔들림. simulation/measurement 페이지가
+  // 같은 캐시를 읽어 이미지·벽 정렬을 동일하게 유지.
+  // source_asset_id 와 floor_id 두 키 모두로 저장 — 백엔드 응답이 둘 중 한쪽만
   // 채워주는 케이스(promote 전후로 source_asset_id 가 한쪽만 null 등) 에서도 lookup 성공.
   useEffect(() => {
     const summary = (draft.summary_json ?? {}) as {
       storage?: { real_width_m?: number };
+      scale_ratio_m_per_px?: number;
     };
-    const v = summary.storage?.real_width_m;
-    if (typeof v !== 'number' || v <= 0) return;
-    if (draft.source_asset_id) saveCachedRealWidth(draft.source_asset_id, v);
-    if (draft.floor_id) saveCachedRealWidth(draft.floor_id, v);
+    const realW = summary.storage?.real_width_m;
+    if (typeof realW === 'number' && realW > 0) {
+      if (draft.source_asset_id) saveCachedRealWidth(draft.source_asset_id, realW);
+      if (draft.floor_id) saveCachedRealWidth(draft.floor_id, realW);
+    }
+    const scaleR = summary.scale_ratio_m_per_px;
+    if (typeof scaleR === 'number' && scaleR > 0) {
+      if (draft.source_asset_id) saveCachedScaleRatio(draft.source_asset_id, scaleR);
+      if (draft.floor_id) saveCachedScaleRatio(draft.floor_id, scaleR);
+    }
   }, [draft]);
   const imageExtent = useMemo(
     () => deriveImageExtent(draft, imageDims),

--- a/frontend/src/features/editor/floorplan-image-extent.ts
+++ b/frontend/src/features/editor/floorplan-image-extent.ts
@@ -1,0 +1,159 @@
+/**
+ * 배경 도면 이미지의 실제 미터 extent 계산 — DraftSceneCanvas / SimulationCanvas 공용.
+ *
+ * 핵심: 벽 좌표가 `pixel × scale_ratio_m_per_px` 로 미터화 되었으므로, 같은 scale 을
+ * 이미지에 적용하면 벽과 정확히 정렬되는 (0,0)~(extent.w, extent.h) 사각형을 얻는다.
+ *
+ * 우선순위:
+ *   1. summary_json.scale_ratio_m_per_px (신규, draft 직후만 채워짐)
+ *   2. summary_json.storage.real_width_m (legacy)
+ *   3. localStorage 캐시 (asset_id / floor_id 키) — promote 후 SceneVersion 으로
+ *      바뀌어 summary 가 비어도 복원 가능
+ *
+ * scale_ratio 캐시도 같은 패턴으로 보관 — editor 에서 한 번 저장하면 simulation
+ * 페이지에서 동일하게 복원.
+ */
+import { useEffect, useState } from 'react';
+
+const REAL_WIDTH_CACHE_PREFIX = 'asset-real-width-m:v1:';
+const SCALE_RATIO_CACHE_PREFIX = 'asset-scale-ratio-m-per-px:v1:';
+
+// ============================================
+// real_width_m (legacy) 캐시
+// ============================================
+export function loadCachedRealWidth(key: string): number | null {
+  try {
+    const raw = localStorage.getItem(REAL_WIDTH_CACHE_PREFIX + key);
+    if (!raw) return null;
+    const v = Number(raw);
+    return Number.isFinite(v) && v > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCachedRealWidth(key: string, w: number): void {
+  try {
+    localStorage.setItem(REAL_WIDTH_CACHE_PREFIX + key, String(w));
+  } catch {
+    /* quota / private mode: 무시 */
+  }
+}
+
+// ============================================
+// scale_ratio_m_per_px 캐시 (신규, 권장)
+// ============================================
+export function loadCachedScaleRatio(key: string): number | null {
+  try {
+    const raw = localStorage.getItem(SCALE_RATIO_CACHE_PREFIX + key);
+    if (!raw) return null;
+    const v = Number(raw);
+    return Number.isFinite(v) && v > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCachedScaleRatio(key: string, ratio: number): void {
+  try {
+    localStorage.setItem(SCALE_RATIO_CACHE_PREFIX + key, String(ratio));
+  } catch {
+    /* quota / private mode: 무시 */
+  }
+}
+
+// ============================================
+// Hook: 이미지 natural 픽셀 dim
+// ============================================
+export function useImageNaturalDimensions(
+  url: string | null | undefined,
+): { w: number; h: number } | null {
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  useEffect(() => {
+    setDims(null);
+    if (!url) return;
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    let cancelled = false;
+    img.onload = () => {
+      if (!cancelled && img.naturalWidth > 0 && img.naturalHeight > 0) {
+        setDims({ w: img.naturalWidth, h: img.naturalHeight });
+      }
+    };
+    img.onerror = () => {
+      if (!cancelled) setDims(null);
+    };
+    img.src = url;
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+  return dims;
+}
+
+// ============================================
+// 핵심: imageExtent (미터) 계산
+// ============================================
+export interface ImageExtentSource {
+  /** draft 직후 summary_json.storage.real_width_m */
+  realWidthM?: number | null;
+  /** draft 직후 summary_json.scale_ratio_m_per_px */
+  scaleRatioMPerPx?: number | null;
+  /** 캐시 lookup 키. 둘 다 시도하므로 가능한 만큼 채움. */
+  sourceAssetId?: string | null;
+  floorId?: string | null;
+}
+
+/**
+ * 이미지의 실제 미터 크기. summary 우선, 없으면 캐시 fallback. 둘 다 없으면 null.
+ *
+ * imageDims 가 없으면 (이미지 못 로드) 항상 null.
+ */
+export function deriveImageExtent(
+  imageDims: { w: number; h: number } | null,
+  src: ImageExtentSource,
+): { w: number; h: number } | null {
+  if (!imageDims || imageDims.w <= 0) return null;
+
+  const scaleRatio = resolveScaleRatio(src);
+  if (scaleRatio != null) {
+    return { w: imageDims.w * scaleRatio, h: imageDims.h * scaleRatio };
+  }
+
+  const realWidthM = resolveRealWidth(src);
+  if (realWidthM != null) {
+    return {
+      w: realWidthM,
+      h: realWidthM * (imageDims.h / imageDims.w),
+    };
+  }
+  return null;
+}
+
+function resolveScaleRatio(src: ImageExtentSource): number | null {
+  const fromSummary = src.scaleRatioMPerPx;
+  if (typeof fromSummary === 'number' && fromSummary > 0) return fromSummary;
+  if (src.sourceAssetId) {
+    const v = loadCachedScaleRatio(src.sourceAssetId);
+    if (v != null) return v;
+  }
+  if (src.floorId) {
+    const v = loadCachedScaleRatio(src.floorId);
+    if (v != null) return v;
+  }
+  return null;
+}
+
+function resolveRealWidth(src: ImageExtentSource): number | null {
+  const fromSummary = src.realWidthM;
+  if (typeof fromSummary === 'number' && fromSummary > 0) return fromSummary;
+  if (src.sourceAssetId) {
+    const v = loadCachedRealWidth(src.sourceAssetId);
+    if (v != null) return v;
+  }
+  if (src.floorId) {
+    const v = loadCachedRealWidth(src.floorId);
+    if (v != null) return v;
+  }
+  return null;
+}

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useRef } from 'react';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import { loadCachedViewBox } from '@/features/editor/viewbox-cache';
+import {
+  deriveImageExtent,
+  useImageNaturalDimensions,
+} from '@/features/editor/floorplan-image-extent';
 import type {
   DraftObject,
   DraftOpening,
@@ -31,6 +35,8 @@ export type MeasurementViewMode = 'route' | 'heatmap' | 'both';
 
 interface Props {
   sceneVersion: SceneVersion | null | undefined;
+  /** 원본 도면 이미지 (배경에 연하게 깔림). 공간편집/시뮬과 동일한 방식. */
+  backgroundImageUrl?: string | null;
   points: MeasurementPoint[];
   aps: PlacedApSimple[];
   mode: MeasurementViewMode;
@@ -64,8 +70,12 @@ function extendBounds(b: Bounds, x: number, y: number) {
   if (y > b.maxY) b.maxY = y;
 }
 
-/** viewBox 는 도형(walls/openings) 기준. 객체는 건물 밖으로 나갈 수 있어 제외. */
-function computeViewBox(scene: SceneVersion | null | undefined) {
+/** viewBox 는 도형(walls/openings) 기준. imageExtent 주어지면 union 으로 잡아서
+ *  배경 이미지와 벽이 같은 좌표계로 정렬 표시. 객체는 건물 밖으로 나갈 수 있어 제외. */
+function computeViewBox(
+  scene: SceneVersion | null | undefined,
+  imageExtent: { w: number; h: number } | null,
+) {
   const b = emptyBounds();
   for (const wall of scene?.walls ?? []) {
     const g = parseGeometry(wall.centerline_geom);
@@ -74,6 +84,10 @@ function computeViewBox(scene: SceneVersion | null | undefined) {
   for (const op of scene?.openings ?? []) {
     const g = parseGeometry(op.line_geom);
     if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  if (imageExtent) {
+    extendBounds(b, 0, 0);
+    extendBounds(b, imageExtent.w, imageExtent.h);
   }
   if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
   const w = b.maxX - b.minX || 1;
@@ -101,6 +115,7 @@ const QUALITY_HEATMAP_RGBA: Record<MeasurementPointQuality, string> = {
  */
 export function MeasurementCanvas({
   sceneVersion,
+  backgroundImageUrl,
   points,
   aps,
   mode,
@@ -108,14 +123,28 @@ export function MeasurementCanvas({
   estimatedHeatmap,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  // viewBox 는 editor 와 동일하게 — 같은 floor_id 의 editor 캐시(localStorage) 를 우선.
-  // 없으면 scene 도형 기준 계산. 페이지 간 캔버스 영역 일관성 유지.
   const sceneId = sceneVersion?.id ?? null;
+
+  // 배경 이미지를 editor 와 동일한 좌표계로 배치하기 위해 imageExtent (미터) 계산.
+  // image 는 (0,0)~(extent.w, extent.h) 에 그림 → 벽과 정확히 정렬.
+  const imageDims = useImageNaturalDimensions(backgroundImageUrl ?? null);
+  const imageExtent = useMemo(
+    () =>
+      deriveImageExtent(imageDims, {
+        sourceAssetId: sceneVersion?.source_asset_id ?? null,
+        floorId: sceneVersion?.floor_id ?? null,
+      }),
+    [imageDims, sceneVersion?.source_asset_id, sceneVersion?.floor_id],
+  );
+
+  // viewBox: imageExtent 있으면 union(walls, image) 자체 계산 (가장 안정적).
+  // 없을 때만 editor 캐시 fallback → 도형 bounds 최후.
   const vb = useMemo(() => {
+    if (imageExtent) return computeViewBox(sceneVersion, imageExtent);
     const cached = loadCachedViewBox(sceneVersion?.floor_id ?? null);
     if (cached) return cached;
-    return computeViewBox(sceneVersion);
-  }, [sceneId, sceneVersion?.floor_id]);
+    return computeViewBox(sceneVersion, null);
+  }, [sceneId, sceneVersion?.floor_id, imageExtent]);
   const sortedPoints = useMemo(
     () => [...points].sort((a, b) => a.order - b.order),
     [points],
@@ -158,6 +187,29 @@ export function MeasurementCanvas({
 
         {/* 모든 콘텐츠를 도면 영역으로 클립. */}
         <g clipPath="url(#mc-viewbox-clip)">
+
+        {/* 배경 원본 도면 이미지 — 가장 아래에 연하게 (공간편집/시뮬과 동일).
+            imageExtent 있으면 실제 미터 좌표 배치 → 벽과 정렬. 없으면 viewBox fit. */}
+        {backgroundImageUrl && (
+          <image
+            href={backgroundImageUrl}
+            xlinkHref={backgroundImageUrl}
+            x={imageExtent ? 0 : vb.x}
+            y={imageExtent ? 0 : vb.y}
+            width={imageExtent ? imageExtent.w : vb.w}
+            height={imageExtent ? imageExtent.h : vb.h}
+            preserveAspectRatio={imageExtent ? 'none' : 'xMidYMid meet'}
+            opacity={0.35}
+            pointerEvents="none"
+            crossOrigin="anonymous"
+            onError={() => {
+              console.warn(
+                '[MeasurementCanvas] 배경 도면 이미지 로드 실패:',
+                backgroundImageUrl,
+              );
+            }}
+          />
+        )}
 
         {/* 히트맵: 도형보다 아래에 깔아 도면이 위에 보이도록.
             GP regression dense heatmap 이 있으면 그것을 우선 표시 (전체 도면 커버).

--- a/frontend/src/features/simulation/HeatmapColorLegend.tsx
+++ b/frontend/src/features/simulation/HeatmapColorLegend.tsx
@@ -1,0 +1,92 @@
+/**
+ * RF 시뮬레이션 히트맵 색 → dBm 범례.
+ *
+ * 각 run 의 실제 사용된 색 스케일 (vmin/vmax, auto-scale p5-p95) 을 ai_api 가
+ * `artifacts.radiomap.color_scale` 로 노출 → backend 가 RfMap.metrics_json.color_scale
+ * 에 보관 → 이 컴포넌트가 그대로 사용. matplotlib inferno cmap 의 stops 을 CSS gradient
+ * 로 재현해서 동일한 시각화 제공.
+ *
+ * color_scale 이 없는 경우 (옛 run / sagemaker 응답에 미포함) 합리적 기본값 -85~-30 dBm
+ * 으로 표시 — 사용자는 대략의 범위라도 파악 가능.
+ */
+
+// matplotlib inferno 의 11개 stops (0.0 → 1.0). matplotlib.cm.inferno(t) 와 같은 색.
+const INFERNO_STOPS: ReadonlyArray<string> = [
+  '#000004',
+  '#160b39',
+  '#420a68',
+  '#6a176e',
+  '#932667',
+  '#bc3754',
+  '#dd513a',
+  '#f37819',
+  '#fca50a',
+  '#f6d746',
+  '#fcffa4',
+];
+
+function buildGradientCss(): string {
+  // 수평 그라데이션 — 왼쪽=낮은 신호(짙은 보라), 오른쪽=높은 신호(밝은 노랑).
+  const stops = INFERNO_STOPS.map(
+    (color, i) => `${color} ${((i / (INFERNO_STOPS.length - 1)) * 100).toFixed(1)}%`,
+  ).join(', ');
+  return `linear-gradient(to right, ${stops})`;
+}
+
+const GRADIENT_CSS = buildGradientCss();
+
+const DEFAULT_VMIN_DBM = -85;
+const DEFAULT_VMAX_DBM = -30;
+
+/** RfMap.metrics_json.color_scale 또는 metrics_json.radio_map.color_scale 에서 추출. */
+export function extractColorScale(
+  raw: unknown,
+): { vminDbm: number; vmaxDbm: number } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const vmin = Number(obj['vmin_dbm']);
+  const vmax = Number(obj['vmax_dbm']);
+  if (!Number.isFinite(vmin) || !Number.isFinite(vmax) || vmax <= vmin) return null;
+  return { vminDbm: vmin, vmaxDbm: vmax };
+}
+
+interface Props {
+  /** color_scale 객체 — 미지정 시 기본 dBm 범위로 fallback. */
+  scale?: { vminDbm: number; vmaxDbm: number } | null;
+  className?: string;
+}
+
+/**
+ * 가로 그라데이션 + 양 끝/중간 dBm 라벨. 캔버스 모서리에 작게 띄우는 용도.
+ */
+export function HeatmapColorLegend({ scale, className }: Props) {
+  const vmin = scale?.vminDbm ?? DEFAULT_VMIN_DBM;
+  const vmax = scale?.vmaxDbm ?? DEFAULT_VMAX_DBM;
+  const vmid = (vmin + vmax) / 2;
+  const isFallback = !scale;
+
+  return (
+    <div
+      className={
+        'pointer-events-none flex flex-col gap-1 rounded-md border bg-card/90 px-2.5 py-1.5 shadow-sm backdrop-blur' +
+        (className ? ` ${className}` : '')
+      }
+      role="img"
+      aria-label={`RSS dBm 색상 범례: ${vmin.toFixed(0)} dBm 에서 ${vmax.toFixed(0)} dBm`}
+    >
+      <div className="flex items-center justify-between gap-2 text-[10px] font-medium text-muted-foreground">
+        <span>RSS (dBm)</span>
+        {isFallback && <span className="text-[9px] text-muted-foreground/70">approx.</span>}
+      </div>
+      <div
+        className="h-2.5 w-44 rounded-sm border border-border/60"
+        style={{ backgroundImage: GRADIENT_CSS }}
+      />
+      <div className="flex justify-between text-[10px] font-mono tabular-nums text-foreground/70">
+        <span>{vmin.toFixed(0)}</span>
+        <span>{vmid.toFixed(0)}</span>
+        <span>{vmax.toFixed(0)}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useRef, useState } from 'react';
 import { parseGeometry, type Coord } from '@/features/editor/geometry-utils';
 import { loadCachedViewBox } from '@/features/editor/viewbox-cache';
+import {
+  deriveImageExtent,
+  useImageNaturalDimensions,
+} from '@/features/editor/floorplan-image-extent';
 import type {
   DraftObject,
   DraftOpening,
@@ -61,11 +65,17 @@ function extendBounds(b: Bounds, x: number, y: number) {
 }
 
 /**
- * 캔버스 viewBox 는 도면 구조(rooms/walls/openings) 만 기준으로 계산.
+ * 캔버스 viewBox 계산. imageExtent 가 주어지면 union(walls, image) 로 잡아서
+ * 이미지와 벽이 같은 좌표계로 함께 표시되도록 함. 없으면 도형(walls/rooms/openings)
+ * bounds 기준 fallback.
+ *
  * 객체(가구/공간 박스) 는 건물 밖으로 삐져나갈 수 있어 viewBox 에서 제외 — 캔버스가
- * 일그러지지 않도록 고정. 밖으로 나간 객체는 잘려 보이지만 캔버스 비율은 안정적.
+ * 일그러지지 않도록 고정. 밖으로 나간 객체는 잘려 보이지만 비율은 안정적.
  */
-function computeViewBox(scene: SceneVersion | null | undefined): {
+function computeViewBox(
+  scene: SceneVersion | null | undefined,
+  imageExtent: { w: number; h: number } | null,
+): {
   x: number;
   y: number;
   w: number;
@@ -84,6 +94,11 @@ function computeViewBox(scene: SceneVersion | null | undefined): {
   for (const op of scene?.openings ?? []) {
     const g = parseGeometry(op.line_geom);
     if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  // image extent 가 있으면 (0,0)~(extent.w, extent.h) 도 bounds 에 포함 → union.
+  if (imageExtent) {
+    extendBounds(b, 0, 0);
+    extendBounds(b, imageExtent.w, imageExtent.h);
   }
   if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
   const w = b.maxX - b.minX || 1;
@@ -112,14 +127,29 @@ export function SimulationCanvas({
   readOnly = false,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  // viewBox 는 editor 와 동일하게 — 같은 floor_id 의 editor 캐시(localStorage) 를 우선.
-  // 없으면 scene 도형 기준으로 계산. 캐시 사용으로 공간편집·시뮬·실측 페이지가 동일한 영역 표시.
   const sceneId = sceneVersion?.id ?? null;
+
+  // 배경 이미지를 editor 와 동일한 좌표계로 배치하기 위해 imageExtent (미터) 계산.
+  // 있으면 image 는 (0,0)~(extent.w, extent.h) 에 그림 → 벽과 정확히 정렬.
+  // 없으면 viewBox 영역에 fit 으로 fallback (정렬은 안 맞아도 결과는 보임).
+  const imageDims = useImageNaturalDimensions(backgroundImageUrl ?? null);
+  const imageExtent = useMemo(
+    () =>
+      deriveImageExtent(imageDims, {
+        sourceAssetId: sceneVersion?.source_asset_id ?? null,
+        floorId: sceneVersion?.floor_id ?? null,
+      }),
+    [imageDims, sceneVersion?.source_asset_id, sceneVersion?.floor_id],
+  );
+
+  // viewBox: image extent 있으면 union(walls, image) 우선 — 가장 안정적인 자체 계산.
+  // 없을 때만 editor 캐시 fallback (이전 페이지에서 잡아둔 영역 유지) → 도형 bounds 최후.
   const vb = useMemo(() => {
+    if (imageExtent) return computeViewBox(sceneVersion, imageExtent);
     const cached = loadCachedViewBox(sceneVersion?.floor_id ?? null);
     if (cached) return cached;
-    return computeViewBox(sceneVersion);
-  }, [sceneId, sceneVersion?.floor_id]);
+    return computeViewBox(sceneVersion, null);
+  }, [sceneId, sceneVersion?.floor_id, imageExtent]);
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOffset, setDragOffset] = useState<Coord>([0, 0]);
 
@@ -212,13 +242,16 @@ export function SimulationCanvas({
           <image
             href={backgroundImageUrl}
             xlinkHref={backgroundImageUrl}
-            x={vb.x}
-            y={vb.y}
-            width={vb.w}
-            height={vb.h}
-            preserveAspectRatio="xMidYMid meet"
+            // imageExtent 가 있으면 실제 미터 좌표 (0,0)~(extent.w, extent.h) 에 배치 →
+            // 벽 좌표와 동일 좌표계 → 정렬 일치. 없으면 vb 영역에 fitting (fallback).
+            x={imageExtent ? 0 : vb.x}
+            y={imageExtent ? 0 : vb.y}
+            width={imageExtent ? imageExtent.w : vb.w}
+            height={imageExtent ? imageExtent.h : vb.h}
+            preserveAspectRatio={imageExtent ? 'none' : 'xMidYMid meet'}
             opacity={0.35}
             pointerEvents="none"
+            crossOrigin="anonymous"
             onError={() => {
               console.warn('[SimulationCanvas] 배경 도면 이미지 로드 실패:', backgroundImageUrl);
             }}

--- a/frontend/src/hooks/use-local-floorplan-image.ts
+++ b/frontend/src/hooks/use-local-floorplan-image.ts
@@ -1,44 +1,101 @@
 import { useEffect, useState } from 'react';
 
 /**
- * 도면 이미지 로컬 캐시 — 백엔드가 source_asset_id 안 채우는 케이스 우회.
- * 사용자가 업로드한 파일을 base64 로 localStorage 에 보관하고, 캔버스 배경에 사용.
+ * 도면 이미지 로컬 캐시 — 백엔드가 source_asset_id 안 채우는 케이스 + 백엔드가 자산 URL 을
+ * 상대경로(`/assets/{id}/raw`) 로만 주는 local 모드 케이스 우회.
  *
- * - 키: `floorplan-image-${floorId}`
+ * 키 전략 — **자산별 키 우선, 층별 키 fallback**:
+ *   - `floorplan-image-asset:{assetId}` (신규, 자산 ID 별로 별도 보관 → 히스토리 버전 클릭 시
+ *     그 당시 업로드한 이미지가 정확히 복원됨)
+ *   - `floorplan-image-{floorId}` (legacy, 층당 1장 — 항상 가장 최근 업로드. 새 업로드 직후
+ *     아직 source_asset_id 모를 때 임시로 쓰는 staging)
+ *
+ * 새 업로드 흐름:
+ *   1. EditorPage.handleFile → `saveLocalFloorplanImage(floorId, file)` (asset_id 없음 → floor 키만)
+ *   2. analyze 완료, draft 의 source_asset_id 알게 됨 → `linkFloorImageToAsset(floorId, assetId)`
+ *      가 floor 키 내용을 asset 키로 복사 (덮어쓰지 않음 — 기존 asset 캐시가 있으면 그대로)
+ *
+ * 히스토리 버전 로드:
+ *   useLocalFloorplanImage({ floorId, sourceAssetId }) — assetId 키 hit 면 즉시 반환,
+ *   없으면 floor 키 (latest) 로 fallback. assetId 가 null 이면 floor 키만 사용 (legacy 동작).
+ *
  * - PDF 는 브라우저가 직접 렌더링 불가하므로 스킵 (image/* 만 저장).
  * - localStorage 용량 초과 시 조용히 실패.
  */
 
-const PREFIX = 'floorplan-image-';
+const FLOOR_PREFIX = 'floorplan-image-';
+const ASSET_PREFIX = 'floorplan-image-asset:';
 
-function key(floorId: string): string {
-  return `${PREFIX}${floorId}`;
+function floorKey(floorId: string): string {
+  return `${FLOOR_PREFIX}${floorId}`;
 }
 
-function readForFloor(floorId: string | null): string | null {
-  if (!floorId) return null;
+function assetKey(assetId: string): string {
+  return `${ASSET_PREFIX}${assetId}`;
+}
+
+function readEntry(key: string): string | null {
   try {
-    return localStorage.getItem(key(floorId));
+    return localStorage.getItem(key);
   } catch {
     return null;
   }
 }
 
-export function useLocalFloorplanImage(floorId: string | null): string | null {
-  const [dataUrl, setDataUrl] = useState<string | null>(() => readForFloor(floorId));
+function readForAssetOrFloor(
+  floorId: string | null,
+  sourceAssetId: string | null | undefined,
+): string | null {
+  if (sourceAssetId) {
+    const v = readEntry(assetKey(sourceAssetId));
+    if (v) return v;
+  }
+  if (floorId) {
+    const v = readEntry(floorKey(floorId));
+    if (v) return v;
+  }
+  return null;
+}
+
+export interface UseLocalFloorplanImageOpts {
+  floorId: string | null;
+  /** SceneVersion / SceneDraft 의 source_asset_id — 있으면 이 자산별 키를 우선 읽음. */
+  sourceAssetId?: string | null;
+}
+
+/**
+ * 두 가지 호출 시그니처 지원:
+ *   - useLocalFloorplanImage(floorId)                   (legacy)
+ *   - useLocalFloorplanImage({ floorId, sourceAssetId })
+ */
+export function useLocalFloorplanImage(
+  floorIdOrOpts: string | null | UseLocalFloorplanImageOpts,
+): string | null {
+  const opts: UseLocalFloorplanImageOpts =
+    typeof floorIdOrOpts === 'object' && floorIdOrOpts !== null
+      ? floorIdOrOpts
+      : { floorId: floorIdOrOpts ?? null };
+  const { floorId, sourceAssetId } = opts;
+
+  const [dataUrl, setDataUrl] = useState<string | null>(() =>
+    readForAssetOrFloor(floorId, sourceAssetId),
+  );
 
   useEffect(() => {
-    setDataUrl(readForFloor(floorId));
-  }, [floorId]);
+    setDataUrl(readForAssetOrFloor(floorId, sourceAssetId));
+  }, [floorId, sourceAssetId]);
 
-  // 다른 탭/스코프에서 변경되거나 같은 페이지의 saveLocalFloorplanImage 호출 후 동기화.
+  // 다른 탭/스코프에서 변경되거나 같은 페이지의 save/link 호출 후 동기화.
   useEffect(() => {
     const onChange = (e: Event) => {
-      const detail = (e as CustomEvent<{ floorId: string }>).detail;
-      if (!floorId) return;
-      if (detail?.floorId === floorId || e.type === 'storage') {
-        setDataUrl(readForFloor(floorId));
+      const detail = (e as CustomEvent<{ floorId?: string; assetId?: string }>).detail;
+      // 우리 키와 무관한 storage 이벤트는 무시.
+      if (e.type === 'floorplan-image-changed') {
+        const matchesFloor = !!floorId && detail?.floorId === floorId;
+        const matchesAsset = !!sourceAssetId && detail?.assetId === sourceAssetId;
+        if (!matchesFloor && !matchesAsset) return;
       }
+      setDataUrl(readForAssetOrFloor(floorId, sourceAssetId));
     };
     window.addEventListener('storage', onChange);
     window.addEventListener('floorplan-image-changed', onChange);
@@ -46,20 +103,19 @@ export function useLocalFloorplanImage(floorId: string | null): string | null {
       window.removeEventListener('storage', onChange);
       window.removeEventListener('floorplan-image-changed', onChange);
     };
-  }, [floorId]);
+  }, [floorId, sourceAssetId]);
 
   return dataUrl;
 }
 
-/** 도면 파일을 floor 별로 캐시. 이미지 파일만 저장 (PDF 는 스킵). */
+/** 업로드 직후 호출 — floor 키에 저장 (asset_id 아직 모를 때의 staging). */
 export function saveLocalFloorplanImage(floorId: string, file: File): void {
   if (!file.type.startsWith('image/')) return;
   const reader = new FileReader();
   reader.onload = () => {
     try {
       const dataUrl = reader.result as string;
-      localStorage.setItem(key(floorId), dataUrl);
-      // 같은 페이지에서 듣고 있는 hook 들 알림.
+      localStorage.setItem(floorKey(floorId), dataUrl);
       window.dispatchEvent(
         new CustomEvent('floorplan-image-changed', { detail: { floorId } }),
       );
@@ -71,9 +127,32 @@ export function saveLocalFloorplanImage(floorId: string, file: File): void {
   reader.readAsDataURL(file);
 }
 
+/**
+ * Draft/Version 의 source_asset_id 알게 된 순간 호출 — floor 키의 이미지를 asset 키로
+ * 복사 보존. 이후 새 업로드가 floor 키를 덮어써도 옛 자산 이미지는 asset 키로 살아남음.
+ * 이미 asset 키에 값이 있으면 덮어쓰지 않음 (한번 link 되면 그 후 불변).
+ */
+export function linkFloorImageToAsset(
+  floorId: string | null | undefined,
+  assetId: string | null | undefined,
+): void {
+  if (!floorId || !assetId) return;
+  try {
+    if (localStorage.getItem(assetKey(assetId))) return; // 이미 link 됨
+    const fromFloor = localStorage.getItem(floorKey(floorId));
+    if (!fromFloor) return;
+    localStorage.setItem(assetKey(assetId), fromFloor);
+    window.dispatchEvent(
+      new CustomEvent('floorplan-image-changed', { detail: { assetId } }),
+    );
+  } catch {
+    /* quota / private mode — 무시 */
+  }
+}
+
 export function clearLocalFloorplanImage(floorId: string): void {
   try {
-    localStorage.removeItem(key(floorId));
+    localStorage.removeItem(floorKey(floorId));
     window.dispatchEvent(
       new CustomEvent('floorplan-image-changed', { detail: { floorId } }),
     );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -94,7 +94,8 @@ export default function DashboardPage() {
     .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
   const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
-  const localImage = useLocalFloorplanImage(floorId);
+  // sourceAssetId 우선 — 히스토리 버전 클릭 시 그 자산 이미지로 정확히 복원.
+  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
   // 절대 http(s) 자산 URL 만 <image> 에서 직접 로드. local 모드 `/assets/{id}/raw`
   // 상대경로는 origin/인증 문제로 못 써서 localStorage 캐시로 fallback.
   const assetUrl = assetUrlQuery.data?.url ?? null;

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/hooks/use-scene-version';
 import { useAssetDownloadUrl, useFloorAssets } from '@/hooks/use-assets';
 import {
+  linkFloorImageToAsset,
   saveLocalFloorplanImage,
   useLocalFloorplanImage,
 } from '@/hooks/use-local-floorplan-image';
@@ -178,7 +179,15 @@ export default function EditorPage() {
   const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
   // 3순위: 사용자가 업로드한 파일을 base64 로 캐시해둔 로컬 이미지 (백엔드 미지원 우회).
-  const localImage = useLocalFloorplanImage(floorId);
+  // sourceAssetId 알면 자산별 키 우선, 없으면 floor 키 fallback — 히스토리 버전 클릭 시
+  // 그 당시 업로드 이미지가 별도 키로 보존돼 있어 정확히 복원됨.
+  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  // 업로드 직후엔 floor 키에만 임시 저장돼있음 → draft.source_asset_id 알게 되는 순간
+  // asset 키로 복사해 보존 (덮어쓰진 않음). 새 업로드가 floor 키를 덮어써도 이전 자산은
+  // 자기 자산 키에 그대로 남음.
+  useEffect(() => {
+    if (floorId && sourceAssetId) linkFloorImageToAsset(floorId, sourceAssetId);
+  }, [floorId, sourceAssetId]);
   // 자산 URL 은 <image href> 에서 직접 로드 가능한 절대 http(s) 만 사용.
   // local 모드의 `/assets/{id}/raw` 같은 상대경로는 (a) 프론트 origin 기준이라 백엔드를
   // 못 가리키고 (b) JWT 인증 헤더를 못 실어서 못 씀 → localStorage 캐시(base64) 로 fallback.

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -31,6 +31,9 @@ import {
 } from '@/hooks/use-measurement-session';
 import { useFloorRfRuns, useRfMaps } from '@/hooks/use-rf-run';
 import { useApLayouts } from '@/hooks/use-ap-layouts';
+import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
+import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
+import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import {
   useCalibrationParameterUpdates,
   useCalibrationRun,
@@ -55,6 +58,22 @@ export default function MeasurementPage() {
   const currentVersion = versions.find((v) => v.is_current) ?? versions[0] ?? null;
   const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
   const sceneVersion = versionDetailQuery.data ?? null;
+
+  // 배경 원본 도면 이미지 — 공간편집/시뮬과 동일한 방식.
+  const versionAsDraft = sceneVersion ? versionToDraftShape(sceneVersion) : null;
+  const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
+  const fallbackAsset = (floorAssetsQuery.data ?? [])
+    .slice()
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
+  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
+  // sourceAssetId 우선 — 히스토리 버전 클릭 시 그 자산 이미지로 정확히 복원.
+  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const assetUrl = assetUrlQuery.data?.url ?? null;
+  const usableAssetUrl =
+    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
+  const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
 
   // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
   const sessionsQuery = useFloorMeasurementSessions(floorId);
@@ -160,6 +179,7 @@ export default function MeasurementPage() {
               <div className="relative min-h-112 flex-1">
                 <MeasurementCanvas
                   sceneVersion={sceneVersion}
+                  backgroundImageUrl={backgroundImageUrl}
                   points={canvasPoints}
                   aps={canvasAps}
                   mode={mode}

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -15,6 +15,9 @@ import { useMemo, useEffect } from 'react';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import { useCreateRfRun, useFloorRfRuns, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
+import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
+import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
+import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import {
   useApCandidates,
   useApLayouts,
@@ -29,12 +32,16 @@ import {
   type SimulationHistoryItem,
 } from '@/features/simulation/SimulationHistory';
 import {
-  DEFAULT_TX_POWER_DBM,
   SimulationCanvas,
   type PlacedAp,
 } from '@/features/simulation/SimulationCanvas';
+import {
+  HeatmapColorLegend,
+  extractColorScale,
+} from '@/features/simulation/HeatmapColorLegend';
 import { toast } from '@/stores/toast-store';
 import type { ApCandidate, ApLayout } from '@/types/ap-layout';
+import type { RfBackend } from '@/types/rf';
 import { cn } from '@/lib/utils';
 
 type SimulationState = 'idle' | 'running' | 'complete';
@@ -55,21 +62,52 @@ export default function SimulationPage() {
   const [aps, setAps] = useState<PlacedAp[]>([]);
   const [pendingAdd, setPendingAdd] = useState(false);
 
+  // 시뮬 실행 백엔드 토글 — local(기본, 로컬 ai_api) | sagemaker(클라우드).
+  // 로컬에서 분 단위로 결과 보는 게 dev 흐름이라 기본값을 local 로.
+  const [backend, setBackend] = useState<RfBackend>('local');
+
   // 캔버스 배경으로 보여줄 확정 버전 상세 (rooms/walls/openings/objects 포함).
   const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
+
+  // 배경 도면 이미지 — 공간편집/대시보드와 동일한 방식.
+  // (a) version 의 source_asset_id 가 있으면 presigned URL, (b) 없으면 floor 의
+  // 가장 최근 floorplan_image asset, (c) 백엔드 자산 없으면 localStorage 캐시.
+  const versionAsDraft = versionDetailQuery.data
+    ? versionToDraftShape(versionDetailQuery.data)
+    : null;
+  const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
+  const fallbackAsset = (floorAssetsQuery.data ?? [])
+    .slice()
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
+  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
+  // sourceAssetId 우선 — 히스토리 버전 클릭 시 그 자산 이미지로 정확히 복원.
+  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const assetUrl = assetUrlQuery.data?.url ?? null;
+  const usableAssetUrl =
+    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
+  const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
 
   // 층의 과거 RF Run 목록 (이력 카드 + 자동 복원용).
   const pastRunsQuery = useFloorRfRuns(floorId, { page_size: 20 });
   const pastRuns = useMemo(() => pastRunsQuery.data?.items ?? [], [pastRunsQuery.data]);
 
-  // 활성 run = 사용자가 명시 선택한 것 ?? 최근 succeeded fallback.
-  // → 새로고침/재진입 시에도 가장 최근 succeeded 자동 활성.
+  // 활성 run = 사용자가 명시 선택한 것 ?? 현재 scene_version 으로 돌린 최근 succeeded.
+  // → 새로고침/재진입 시에도 자동 활성, 단 **현재 버전과 일치하는 run** 만 대상.
+  //   공간편집으로 새 버전 만든 직후 시뮬 페이지로 오면 옛 run 은 자동복원 안 됨 → idle.
   // 단 사용자가 명시적으로 "다시 실행" 누른 직후엔 idle 유지.
+  // 명시 선택(pickedRunId) 은 버전 일치 무관 — 사용자가 기록에서 직접 골랐으니 존중.
   const activeRunId = useMemo(() => {
     if (resetCleared) return null;
     if (pickedRunId) return pickedRunId;
-    return pastRuns.find((r) => r.status === 'succeeded')?.id ?? null;
-  }, [resetCleared, pickedRunId, pastRuns]);
+    if (!currentVersion) return null;
+    return (
+      pastRuns.find(
+        (r) => r.status === 'succeeded' && r.scene_version_id === currentVersion.id,
+      )?.id ?? null
+    );
+  }, [resetCleared, pickedRunId, pastRuns, currentVersion]);
   const setActiveRunId = (id: string | null) => {
     setResetCleared(false);
     setPickedRunId(id);
@@ -112,6 +150,15 @@ export default function SimulationPage() {
     return maps.find((m) => m.map_type === 'heatmap') ?? maps[0] ?? null;
   }, [rfMapsQuery.data, isRunForCurrentVersion]);
   const heatmapUrl = heatmapMap?.url ?? null;
+  // 히트맵 색 스케일 (vmin/vmax dBm) — color legend 가 같은 inferno 그라데이션 +
+  // 동일 범위로 표시. local backend / 최신 sagemaker container 가 응답에 채워넣음.
+  const heatmapColorScale = useMemo(
+    () =>
+      extractColorScale(
+        (heatmapMap?.metrics_json as Record<string, unknown> | undefined)?.['color_scale'],
+      ),
+    [heatmapMap],
+  );
   const heatmapBounds = useMemo(
     () => parseHeatmapBounds(heatmapMap?.bounds_json),
     [heatmapMap],
@@ -141,15 +188,11 @@ export default function SimulationPage() {
           y_m: ap.y_m,
           z_m: ap.z_m,
         })),
-        simulation: {
-          frequency_hz: 2.4e9,
-          tx_power_dbm: DEFAULT_TX_POWER_DBM,
-          resolution_m: 0.5,
-          measurement_plane_z_m: 1.0,
-          max_depth: 3,
-          samples_per_tx: 100_000,
-          seed: 42,
-        },
+        // 모든 시뮬 파라미터는 backend `app/core/rf_defaults.py` 의 디폴트 사용 —
+        // 5GHz / 20dBm / max_depth=3 / samples=100k 등. UI 에서 사용자가 직접 정하는
+        // 값이 생기면 여기 채워 보내면 backend 가 우선 적용. 빈 `{}` 는 "new flow" 트리거.
+        simulation: {},
+        backend,
       },
       { onSuccess: (data) => setActiveRunId(data.id) },
     );
@@ -205,6 +248,8 @@ export default function SimulationPage() {
         hasVersion={!!currentVersion}
         isStarting={createRfRun.isPending}
         apsCount={aps.length}
+        backend={backend}
+        onBackendChange={setBackend}
         onStart={handleStart}
         onReset={handleReset}
       />
@@ -231,10 +276,7 @@ export default function SimulationPage() {
                 <CanvasModeBar apsCount={aps.length} />
                 <SimulationCanvas
                   sceneVersion={versionDetailQuery.data}
-                  // 시뮬레이션 페이지는 배경 도면 이미지 안 깔음 — 도형만으로 표시
-                  // (공간편집/대시보드만 배경 이미지). 히트맵과 시각 충돌 방지 + AP 배치
-                  // 시 깔끔한 캔버스 유지.
-                  backgroundImageUrl={null}
+                  backgroundImageUrl={backgroundImageUrl}
                   aps={aps}
                   onAdd={handleAddAp}
                   onMove={handleMoveAp}
@@ -263,7 +305,7 @@ export default function SimulationPage() {
                 )}
                 <SimulationCanvas
                   sceneVersion={versionDetailQuery.data}
-                  backgroundImageUrl={null}
+                  backgroundImageUrl={backgroundImageUrl}
                   aps={aps}
                   onAdd={handleAddAp}
                   onMove={handleMoveAp}
@@ -274,6 +316,11 @@ export default function SimulationPage() {
                   heatmapBounds={heatmapBounds}
                   readOnly
                 />
+                {heatmapUrl && isRunForCurrentVersion && (
+                  <div className="absolute bottom-3 right-3 z-10">
+                    <HeatmapColorLegend scale={heatmapColorScale} />
+                  </div>
+                )}
               </>
             )}
           </div>
@@ -391,6 +438,8 @@ function PageHeader({
   hasVersion,
   isStarting,
   apsCount,
+  backend,
+  onBackendChange,
   onStart,
   onReset,
 }: {
@@ -398,6 +447,8 @@ function PageHeader({
   hasVersion: boolean;
   isStarting: boolean;
   apsCount: number;
+  backend: RfBackend;
+  onBackendChange: (b: RfBackend) => void;
   onStart: () => void;
   onReset: () => void;
 }) {
@@ -410,7 +461,10 @@ function PageHeader({
         </p>
       </div>
 
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-3">
+        {state === 'idle' && (
+          <BackendToggle value={backend} onChange={onBackendChange} disabled={isStarting} />
+        )}
         {state === 'idle' ? (
           <button
             type="button"
@@ -438,6 +492,52 @@ function PageHeader({
         )}
       </div>
     </header>
+  );
+}
+
+/** SageMaker | Local 백엔드 토글 (idle 일 때만 노출). */
+function BackendToggle({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: RfBackend;
+  onChange: (b: RfBackend) => void;
+  disabled?: boolean;
+}) {
+  const options: Array<{ key: RfBackend; label: string; hint: string }> = [
+    { key: 'sagemaker', label: 'Cloud', hint: 'SageMaker async (운영 기본)' },
+    { key: 'local', label: 'Local', hint: '로컬 ai_api 직접 호출 (테스트용)' },
+  ];
+  return (
+    <div
+      role="radiogroup"
+      aria-label="시뮬 실행 백엔드"
+      className="inline-flex items-center gap-0.5 rounded-lg border bg-background p-0.5 shadow-sm"
+    >
+      {options.map((opt) => {
+        const active = value === opt.key;
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(opt.key)}
+            disabled={disabled}
+            title={opt.hint}
+            className={cn(
+              'rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+              active
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/frontend/src/types/rf.ts
+++ b/frontend/src/types/rf.ts
@@ -9,6 +9,9 @@ export type RfRunStatus =
   | 'failed'
   | string;
 
+/** §13.1 시뮬 실행 백엔드. sagemaker(기본)=클라우드, local=로컬 ai_api(테스트용). */
+export type RfBackend = 'sagemaker' | 'local';
+
 /** §13.1 RF 시뮬레이션 access point. 1~8 개. */
 export interface AccessPointDTO {
   id: string;
@@ -17,10 +20,11 @@ export interface AccessPointDTO {
   z_m: number;
 }
 
-/** §13.1 RF 시뮬레이션 파라미터. SageMaker 입력. */
+/** §13.1 RF 시뮬레이션 파라미터. 모든 필드 optional — 미지정 시 backend 의
+ *  `app/core/rf_defaults.py` 값 적용. 프론트는 UI 에서 사용자가 직접 정한 것만 보낸다. */
 export interface RfSimulationParams {
-  frequency_hz: number;
-  tx_power_dbm: number;
+  frequency_hz?: number;
+  tx_power_dbm?: number;
   resolution_m?: number;
   measurement_plane_z_m?: number;
   max_depth?: number;
@@ -40,6 +44,8 @@ export interface RfRunCreate {
    * 미지정 시 백엔드 default=true (보정 자동 적용). false 면 raw 시뮬 (비교용).
    */
   apply_calibration?: boolean;
+  /** 시뮬 실행 백엔드. 미지정 시 백엔드 default='sagemaker'. */
+  backend?: RfBackend;
   /** Legacy 호환 (deprecated). */
   request_json?: Record<string, unknown>;
 }


### PR DESCRIPTION
## 개요
RF 시뮬레이션 실행 시 사용되는 물리/solver/propagation 기본값을 `backend/app/core/rf_defaults.py`로 분리하여 관리 지점을 단일화

이번 변경으로 web-platform 경로에서는 `rf_defaults.py`의 값이 RFSimulationParams를 통해 채워지고, local ai_api/SageMaker 요청 payload에도 명시적으로 전달되도록 정리

또한 SageMaker async 외에 로컬에서 띄운 ai_api 의 `/internal/sionna/run`을 직접 호출하는 `local` 백엔드를 추가 
Local 백엔드는 submit 시 즉시 RFRun과 Job 을 running 상태로 생성한 뒤, 백그라운드 thread에서 ai_api를 호출하고 완료/실패 결과를 DB에 반영하는 구조

## 변경 사항
### 1. RF 기본 하이퍼파라미터 단일화
- `backend/app/core/rf_defaults.py`를 새로 추가해서 RF 시뮬레이션 기본값을 한 곳에서 관리하도록 변경

### 2. `RFSimulationParans` 기본값 정리
기존에는 RfSimulationParams 안에 resolution_m=0.5, max_depth=3, samples_per_tx=100_000 같은 값이 직접 박혀 있었는데, 이번 PR에서는 rf_defaults.py에서 import한 상수를 사용하도록 변경

### 3. Local ai_api 백엔드 추가
rf_backend_local.py가 추가되어 SageMaker를 거치지 않고 로컬 ai_api의 /internal/sionna/run을 직접 호출

### 4. RF Job 서비스에서 backend 분기 처리
- submit_rf_simulation에 backend 파라미터가 추가되어 "sagemaker"와 "local"을 선택할 수 있게 변경
- backend == "local"이면 submit_via_local_ai_api로 보내고, 아니면 기존 SageMaker async 경로를 사용
- poll 로직도 local backend일 때는 외부 S3/SageMaker 확인 없이 DB 상태만 refresh해서 읽도록 분기

### 5. ai_api client 개선
- ai_api_client.py에는 local Sionna 호출용 run_sionna_simulation이 추가됐고, base URL도 AI_API_BASE_URL → AI_SERVICE_URL → localhost:9000 순서로 fallback되도록 정리


## Test
- Local backend 선택 후 시뮬레이션 실행
- `Job.status`가 running → done 또는 failed로 정상 전이되는지 확인
- `/rf-runs/{id}` 응답의 `metrics_json.config.solver` 확인
  - `max_depth = 10`
  - `samples_per_tx = 500000`
- `metrics_json.config.propagation` 확인
  - `los = true`
  - `specular_reflection = true`
  - `refraction = true`
  - `diffuse_reflection = true`
  - `diffraction = true`
- `metrics_json.config.physical` 확인
  - `frequency_ghz = 5.0`
  - `tx_power_dbm = 20`
- Local backend 결과에서 heatmap 이미지 URL, bounds, color_scale이 프론트에 정상 반영되는지 확인