### PR TITLE
[Feat] 공간 유형 별 파라미터 보정 적용과 path-loss 파라미터 보정 적용 및 프론트 수정

### DIFF
--- a/backend/app/models/floor.py
+++ b/backend/app/models/floor.py
@@ -27,6 +27,11 @@ class Floor(Base):
     default_ceiling_height_m: Mapped[Decimal] = mapped_column(
         Numeric(6, 3), nullable=False, server_default=text("2.4")
     )
+    # 공간 유형 (calibration BO prior + 향후 sim defaults 의 source of truth).
+    # SpaceType StrEnum 의 string 값과 매칭 (cafe / study_room / classroom / office / residential / unknown).
+    space_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'unknown'")
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/backend/app/routers/rf/measurements.py
+++ b/backend/app/routers/rf/measurements.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
@@ -40,9 +41,30 @@ def create_measurement_link(
 )
 def get_measurement_link_context(
     token: str,
+    request: Request,
     db: Session = Depends(get_db),
 ) -> MeasurementLinkContextResponseDTO:
-    return measurement_service.get_measurement_link_context(db, token)
+    # request.base_url 은 모바일이 backend 를 부른 그 host (예: http://192.168.0.10:8000/).
+    # 이 host 를 그대로 써서 floorplan-image URL 을 absolute 로 구성 → 모바일이 동일 host
+    # 로 이미지 다운로드 가능. 폰이 https 로 들어왔으면 https 그대로 나감.
+    base = str(request.base_url).rstrip("/")
+    return measurement_service.get_measurement_link_context(db, token, base_url=base)
+
+
+@router.get(
+    "/measurement-links/{token}/floorplan-image",
+    summary="측정 link token 으로 인증되는 floorplan 이미지 스트리밍 (모바일 전용)",
+)
+def get_measurement_link_floorplan_image(
+    token: str,
+    db: Session = Depends(get_db),
+):
+    """JWT 우회 — link token 자체가 권한 증명. local dev mode 의 file:// asset 을
+    모바일 (Coil) 이 다운로드 가능하게 만들기 위한 라우트. S3 자산은 /context 응답의
+    presigned URL 을 직접 받으므로 이 라우트로 안 옴.
+    """
+    path, mime = measurement_service.resolve_floorplan_image_for_link(db, token)
+    return FileResponse(str(path), media_type=mime, filename=path.name)
 
 
 @router.post(
@@ -147,14 +169,25 @@ def list_detected_aps(
 @router.get(
     "/measurement-sessions/{session_id}/estimated-coverage",
     response_model=EstimatedCoverageResponseDTO,
-    summary="GP regression 으로 측정점 → dense RSSI 맵 추정 (#81)",
+    summary="측정점 → dense RSSI 맵 추정 (#81). method 로 GP/residual kriging 선택.",
 )
 def estimate_session_coverage(
     session_id: str,
     resolution_m: float = Query(default=0.5, gt=0.1, le=2.0),
+    method: str = Query(
+        default="auto",
+        pattern="^(auto|gp_only|residual_kriging)$",
+        description=(
+            "auto: sim 있으면 residual_kriging, 없으면 gp_only. "
+            "gp_only: 측정값만 GP 보간 ('실측 히트맵' 의미). "
+            "residual_kriging: sim 을 prior 로 측정 residual 만 GP ('통합 분석' 의미)."
+        ),
+    ),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> EstimatedCoverageResponseDTO:
     return measurement_service.estimate_session_coverage(
-        db, session_id, current_user, grid_resolution_m=resolution_m
+        db, session_id, current_user,
+        grid_resolution_m=resolution_m,
+        method=method,
     )

--- a/backend/app/schemas/floor.py
+++ b/backend/app/schemas/floor.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+SpaceTypeLiteral = Literal[
+    "cafe", "study_room", "classroom", "office", "residential", "unknown"
+]
 
 
 # ============================================
@@ -16,16 +22,19 @@ class FloorCreateRequest(BaseModel):
     floor_name: str = Field(min_length=1, max_length=80)
     floor_order: int = Field(default=0)
     height_m: Decimal = Field(default=Decimal("2.4"), gt=0, le=Decimal("99.999"))
+    space_type: SpaceTypeLiteral | None = None
 
 
 class FloorUpdateRequest(BaseModel):
     floor_name: str | None = Field(default=None, min_length=1, max_length=80)
     floor_order: int | None = None
     height_m: Decimal | None = Field(default=None, gt=0, le=Decimal("99.999"))
+    # 공간 유형 변경. 'unknown' 도 명시 가능, null/생략 시 미변경 (PATCH 시맨틱).
+    space_type: SpaceTypeLiteral | None = None
 
 
 # ============================================
-# Response DTO 
+# Response DTO
 # ============================================
 class FloorResponse(BaseModel):
 
@@ -43,6 +52,7 @@ class FloorResponse(BaseModel):
         validation_alias="default_ceiling_height_m",
         serialization_alias="height_m",
     )
+    space_type: SpaceTypeLiteral = "unknown"
     created_at: datetime
 
     model_config = ConfigDict(

--- a/backend/app/schemas/rf/calibration_run.py
+++ b/backend/app/schemas/rf/calibration_run.py
@@ -2,12 +2,18 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.core.enums import normalize_job_status
+
+# SpaceType 의 string 값들을 Literal 로 받아 Pydantic 검증 — runner 의 resolve_space_type
+# 이 unknown fallback 처리하므로 빠져도 안전하지만 typo 는 여기서 차단.
+SpaceTypeLiteral = Literal[
+    "cafe", "study_room", "classroom", "office", "residential", "unknown"
+]
 
 
 class CalibrationRunCreate(BaseModel):
@@ -17,6 +23,8 @@ class CalibrationRunCreate(BaseModel):
     session_id: UUID
     rf_run_id: UUID
     version_id: UUID
+    # 공간 유형 (soft prior). 미지정 시 backend runner 가 "unknown" 으로 fallback.
+    space_type: Optional[SpaceTypeLiteral] = None
 
 
 class CalibrationRunResponse(BaseModel):

--- a/backend/app/schemas/rf/measurement.py
+++ b/backend/app/schemas/rf/measurement.py
@@ -205,3 +205,4 @@ class EstimatedCoverageResponseDTO(BaseModel):
     uncertainty_max_db: float
     input_point_count: int     # GP 학습에 쓴 측정점 개수
     kernel_repr: str           # 학습된 kernel 정보 (디버깅)
+    method: str = "gp_only"    # 'gp_only' (sim 없음) | 'residual_kriging' (sim prior 사용)

--- a/backend/app/services/floor_service.py
+++ b/backend/app/services/floor_service.py
@@ -77,6 +77,7 @@ def create_floor(
         name=payload.floor_name.strip(),
         floor_index=payload.floor_order,
         default_ceiling_height_m=payload.height_m,
+        space_type=payload.space_type or "unknown",
     )
     db.add(floor)
     db.commit()
@@ -119,6 +120,7 @@ def update_floor(
         "floor_name": "name",
         "floor_order": "floor_index",
         "height_m": "default_ceiling_height_m",
+        "space_type": "space_type",  # 동일 이름 그대로
     }
 
     for spec_field, value in update_data.items():

--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -190,6 +190,16 @@ def create_calibration_run(
     # 백그라운드 워커 (job_poller) 가 픽업하도록 running 으로 시작.
     # poller 는 status=running 만 본다.
     now = datetime.now(timezone.utc)
+    # space_type 결정 우선순위:
+    #  1. payload.space_type (request override — 일회성)
+    #  2. floor.space_type (사용자가 설정한 공간 유형 — source of truth)
+    #  3. None → runner 가 "unknown" 으로 fallback
+    from app.models.floor import Floor
+    floor = db.execute(select(Floor).where(Floor.id == sv.floor_id)).scalar_one_or_none()
+    effective_space_type = (
+        payload.space_type
+        or (floor.space_type if floor and floor.space_type else None)
+    )
     job = Job(
         project_id=sv.project_id,
         floor_id=sv.floor_id,
@@ -200,6 +210,7 @@ def create_calibration_run(
             "scene_version_id": sv.id,
             "rf_run_id": rr.id,
             "measurement_session_id": ms.id,
+            "space_type": effective_space_type,
         },
         started_at=now,
     )

--- a/backend/app/services/rf/calibration_worker/path_loss.py
+++ b/backend/app/services/rf/calibration_worker/path_loss.py
@@ -93,8 +93,16 @@ class Measurement:
 
 @dataclass
 class CalibrationParams:
-    """BO 변수 → 모델 파라미터."""
+    """BO 변수 → 모델 파라미터.
+
+    path_loss_exp: log-distance 모델의 n. 공간 유형별 prior 로 초기값/bounds 가
+    달라지지만 absolute value 로 저장 (delta 가 아님 — 해석 가능성 ↑).
+    PL0_DB 는 BO 변수로 안 둠 — tx_power_offset_db 와 식별성이 겹쳐 잡음.
+    """
     tx_power_offset_db: float = 0.0
+    # log-distance exponent. 디폴트는 generic indoor (모듈 상수 PATH_LOSS_EXP).
+    # SPACE_PRIORS 가 None 이거나 미지정 시 fallback.
+    path_loss_exp: float = PATH_LOSS_EXP
     floor_thickness_m: float = 0.10
     furniture_default_thickness_m: float = 0.05
     # material_label → scale (없으면 1.0)
@@ -162,7 +170,9 @@ def predict_rssi(
     d = math.hypot(dx, dy)
     d = max(d, REF_DISTANCE_M)
 
-    fspl_term = PL0_DB + 10.0 * PATH_LOSS_EXP * math.log10(d / REF_DISTANCE_M)
+    # path-loss exponent: params 가 우선 (공간 유형별 BO 결과). 0 이하면 모듈 상수로 폴백.
+    n = params.path_loss_exp if params.path_loss_exp > 0 else PATH_LOSS_EXP
+    fspl_term = PL0_DB + 10.0 * n * math.log10(d / REF_DISTANCE_M)
     wall_term = _wall_attenuation_db(ap, point, walls, params)
     rssi = ap.tx_power_dbm + params.tx_power_offset_db - fspl_term - wall_term
     return max(rssi, RSSI_FLOOR_DBM)

--- a/backend/app/services/rf/calibration_worker/runner.py
+++ b/backend/app/services/rf/calibration_worker/runner.py
@@ -43,6 +43,12 @@ from app.services.rf.calibration_worker.path_loss import (
     WallSegment,
     compute_error_metrics,
 )
+from app.services.rf.calibration_worker.space_priors import (
+    SpaceType,
+    get_feedback_message,
+    get_prior,
+    resolve_space_type,
+)
 from app.services.scene.scene_version_export import export_scene_version_to_scene_json
 from app.core.geom import wkb_to_geojson
 
@@ -53,19 +59,17 @@ JOB_TYPE_CALIBRATION = "calibration"
 
 
 # ────────────────────────────────────────────────────────────────────
-# BO 변수 공간 — 순서 = (5개 material scale, tx_offset, floor_th, furn_th)
+# BO 변수 공간 — 순서 = (path_loss_exp, 5개 material scale, tx_offset, floor_th, furn_th)
+# bounds 는 space_type prior 기반으로 build 시점에 동적 생성.
 # ────────────────────────────────────────────────────────────────────
-_BO_BOUNDS: list[tuple[float, float]] = (
-    [(0.3, 3.0)] * len(CALIBRATABLE_MATERIALS)  # 5 dims
-    + [(-10.0, 10.0)]   # tx_power_offset_db
-    + [(0.02, 0.20)]    # floor_thickness_m
-    + [(0.02, 0.30)]    # furniture_default_thickness_m
-)
 _PARAM_NAMES: list[str] = (
-    [f"materials.{m}.attenuation_scale" for m in CALIBRATABLE_MATERIALS]
-    + ["physical.tx_power_offset_db",
-       "scene_defaults.floor_thickness_m",
-       "scene_defaults.furniture_default_thickness_m"]
+    ["physical.path_loss_exp"]
+    + [f"materials.{m}.attenuation_scale" for m in CALIBRATABLE_MATERIALS]
+    + [
+        "physical.tx_power_offset_db",
+        "scene_defaults.floor_thickness_m",
+        "scene_defaults.furniture_default_thickness_m",
+    ]
 )
 
 # 기본 evaluation budget (env override 가능)
@@ -73,13 +77,34 @@ _BO_N_INITIAL = int(os.getenv("CALIBRATION_BO_N_INITIAL", "12"))
 _BO_N_ITER = int(os.getenv("CALIBRATION_BO_N_ITER", "38"))
 
 
+def _build_bo_bounds(space_type: SpaceType) -> list[tuple[float, float]]:
+    """공간 유형 prior 기반 BO bounds — _PARAM_NAMES 순서와 1:1.
+
+    순서: [path_loss_exp, *material_scales, tx_offset, floor_th, furn_th]
+    """
+    prior = get_prior(space_type)
+    return (
+        [prior["path_loss_exp_bounds"]]
+        + [prior["material_scale_bounds"][m] for m in CALIBRATABLE_MATERIALS]
+        + [
+            (-10.0, 10.0),   # tx_power_offset_db
+            (0.02, 0.20),    # floor_thickness_m
+            (0.02, 0.30),    # furniture_default_thickness_m
+        ]
+    )
+
+
 def _vector_to_params(x: np.ndarray) -> CalibrationParams:
+    """BO 후보 벡터 → CalibrationParams. _PARAM_NAMES 순서 따름."""
     n_mat = len(CALIBRATABLE_MATERIALS)
-    scales = {m: float(x[i]) for i, m in enumerate(CALIBRATABLE_MATERIALS)}
+    path_loss_exp = float(x[0])
+    scales = {m: float(x[1 + i]) for i, m in enumerate(CALIBRATABLE_MATERIALS)}
+    base = 1 + n_mat
     return CalibrationParams(
-        tx_power_offset_db=float(x[n_mat]),
-        floor_thickness_m=float(x[n_mat + 1]),
-        furniture_default_thickness_m=float(x[n_mat + 2]),
+        path_loss_exp=path_loss_exp,
+        tx_power_offset_db=float(x[base]),
+        floor_thickness_m=float(x[base + 1]),
+        furniture_default_thickness_m=float(x[base + 2]),
         material_attenuation_scales=scales,
     )
 
@@ -235,6 +260,20 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
     if not measurements:
         _finalize_failure(db, cr, job, "No measurement points with RSSI found.")
         return
+    # BO 가 9차원 파라미터를 fit 하므로 최소 측정점 가드 — 너무 적으면 overfit 되어
+    # next 시뮬에 극단적 파라미터 적용 (벽이 무한히 두꺼워지는 등). 통계적 신뢰는 ~10점+.
+    # 8점 미만이면 거부; 8~9점이면 진행하되 metrics 에 경고 플래그.
+    _MIN_MEASUREMENTS_HARD = 8
+    if len(measurements) < _MIN_MEASUREMENTS_HARD:
+        _finalize_failure(
+            db, cr, job,
+            f"Not enough measurement points for reliable calibration "
+            f"(got {len(measurements)}, need at least {_MIN_MEASUREMENTS_HARD}). "
+            f"Walk around the floor and measure more points before calibrating — "
+            f"BO 가 9차원 파라미터를 fit 하므로 적은 점은 overfit 되어 다음 시뮬 결과를 "
+            f"극단적으로 왜곡합니다.",
+        )
+        return
 
     rf_run = db.execute(
         select(RfRun).where(RfRun.id == cr.rf_run_id)
@@ -249,6 +288,12 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
         return
 
     walls = _load_walls(db, cr.scene_version_id)
+
+    # space_type — Job.input_json 에서 추출. 미지정/오타/None 은 UNKNOWN.
+    # SPACE_PRIORS lookup → BO bounds 동적 구성.
+    space_type = resolve_space_type((job.input_json or {}).get("space_type"))
+    bo_bounds = _build_bo_bounds(space_type)
+    prior = get_prior(space_type)
 
     # 같은 scene_version 의 이전 완료된 calibration 이 있으면 그 best_params 를
     # baseline 으로 깔고 그 위에서 delta 만 BO 로 탐색 → 누적 refinement.
@@ -271,8 +316,9 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
 
     has_prev = prev_run is not None
     logger.info(
-        "Calibration %s: measurements=%d aps=%d walls=%d → BO start (init=%d, iter=%d) %s",
-        cr.id, len(measurements), len(aps), len(walls), _BO_N_INITIAL, _BO_N_ITER,
+        "Calibration %s: space_type=%s measurements=%d aps=%d walls=%d → BO start (init=%d, iter=%d) %s",
+        cr.id, space_type.value, len(measurements), len(aps), len(walls),
+        _BO_N_INITIAL, _BO_N_ITER,
         f"warm-start from prev={prev_run.id}" if has_prev else "cold-start",
     )
 
@@ -291,7 +337,7 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
     bo_result = await run_in_threadpool(
         bo_optimizer.minimize,
         _objective,
-        _BO_BOUNDS,
+        bo_bounds,
         n_initial=_BO_N_INITIAL,
         n_iter=_BO_N_ITER,
         seed=bo_seed,
@@ -319,6 +365,18 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
         "bo_n_iter": bo_result.n_iter,
         "bo_seed": bo_seed,
         "best_params": _params_to_dict(best_params),
+        # 공간 유형 prior 적용 정보 — UI 가 결과 해석 및 사용자 피드백에 사용.
+        "space_type": space_type.value,
+        "applied_prior": {
+            "path_loss_exp_init": prior["path_loss_exp_init"],
+            "path_loss_exp_bounds": list(prior["path_loss_exp_bounds"]),
+            "description": prior["description"],
+        },
+        "feedback_message": _build_feedback_message(
+            space_type=space_type,
+            baseline_rmse=baseline_metrics.rmse_dbm,
+            calibrated_rmse=best_metrics.rmse_dbm,
+        ),
         "previous_calibration_run_id": str(prev_run.id) if has_prev else None,
         "previous_rmse_dbm": round(prev_metrics.rmse_dbm, 3) if prev_metrics else None,
         "delta_from_previous": _params_to_dict(delta_params) if has_prev else None,
@@ -375,6 +433,7 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
 # ────────────────────────────────────────────────────────────────────
 def _params_to_dict(p: CalibrationParams) -> dict[str, Any]:
     return {
+        "path_loss_exp": round(p.path_loss_exp, 3),
         "tx_power_offset_db": round(p.tx_power_offset_db, 3),
         "floor_thickness_m": round(p.floor_thickness_m, 4),
         "furniture_default_thickness_m": round(p.furniture_default_thickness_m, 4),
@@ -385,9 +444,13 @@ def _params_to_dict(p: CalibrationParams) -> dict[str, Any]:
 
 
 def _params_from_dict(d: dict[str, Any]) -> CalibrationParams:
-    """`_params_to_dict` 의 역. 누락 필드는 baseline (1.0 / 0.0 / 기본 두께) 으로 채움."""
+    """`_params_to_dict` 의 역. 누락 필드는 baseline (1.0 / 0.0 / 기본 두께) 으로 채움.
+
+    옛 calibration record 에 path_loss_exp 없으면 CalibrationParams 디폴트(=PATH_LOSS_EXP) 사용.
+    """
     defaults = CalibrationParams()
     return CalibrationParams(
+        path_loss_exp=float(d.get("path_loss_exp", defaults.path_loss_exp)),
         tx_power_offset_db=float(d.get("tx_power_offset_db", defaults.tx_power_offset_db)),
         floor_thickness_m=float(d.get("floor_thickness_m", defaults.floor_thickness_m)),
         furniture_default_thickness_m=float(
@@ -401,11 +464,13 @@ def _params_from_dict(d: dict[str, Any]) -> CalibrationParams:
 
 
 def _compose_params(prev: CalibrationParams, delta: CalibrationParams) -> CalibrationParams:
-    """누적 보정 — composed.scale[m] = prev.scale × delta.scale, offset = prev + delta.
+    """누적 보정.
 
-    `apply_to_scene_and_sim` 가 wall.thickness *= scale 하는 구조라
-    scale 은 곱셈, tx_offset 은 덧셈이 시뮬에 정확히 누적 반영됨.
-    floor/furniture thickness 는 절대값이라 delta 값으로 대체 (BO 가 매번 최적값 탐색).
+    - material_scales: prev × delta (`apply_to_scene_and_sim` 가 wall.thickness *= scale)
+    - tx_offset: prev + delta (덧셈)
+    - floor/furniture thickness: delta 값 그대로 (절대값 overwrite)
+    - **path_loss_exp: delta 값 그대로 (absolute value overwrite)** — 해석 가능성 우선
+      (issue 권장: delta 보다 absolute 가 안전. BO 가 매번 best n 을 직접 탐색).
     """
     materials = (
         set(prev.material_attenuation_scales.keys())
@@ -418,11 +483,33 @@ def _compose_params(prev: CalibrationParams, delta: CalibrationParams) -> Calibr
         for m in materials
     }
     return CalibrationParams(
+        path_loss_exp=delta.path_loss_exp,
         tx_power_offset_db=prev.tx_power_offset_db + delta.tx_power_offset_db,
         floor_thickness_m=delta.floor_thickness_m,
         furniture_default_thickness_m=delta.furniture_default_thickness_m,
         material_attenuation_scales=composed_scales,
     )
+
+
+def _build_feedback_message(
+    *,
+    space_type: SpaceType,
+    baseline_rmse: float,
+    calibrated_rmse: float,
+) -> str:
+    """공간 유형별 메인 문구 + 개선폭 수치를 합쳐 반환. UI 가 그대로 표시.
+
+    개선폭 (baseline → calibrated) 이 명확히 양수면 prefix 로 수치를 붙임.
+    그렇지 않으면 공간 유형 문구만 반환.
+    """
+    base = get_feedback_message(space_type)
+    improvement = baseline_rmse - calibrated_rmse
+    if improvement > 0.5:
+        return (
+            f"보정 결과 RMSE 가 {baseline_rmse:.1f} → {calibrated_rmse:.1f} dB "
+            f"({improvement:.1f} dB 개선) 으로 좁혀졌습니다. {base}"
+        )
+    return base
 
 
 def _write_parameter_updates(
@@ -445,6 +532,14 @@ def _write_parameter_updates(
             old_value_json={"value": baseline.scale_for(m)},
             new_value_json={"value": round(params.scale_for(m), 3)},
         ))
+    rows.append(ParameterUpdate(
+        calibration_run_id=cr.id,
+        target_type="scene_version",
+        target_id=cr.scene_version_id,
+        parameter_name="physical.path_loss_exp",
+        old_value_json={"value": baseline.path_loss_exp},
+        new_value_json={"value": round(params.path_loss_exp, 3)},
+    ))
     rows.append(ParameterUpdate(
         calibration_run_id=cr.id,
         target_type="scene_version",

--- a/backend/app/services/rf/calibration_worker/space_priors.py
+++ b/backend/app/services/rf/calibration_worker/space_priors.py
@@ -1,0 +1,189 @@
+"""공간 유형별 path-loss surrogate model 의 soft prior config.
+
+## 왜 필요한가
+
+Calibration BO 의 fast objective 인 path-loss 모델은 다음 식을 쓴다.
+
+    RSSI = TX + offset - PL0 - 10*n*log10(d/d0) - Σ(att·thickness·scale)
+
+이 중 `n` (path-loss exponent) 은 공간 유형마다 다른 값이 자연스럽다 — 카페/오피스는
+가구·사람 흡수로 큰 n, 강의실은 개방형이라 작은 n, 원룸은 비교적 작은 n 등.
+
+기존엔 `PATH_LOSS_EXP=3.0` 고정이라 BO 가 거리 감쇠 mismatch 를 material_scale 이나
+tx_power_offset 으로 잘못 흡수했음. 이 모듈은 **공간 유형을 hint 로 받아 BO 의**
+**탐색 범위/초기값을 다르게 잡는 soft prior** 역할.
+
+## 핵심 원칙
+
+- **Hard rule 아님**. "카페면 n=3.8" 처럼 강제 X — BO 가 measurements 기반으로 최종 결정.
+- prior 는 **bounds 와 init** 만 좁혀줌. measurements 가 다른 값을 강하게 시사하면 BO 가
+  그 방향으로 이동 가능.
+- 잘못된 space_type 이 와도 안전하도록 bounds 를 과하게 좁히지 않음.
+"""
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final, TypedDict
+
+
+class SpaceType(StrEnum):
+    """공간 유형 — 사용자 선택 또는 scene metadata 에서 옴.
+
+    `unknown` 은 미지정/분류 애매 → generic indoor prior 사용.
+    """
+    CAFE = "cafe"
+    STUDY_ROOM = "study_room"
+    CLASSROOM = "classroom"
+    OFFICE = "office"
+    RESIDENTIAL = "residential"
+    UNKNOWN = "unknown"
+
+
+class SpacePrior(TypedDict):
+    """공간 유형 1개에 대한 calibration prior."""
+    path_loss_exp_init: float
+    path_loss_exp_bounds: tuple[float, float]
+    furniture_default_thickness_init: float
+    material_scale_bounds: dict[str, tuple[float, float]]
+    description: str   # 짧은 영문 식별자 (i18n/UI 분기용)
+
+
+# 초기 heuristic — 실험 데이터로 추후 조정 가능.
+# bounds 가 과하게 좁아 BO 가 잘못된 space_type 에 갇히지 않도록, low~high 폭은 1.5~2.5 유지.
+SPACE_PRIORS: Final[dict[SpaceType, SpacePrior]] = {
+    SpaceType.CAFE: {
+        "path_loss_exp_init": 3.4,
+        "path_loss_exp_bounds": (2.6, 4.3),
+        "furniture_default_thickness_init": 0.10,
+        "material_scale_bounds": {
+            "drywall":  (0.5, 3.0),
+            "concrete": (0.5, 3.5),
+            "wood":     (0.5, 3.0),
+            "glass":    (0.5, 3.0),
+            "metal":    (0.5, 4.0),
+        },
+        "description": "furniture_and_people_dense",
+    },
+    SpaceType.STUDY_ROOM: {
+        "path_loss_exp_init": 3.3,
+        "path_loss_exp_bounds": (2.6, 4.0),
+        "furniture_default_thickness_init": 0.08,
+        "material_scale_bounds": {
+            "drywall":  (0.5, 3.5),
+            "concrete": (0.5, 3.0),
+            "wood":     (0.5, 2.5),
+            "glass":    (0.5, 3.5),
+            "metal":    (0.5, 3.0),
+        },
+        "description": "partition_and_small_rooms",
+    },
+    SpaceType.CLASSROOM: {
+        "path_loss_exp_init": 2.8,
+        "path_loss_exp_bounds": (2.0, 3.6),
+        "furniture_default_thickness_init": 0.05,
+        "material_scale_bounds": {
+            "drywall":  (0.5, 2.5),
+            "concrete": (0.5, 3.0),
+            "wood":     (0.5, 2.5),
+            "glass":    (0.5, 2.5),
+            "metal":    (0.5, 3.0),
+        },
+        "description": "open_large_room",
+    },
+    SpaceType.OFFICE: {
+        "path_loss_exp_init": 3.2,
+        "path_loss_exp_bounds": (2.4, 4.1),
+        "furniture_default_thickness_init": 0.08,
+        "material_scale_bounds": {
+            "drywall":  (0.5, 3.0),
+            "concrete": (0.5, 3.0),
+            "wood":     (0.5, 3.0),
+            "glass":    (0.5, 3.5),
+            "metal":    (0.5, 4.0),
+        },
+        "description": "partition_glass_metal_mixed",
+    },
+    SpaceType.RESIDENTIAL: {
+        "path_loss_exp_init": 2.6,
+        "path_loss_exp_bounds": (1.8, 3.4),
+        "furniture_default_thickness_init": 0.05,
+        "material_scale_bounds": {
+            "drywall":  (0.5, 2.5),
+            "concrete": (0.5, 3.0),
+            "wood":     (0.5, 2.5),
+            "glass":    (0.5, 2.0),
+            "metal":    (0.5, 2.5),
+        },
+        "description": "small_residential_space",
+    },
+    SpaceType.UNKNOWN: {
+        # generic indoor — 가장 넓은 bound. 잘못된 분류 시 안전망.
+        "path_loss_exp_init": 3.0,
+        "path_loss_exp_bounds": (1.8, 4.5),
+        "furniture_default_thickness_init": 0.05,
+        "material_scale_bounds": {
+            "drywall":  (0.3, 3.0),
+            "concrete": (0.3, 3.0),
+            "wood":     (0.3, 3.0),
+            "glass":    (0.3, 3.0),
+            "metal":    (0.3, 3.0),
+        },
+        "description": "generic_indoor",
+    },
+}
+
+
+def resolve_space_type(value: str | None) -> SpaceType:
+    """문자열 → SpaceType. 미지정/오타/None 모두 UNKNOWN 으로 안전 fallback."""
+    if not value:
+        return SpaceType.UNKNOWN
+    try:
+        return SpaceType(value.strip().lower())
+    except ValueError:
+        return SpaceType.UNKNOWN
+
+
+def get_prior(space_type: SpaceType) -> SpacePrior:
+    """SPACE_PRIORS lookup. 매핑에 없으면 UNKNOWN fallback (안전망)."""
+    return SPACE_PRIORS.get(space_type, SPACE_PRIORS[SpaceType.UNKNOWN])
+
+
+# ============================================================
+# 사용자용 피드백 (공간 유형별 calibration 결과 해석)
+# ============================================================
+# 결과 RMSE 가 baseline 대비 줄었을 때 보여줄 문구. 수치 자체는 호출자가 가공해서 합침.
+SPACE_FEEDBACK_MESSAGES: Final[dict[SpaceType, str]] = {
+    SpaceType.CAFE: (
+        "실측 결과, 가구/좌석 밀집 구역에서 예측보다 신호가 약하게 나타났습니다. "
+        "카페 환경에서는 사람·가구·유리면 반사 및 흡수 영향으로 RSSI 변동성이 커질 수 있습니다. "
+        "AP 를 좌석 중앙부에 더 가깝게 배치하거나 보조 AP 추가를 검토할 수 있습니다."
+    ),
+    SpaceType.STUDY_ROOM: (
+        "방 사이 벽 또는 유리 파티션을 통과한 뒤 신호 감쇠가 크게 나타났습니다. "
+        "스터디룸처럼 작은 방이 분리된 구조에서는 복도 중앙보다 각 방 입구 또는 공용 공간에 "
+        "AP 를 배치하는 것이 유리할 수 있습니다."
+    ),
+    SpaceType.CLASSROOM: (
+        "공간이 넓어 AP 와 멀어질수록 신호가 점진적으로 감소하는 패턴이 나타났습니다. "
+        "벽보다 거리 기반 감쇠가 주요 원인으로 보이며, 후방 좌석 커버리지를 위해 "
+        "AP 위치 조정 또는 추가 설치가 필요할 수 있습니다."
+    ),
+    SpaceType.OFFICE: (
+        "회의실·파티션·유리벽 또는 금속 가구 주변에서 예측과 실측 차이가 발생했을 수 있습니다. "
+        "업무 공간에서는 회의실 내부와 공용 좌석 구역을 분리해 AP 배치를 검토하는 것이 좋습니다."
+    ),
+    SpaceType.RESIDENTIAL: (
+        "소형 주거 공간에서는 공유기 위치와 벽 1~2개 통과 여부가 Wi-Fi 품질에 큰 영향을 줄 수 있습니다. "
+        "공유기를 방 모서리보다 중앙부 또는 주요 사용 공간 근처에 배치하는 것이 유리할 수 있습니다."
+    ),
+    SpaceType.UNKNOWN: (
+        "공간 유형이 지정되지 않아 일반적인 실내 prior 로 보정을 수행했습니다. "
+        "프로젝트/층 설정에서 공간 유형을 지정하면 더 정확한 진단이 가능합니다."
+    ),
+}
+
+
+def get_feedback_message(space_type: SpaceType) -> str:
+    return SPACE_FEEDBACK_MESSAGES.get(
+        space_type, SPACE_FEEDBACK_MESSAGES[SpaceType.UNKNOWN]
+    )

--- a/backend/app/services/rf/measurement_estimation/gp_estimator.py
+++ b/backend/app/services/rf/measurement_estimation/gp_estimator.py
@@ -33,6 +33,7 @@ class CoverageEstimate:
     ys: np.ndarray          # (H,) grid y 좌표 (m)
     input_point_count: int  # 입력 측정점 개수
     kernel_repr: str        # 학습 후 kernel string (디버깅)
+    method: str = "gp_only" # 'gp_only' 또는 'residual_kriging'
 
 
 def estimate_coverage(
@@ -110,4 +111,137 @@ def estimate_coverage(
         ys=ys,
         input_point_count=len(points),
         kernel_repr=str(gp.kernel_),
+        method="gp_only",
+    )
+
+
+def _sample_grid_bilinear(
+    grid: np.ndarray,
+    grid_xs: np.ndarray,
+    grid_ys: np.ndarray,
+    x: float,
+    y: float,
+) -> float:
+    """grid 의 (x, y) 미터 좌표에서 bilinear interpolation 값. bounds 밖이면 NaN."""
+    if grid.size == 0 or grid_xs.size < 2 or grid_ys.size < 2:
+        return float("nan")
+    if x < grid_xs[0] or x > grid_xs[-1] or y < grid_ys[0] or y > grid_ys[-1]:
+        return float("nan")
+    dx = grid_xs[1] - grid_xs[0]
+    dy = grid_ys[1] - grid_ys[0]
+    fx = (x - grid_xs[0]) / dx
+    fy = (y - grid_ys[0]) / dy
+    i0 = int(np.floor(fy))
+    j0 = int(np.floor(fx))
+    i1 = min(i0 + 1, grid.shape[0] - 1)
+    j1 = min(j0 + 1, grid.shape[1] - 1)
+    wy = fy - i0
+    wx = fx - j0
+    v00 = grid[i0, j0]
+    v01 = grid[i0, j1]
+    v10 = grid[i1, j0]
+    v11 = grid[i1, j1]
+    return float(
+        (1 - wy) * ((1 - wx) * v00 + wx * v01)
+        + wy * ((1 - wx) * v10 + wx * v11)
+    )
+
+
+def estimate_coverage_residual(
+    points: list[tuple[float, float, float]],
+    sim_grid: np.ndarray,
+    sim_xs: np.ndarray,
+    sim_ys: np.ndarray,
+    *,
+    initial_length_scale_m: float = 3.0,
+    initial_noise_db: float = 2.0,
+) -> CoverageEstimate:
+    """Residual kriging — 시뮬 prediction 을 prior 로 깔고 GP 가 residual 만 보간.
+
+    측정점이 sparse 해도 시뮬의 spatial structure 가 유지돼서 단조로운 분포 안 됨.
+    Bayesian 관점: posterior = prior(sim) + GP(measured − sim_at_measurement).
+
+    Args:
+        points: (x_m, y_m, rssi_dbm) 측정점.
+        sim_grid: (H, W) 시뮬 예측 RSSI grid (dBm).
+        sim_xs, sim_ys: grid x/y 좌표 배열 (m).
+
+    Returns:
+        CoverageEstimate (method='residual_kriging').
+
+    Raises:
+        ValueError: 측정점 < 3 또는 모든 점이 sim grid bounds 밖.
+    """
+    if len(points) < 3:
+        raise ValueError(
+            f"At least 3 measurement points required for residual kriging (got {len(points)})"
+        )
+
+    # sim grid 의 invalid 셀 (-200 이하 = Sionna 의 "시뮬 불가" sentinel + 노이즈) 을 마스킹.
+    # 이 값들이 residual 에 섞이면 final = sim+residual 이 -260 같은 비현실 값까지 떨어짐 →
+    # color scale 가 망가져 사용자가 보는 히트맵이 한쪽 색에 쏠림.
+    # NaN 으로 바꿔두면 final grid 에서도 NaN 으로 남고, 색 범위 계산이 그것들을 무시함.
+    _SIM_INVALID_THRESHOLD = -150.0  # Wi-Fi 실내 noise floor 보다 한참 아래
+    sim_grid_masked = np.where(sim_grid > _SIM_INVALID_THRESHOLD, sim_grid, np.nan)
+
+    # 각 측정점에서 sim 예측값 sampling → residual = measured - sim.
+    # NaN (bounds 밖) 인 점은 제외.
+    residual_points: list[tuple[float, float, float]] = []
+    for x, y, rssi in points:
+        sim_at_point = _sample_grid_bilinear(sim_grid_masked, sim_xs, sim_ys, x, y)
+        if not np.isfinite(sim_at_point):
+            continue
+        residual_points.append((x, y, rssi - sim_at_point))
+
+    if len(residual_points) < 3:
+        raise ValueError(
+            f"Need at least 3 measurement points inside sim bounds "
+            f"(got {len(residual_points)} after filtering)"
+        )
+
+    # GP fit residual — residual 은 본질적으로 smooth 하므로 length scale 약간 크게.
+    arr = np.asarray(residual_points, dtype=np.float64)
+    X = arr[:, :2]
+    y_resid = arr[:, 2]
+
+    kernel = (
+        ConstantKernel(constant_value=1.0, constant_value_bounds=(1e-2, 1e3))
+        * RBF(length_scale=initial_length_scale_m, length_scale_bounds=(0.5, 50.0))
+        + WhiteKernel(noise_level=initial_noise_db, noise_level_bounds=(0.1, 50.0))
+    )
+    gp = GaussianProcessRegressor(
+        kernel=kernel,
+        n_restarts_optimizer=5,
+        normalize_y=True,
+        random_state=42,
+    )
+    gp.fit(X, y_resid)
+
+    grid_X, grid_Y = np.meshgrid(sim_xs, sim_ys)
+    grid_points = np.column_stack([grid_X.ravel(), grid_Y.ravel()])
+    resid_mean, resid_std = gp.predict(grid_points, return_std=True)
+
+    H, W = sim_grid.shape
+    # invalid sim 셀은 NaN 으로 마스킹된 grid 사용 → final 에서도 NaN 유지.
+    final_mean = sim_grid_masked + resid_mean.reshape(H, W)
+    # 실내 Wi-Fi 의 물리적 한계 ([-100, 0] dBm) 로 clamp — outlier 가 color scale 망가뜨리는 거 방지.
+    # NaN 은 clip 결과도 NaN 으로 보존됨 (heatmap renderer 가 transparent / invalid 처리).
+    final_mean = np.clip(final_mean, -100.0, 0.0)
+    # std 는 residual GP 의 std 그대로 — sim 은 deterministic 가정.
+    final_std = resid_std.reshape(H, W)
+
+    logger.info(
+        "Residual kriging fitted: N=%d, kernel=%s, residual_mean=%.2f, residual_std=%.2f",
+        len(residual_points), gp.kernel_,
+        float(np.mean(y_resid)), float(np.std(y_resid)),
+    )
+
+    return CoverageEstimate(
+        mean_grid=final_mean,
+        std_grid=final_std,
+        xs=sim_xs,
+        ys=sim_ys,
+        input_point_count=len(residual_points),
+        kernel_repr=str(gp.kernel_),
+        method="residual_kriging",
     )

--- a/backend/app/services/rf/measurement_estimation/heatmap.py
+++ b/backend/app/services/rf/measurement_estimation/heatmap.py
@@ -21,6 +21,44 @@ from .gp_estimator import CoverageEstimate
 logger = logging.getLogger(__name__)
 
 
+# 색 스케일 fallback / minimum span — measurement 점이 1~2개라 GP mean grid spread 가
+# 거의 0 일 때 vmin≈vmax 가 되어 전체가 colormap 한 색으로 깔리는 버그 방지.
+_MEAN_FALLBACK_VMIN_DBM = -95.0
+_MEAN_FALLBACK_VMAX_DBM = -35.0
+_MEAN_MIN_SPAN_DB = 12.0
+
+
+# 실내 Wi-Fi RSSI 물리적 noise floor — 이하 값은 시뮬 invalid 셀의 sentinel (-200, -270 등) 이라
+# 의미 없음. p5/p95 계산 시 제외해야 color scale 가 망가지지 않음.
+_NOISE_FLOOR_DBM = -120.0
+
+
+def _resolve_mean_color_limits(grid: np.ndarray) -> tuple[float, float]:
+    """grid mean 의 p5~p95. spread 너무 좁거나 비유한값이면 fallback / mean ± span/2.
+
+    Wi-Fi noise floor (-120dBm) 이하는 시뮬 invalid sentinel 이거나 잡음이므로 제외.
+    sionna_artifacts.resolve_radiomap_color_limits 와 동일 패턴 — 일관성.
+    """
+    if grid is None or grid.size == 0:
+        return (_MEAN_FALLBACK_VMIN_DBM, _MEAN_FALLBACK_VMAX_DBM)
+    finite = grid[np.isfinite(grid)]
+    # noise floor 이하는 색 스케일 결정에서 제외 — invalid sim 셀이 -200 ~ -270 정도라
+    # 포함 시 p5 가 그쪽으로 끌려가서 색이 한쪽에 쏠림.
+    valid = finite[finite > _NOISE_FLOOR_DBM]
+    if valid.size == 0:
+        return (_MEAN_FALLBACK_VMIN_DBM, _MEAN_FALLBACK_VMAX_DBM)
+    lo, hi = np.percentile(valid, [5.0, 95.0])
+    if not (np.isfinite(lo) and np.isfinite(hi)):
+        return (_MEAN_FALLBACK_VMIN_DBM, _MEAN_FALLBACK_VMAX_DBM)
+    if float(hi - lo) < _MEAN_MIN_SPAN_DB:
+        # 측정점 sparse → GP 가 prior mean 으로 단조롭게 깔림 → spread 좁음.
+        # 평균 중심으로 min span 만큼 강제 확장 → colormap 끝색 한가지로 안 깔림.
+        mid = float(np.mean(valid))
+        half = _MEAN_MIN_SPAN_DB / 2.0
+        return (mid - half, mid + half)
+    return (float(lo), float(hi))
+
+
 def _render_to_png(
     grid: np.ndarray,
     xs: np.ndarray,
@@ -80,14 +118,17 @@ def render_and_upload(
     mean = estimate.mean_grid
     std = estimate.std_grid
 
-    # mean 색 범위: -100 ~ -30 dBm (Wi-Fi RSSI 일반)
+    # mean 색 범위 — _resolve_mean_color_limits 가 narrow spread / NaN / empty 안전 처리.
+    # cmap='inferno' — Sionna RT heatmap, frontend Legend/측정점 그라데이션과 동일 palette.
+    # (이전엔 jet 라서 frontend 측정점 inferno 와 색 mismatch 발생.)
+    mean_vmin, mean_vmax = _resolve_mean_color_limits(mean)
     mean_png = _render_to_png(
         mean,
         estimate.xs,
         estimate.ys,
-        cmap="jet",
-        vmin=float(np.percentile(mean, 5)),
-        vmax=float(np.percentile(mean, 95)),
+        cmap="inferno",
+        vmin=mean_vmin,
+        vmax=mean_vmax,
         title=f"Estimated RSSI Coverage (GP, N={estimate.input_point_count})",
         colorbar_label="RSSI (dBm)",
         overlay_points=overlay,

--- a/backend/app/services/rf/measurement_service.py
+++ b/backend/app/services/rf/measurement_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from urllib.parse import urlencode, urlparse
 
 from sqlalchemy import func, select
@@ -159,15 +160,27 @@ def _resolve_scene_and_asset(
     return None, fallback.id if fallback else None
 
 
-def _floorplan_info_from_asset(db: Session, asset_id: str | None) -> FloorplanInfoDTO:
+def _floorplan_info_from_asset(
+    db: Session,
+    asset_id: str | None,
+    *,
+    link_token: str | None = None,
+    base_url: str | None = None,
+) -> FloorplanInfoDTO:
+    """asset → mobile 이 다운로드 가능한 URL 로 변환.
+
+    - `s3://`: presigned GET URL (모바일이 직접 다운로드)
+    - `file://`: backend 의 token-인증 public 라우트 URL 로 변환 (link_token 필수).
+      모바일은 PC 의 로컬 파일을 못 봐서, JWT 우회 + token 검증되는 streaming
+      endpoint 가 필요. link_token 없으면 None (예: 권한 없는 호출).
+    - 기타 스킴 / null: URL 없음 → 모바일 UI 가 "도면 자산 없음" 표시
+    """
     if asset_id is None:
         return FloorplanInfoDTO()
     asset = db.get(Asset, asset_id)
     if asset is None:
         return FloorplanInfoDTO()
     metadata = asset.metadata_json or {}
-    # S3 객체면 presigned URL 발급 (모바일이 직접 다운로드 가능하게).
-    # 비-S3 (옛 로컬 경로) 면 그대로 노출 — 어차피 외부 접근 불가지만 fallback.
     url = asset.storage_url
     if url and url.startswith("s3://"):
         from app.services import _s3
@@ -175,6 +188,17 @@ def _floorplan_info_from_asset(db: Session, asset_id: str | None) -> FloorplanIn
             url = _s3.presigned_get_url(url)
         except Exception:
             url = None
+    elif url and url.startswith("file://"):
+        # 로컬 dev mode — backend 가 자체 스트리밍 endpoint 로 노출.
+        # base_url 이 있으면 absolute URL, 없으면 relative (모바일은 absolute 필요).
+        if link_token:
+            path = f"/measurement-links/{link_token}/floorplan-image"
+            url = f"{base_url.rstrip('/')}{path}" if base_url else path
+        else:
+            url = None
+    else:
+        # 알 수 없는 스킴 — 모바일이 못 씀.
+        url = None
     return FloorplanInfoDTO(
         url=url,
         width_px=metadata.get("width_px"),
@@ -295,8 +319,59 @@ def create_measurement_link(
     )
 
 
-def get_measurement_link_context(
+def resolve_floorplan_image_for_link(
     db: Session, token: str
+) -> tuple[Path, str]:
+    """측정 link token 으로 인증되는 floorplan 이미지 path + mime 반환.
+
+    `/measurement-links/{token}/floorplan-image` 라우트가 사용. JWT 우회 — link token
+    자체가 권한 증명 (이미 컨텍스트/세션 생성에 쓰는 동일 토큰이라 동등 권한).
+
+    - link revoked / expired → 410 AppError (`_ensure_link_active`)
+    - asset 없거나 file:// 아님 → 404
+    """
+    link = _load_link(db, token)
+    _ensure_link_active(link)
+    if link.asset_id is None:
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            "This measurement link has no floorplan asset.",
+            status_code=404,
+        )
+    asset = db.get(Asset, link.asset_id)
+    if asset is None:
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            f"Asset {link.asset_id} not found.",
+            status_code=404,
+        )
+    url_value = asset.storage_url or ""
+    if not url_value.startswith("file://"):
+        # S3 자산이면 모바일이 _floorplan_info_from_asset 의 presigned URL 을 직접 받음 —
+        # 이 라우트로 오면 안 되는 경로. 안내성 404.
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            "Asset is not a local file (use presigned URL from /context instead).",
+            status_code=404,
+        )
+    from urllib.parse import urlparse, unquote
+    parsed = urlparse(url_value)
+    raw_path = unquote(parsed.path)
+    # 윈도우: file:///C:/foo → /C:/foo 형태로 path 가 들어옴, 앞 / 떼야 OS path 됨.
+    if raw_path.startswith("/") and len(raw_path) > 3 and raw_path[2] == ":":
+        raw_path = raw_path[1:]
+    path = Path(raw_path)
+    if not path.is_file():
+        raise AppError(
+            ErrorCode.UPLOADED_FILE_NOT_FOUND,
+            f"Local floorplan file missing: {path}",
+            status_code=404,
+        )
+    return path, (asset.mime_type or "image/png")
+
+
+def get_measurement_link_context(
+    db: Session, token: str, *, base_url: str | None = None,
 ) -> MeasurementLinkContextResponseDTO:
     link = _load_link(db, token)
     _ensure_link_active(link)
@@ -306,7 +381,10 @@ def get_measurement_link_context(
         db.commit()
         db.refresh(link)
 
-    floorplan = _floorplan_info_from_asset(db, link.asset_id)
+    # link_token + base_url 을 넘겨 file:// asset 도 모바일이 접근 가능한 URL 생성.
+    floorplan = _floorplan_info_from_asset(
+        db, link.asset_id, link_token=token, base_url=base_url,
+    )
     bounds = _bounds_from_floorplan(floorplan)
 
     return MeasurementLinkContextResponseDTO(
@@ -618,28 +696,86 @@ def list_sessions_by_floor(
     )
 
 
+def _try_load_sim_grid_for_floor(
+    db: Session, floor_id: str,
+) -> tuple["np.ndarray", "np.ndarray", "np.ndarray"] | None:
+    """floor 의 최근 succeeded RfRun 의 radio_map values_dbm + xs/ys 추출.
+
+    Returns:
+        (grid, xs, ys) — residual kriging 의 prior 로 사용.
+        None — sim 없거나 values_dbm 누락 or 형식 오류.
+    """
+    import numpy as np
+    from app.models.rf_run import RfRun
+
+    # 가장 최근 done/completed/succeeded — 백엔드 status 표기 다양.
+    rf_run = db.execute(
+        select(RfRun)
+        .where(
+            RfRun.floor_id == floor_id,
+            RfRun.status.in_(["done", "completed", "succeeded"]),
+        )
+        .order_by(RfRun.created_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if rf_run is None:
+        return None
+
+    radio_map = (rf_run.metrics_json or {}).get("radio_map") or {}
+    values = radio_map.get("values_dbm")
+    bounds = radio_map.get("bounds_m") or {}
+    if not isinstance(values, list) or not values:
+        return None
+    try:
+        grid = np.asarray(values, dtype=np.float64)
+    except Exception:
+        return None
+    if grid.ndim != 2 or grid.size == 0:
+        return None
+
+    # bounds_m → xs/ys 배열. 미지정 시 grid_shape 만 있으면 0 origin 으로 fallback.
+    H, W = grid.shape
+    min_x = float(bounds.get("min_x", 0.0))
+    max_x = float(bounds.get("max_x", float(W)))
+    min_y = float(bounds.get("min_y", 0.0))
+    max_y = float(bounds.get("max_y", float(H)))
+    if max_x <= min_x or max_y <= min_y:
+        return None
+    xs = np.linspace(min_x, max_x, W)
+    ys = np.linspace(min_y, max_y, H)
+    return grid, xs, ys
+
+
 def estimate_session_coverage(
     db: Session,
     session_id: str,
     user: User,
     grid_resolution_m: float = 0.5,
+    method: str = "auto",
 ) -> "EstimatedCoverageResponseDTO":
     """§81 — 세션의 측정점들을 GP regression 으로 dense map 추정.
 
-    1. 권한 + 세션 로드
-    2. 측정점 (x, y, rssi) 로드 — rssi NULL 인 점은 제외
-    3. floor 의 도면 bounds 계산 (없으면 측정점 bounding box)
-    4. GP fit + predict
-    5. heatmap PNG 생성 + S3 업로드
-    6. presigned URL 응답
+    method:
+      - 'auto':            sim 있으면 residual_kriging, 없으면 gp_only
+      - 'gp_only':         측정값만 GP — "실측 히트맵" 의미. sim 안 섞임
+      - 'residual_kriging': sim 을 prior 로 residual GP — "통합 분석" 의미.
+                            sim 없으면 gp_only 로 fallback (안전망)
+
+    프론트엔드의 '실측 히트맵' 탭은 gp_only, '예측·실측 통합 분석' 탭은
+    residual_kriging 를 명시적으로 호출 → 라벨과 의미 일치.
     """
     # lazy import — 무거운 sklearn / matplotlib 을 모듈 import 단에서 끌어오지 않음
+    import numpy as np
+
     from app.schemas.rf.measurement import (
         EstimatedCoverageResponseDTO,
         EstimatedRssiRangeDTO,
     )
     from app.services._s3 import presigned_get_url
-    from app.services.rf.measurement_estimation.gp_estimator import estimate_coverage
+    from app.services.rf.measurement_estimation.gp_estimator import (
+        estimate_coverage,
+        estimate_coverage_residual,
+    )
     from app.services.rf.measurement_estimation.heatmap import render_and_upload
 
     session_row = _load_owned_session(db, session_id, user)
@@ -688,28 +824,60 @@ def estimate_session_coverage(
         )
     bounds_tuple = (bounds_dto.min_x, bounds_dto.min_y, bounds_dto.max_x, bounds_dto.max_y)
 
-    # GP 학습 + 예측
-    estimate = estimate_coverage(
-        points, bounds=bounds_tuple, grid_resolution_m=grid_resolution_m
-    )
+    # method 분기:
+    #   - gp_only:           sim 무시, 측정값만 GP (실측 의미 정직)
+    #   - residual_kriging:  sim prior + residual GP (sim 없으면 gp_only 로 fallback)
+    #   - auto:              sim 있으면 residual, 없으면 gp_only
+    estimate = None
+    want_residual = method in ("residual_kriging", "auto")
+    if want_residual:
+        sim_grid_data = _try_load_sim_grid_for_floor(db, str(session_row.floor_id))
+        if sim_grid_data is not None:
+            sim_grid, sim_xs, sim_ys = sim_grid_data
+            try:
+                estimate = estimate_coverage_residual(
+                    points, sim_grid=sim_grid, sim_xs=sim_xs, sim_ys=sim_ys,
+                )
+            except ValueError as exc:
+                # 측정점 다 sim bounds 밖이면 fallback (sim 없는 거나 마찬가지).
+                import logging
+                logging.getLogger(__name__).info(
+                    "Residual kriging skipped (%s) — falling back to pure GP", exc,
+                )
+                estimate = None
+
+    if estimate is None:
+        estimate = estimate_coverage(
+            points, bounds=bounds_tuple, grid_resolution_m=grid_resolution_m
+        )
 
     # heatmap 생성 + S3
     mean_uri, std_uri = render_and_upload(estimate, str(session_row.id), points)
 
+    # rssi_range: frontend Legend/점 색 그라데이션이 이 값으로 색 스케일을 잡음.
+    # raw min/max 는 sim invalid 셀 (-200 이하 sentinel) 로 오염될 수 있어 그대로 쓰면
+    # 그라데이션이 "-263 · -154 · -45" 같은 비현실 값 표시 + 색이 한쪽으로 쏠림.
+    # → noise floor 이상 + 비유한값 제외한 셀 들로만 계산.
+    grid = estimate.mean_grid
+    finite_mask = np.isfinite(grid) & (grid > -120.0)
+    if finite_mask.any():
+        valid = grid[finite_mask]
+        # p2~p98 percentile — 양 극단 outlier (정상 범위지만 1~2 셀만 튀는 값) 도 제외.
+        lo, hi = np.percentile(valid, [2.0, 98.0])
+        rmin, rmax, rmean = float(lo), float(hi), float(valid.mean())
+    else:
+        rmin, rmax, rmean = -90.0, -30.0, -60.0  # fallback
     return EstimatedCoverageResponseDTO(
         heatmap_url=presigned_get_url(mean_uri),
         uncertainty_url=presigned_get_url(std_uri),
         bounds=bounds_dto,
         grid_shape=list(estimate.mean_grid.shape),
         grid_resolution_m=grid_resolution_m,
-        rssi_range=EstimatedRssiRangeDTO(
-            min=float(estimate.mean_grid.min()),
-            max=float(estimate.mean_grid.max()),
-            mean=float(estimate.mean_grid.mean()),
-        ),
+        rssi_range=EstimatedRssiRangeDTO(min=rmin, max=rmax, mean=rmean),
         uncertainty_max_db=float(estimate.std_grid.max()),
         input_point_count=estimate.input_point_count,
         kernel_repr=estimate.kernel_repr,
+        method=estimate.method,
     )
 
 

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -143,6 +143,10 @@ async def submit_via_local_ai_api(
         input_json["rf_run_id"] = rf_run.id
         job.input_json = input_json
         db.add(job)
+        # rf_run.request_json.access_points 와 동일 좌표로 ApLayout row 자동 생성 —
+        # 측정/진단 페이지가 ApLayout 만 보던 기존 코드도 즉시 호환.
+        from app.services.rf.rf_job_service import create_ap_layouts_from_request
+        create_ap_layouts_from_request(db, rf_run, access_points)
         db.commit()
         db.refresh(rf_run)
         db.refresh(job)
@@ -258,6 +262,10 @@ def _persist_local_success(
             "valid_ratio": artifacts.get("valid_ratio") or metrics.get("valid_ratio"),
             # heatmap PNG 와 동일한 색 스케일 (vmin/vmax) — 프론트 ColorLegend 에서 사용.
             "color_scale": radiomap.get("color_scale"),
+            # Full grid 값 (residual kriging 용 — measurement_estimation 이 prior 로 사용).
+            # 100x50 grid 면 ~40KB, 200x200 이면 ~1.3MB. 크긴 한데 sim 당 1회 저장이라 OK.
+            # 없거나 너무 크면 estimate_session_coverage 가 pure GP 로 fallback.
+            "values_dbm": radiomap.get("values_dbm"),
         }
 
         rf_run = db.execute(

--- a/backend/app/services/rf/rf_job_service.py
+++ b/backend/app/services/rf/rf_job_service.py
@@ -20,7 +20,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
+from app.core.geom import geojson_to_wkb
 from app.models import Job, Project, RfRun, SceneVersion, User
+from app.models.ap_layout import ApLayout
 from app.models.rf_map import RfMap
 from app.services.rf.sagemaker_rf_inference_service import (
     SageMakerRfInferenceFailure,
@@ -213,6 +215,9 @@ async def _submit_via_sagemaker(
         input_json["rf_run_id"] = rf_run.id
         job.input_json = input_json
         db.add(job)
+        # request_json.access_points → ApLayout row 들 자동 생성 (#measurement 페이지 표시).
+        # 사용자가 시뮬 페이지에서 찍은 AP 좌표를 다른 페이지 (측정/진단) 에서도 보려면 필요.
+        create_ap_layouts_from_request(db, rf_run, access_points)
         db.commit()
         db.refresh(rf_run)
         db.refresh(job)
@@ -474,6 +479,46 @@ def _mark_job_failed(
 # ============================================================
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def create_ap_layouts_from_request(
+    db: Session, rf_run: RfRun, access_points: list[dict[str, Any]],
+) -> None:
+    """access_points 리스트 → ApLayout row 들 일괄 add (commit 은 호출자 책임).
+
+    데이터 모델 정리: rf_run.request_json.access_points 와 ap_layouts 테이블이
+    중복으로 같은 정보 보관 중. 이 함수가 submit 시점에 ap_layouts 도 같이 채워서
+    측정/진단 페이지가 일관되게 AP 마커 표시 가능.
+
+    fallback 동작: x/y 누락된 entry 는 skip. 빈 access_points 는 no-op.
+    """
+    if not access_points:
+        return
+    for i, ap in enumerate(access_points):
+        x = ap.get("x_m") if ap.get("x_m") is not None else ap.get("x")
+        y = ap.get("y_m") if ap.get("y_m") is not None else ap.get("y")
+        if x is None or y is None:
+            continue
+        z = ap.get("z_m") if ap.get("z_m") is not None else ap.get("z")
+        ap_id = str(ap.get("id") or f"ap{i + 1}")
+        try:
+            point_geom = geojson_to_wkb(
+                {"type": "Point", "coordinates": [float(x), float(y)]},
+                "Point",
+                "ap_layout.point_geom",
+            )
+        except AppError:
+            # 좌표 파싱 실패는 silent skip — 시뮬 자체는 진행되도록.
+            continue
+        db.add(
+            ApLayout(
+                rf_run_id=rf_run.id,
+                ap_name=ap_id,
+                point_geom=point_geom,
+                z_m=float(z) if z is not None else 2.5,
+                power_dbm=float(ap["power_dbm"]) if ap.get("power_dbm") is not None else None,
+            )
+        )
 
 
 def _get_owned_scene_version(

--- a/backend/migrations/versions/20260527_0010_floors_space_type.py
+++ b/backend/migrations/versions/20260527_0010_floors_space_type.py
@@ -1,0 +1,38 @@
+"""floors.space_type 추가 — calibration prior 의 source of truth 를 Floor 단위로 통일.
+
+기존: space_type 이 CalibrationRunCreate.space_type 으로 request 마다 전달됨 → 사용자가
+   보정마다 같은 값 반복 선택해야 하고, 시뮬 페이지에선 모르는 정보였음.
+
+변경: Floor 에 space_type 컬럼 추가. 사용자가 floor 단위로 한 번 정하면 calibration 이
+   자동으로 그 값 사용. 미지정 시 'unknown' (기존 fallback 과 동일).
+
+Revision ID: 20260527_0010
+Revises: 20260517_0009
+Create Date: 2026-05-27 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260527_0010"
+down_revision: Union[str, Sequence[str], None] = "20260517_0009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "floors",
+        sa.Column(
+            "space_type",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'unknown'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("floors", "space_type")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,9 @@ email-validator==2.2.0
 easyocr==1.7.2
 # GP regression for measurement coverage estimation (#81)
 scikit-learn>=1.6
+# Heatmap PNG rendering — measurement_estimation/heatmap.py 가 사용 (예전엔 누락돼있어
+# 런타임에 ModuleNotFoundError 발생했음). use("Agg") 로 GUI backend 비활성화.
+matplotlib>=3.10
 # AWS SDK — S3 자산 저장 + SageMaker 추론 호출 (#65)
 boto3==1.43.11
 

--- a/frontend/src/api/measurement-session.ts
+++ b/frontend/src/api/measurement-session.ts
@@ -1,6 +1,7 @@
 import { api } from './client';
 import type { Paginated, UUID } from '@/types/common';
 import type {
+  CoverageEstimationMethod,
   DetectedAp,
   EstimatedCoverage,
   MeasurementPoint,
@@ -42,9 +43,13 @@ export const measurementSessionApi = {
       .get<DetectedAp[]>(`/measurement-sessions/${sessionId}/detected-aps`)
       .then((r) => r.data),
 
-  // GET /measurement-sessions/{session_id}/estimated-coverage — GP regression dense RSSI 맵 (#81).
-  // 응답에 presigned heatmap_url / uncertainty_url 포함. resolution_m 으로 해상도 조절(0.1~2.0).
-  getEstimatedCoverage: (sessionId: UUID, params?: { resolution_m?: number }) =>
+  // GET /measurement-sessions/{session_id}/estimated-coverage — dense RSSI 맵 추정 (#81).
+  // method: 'gp_only' = 측정값만 GP (실측 의미), 'residual_kriging' = sim prior + residual GP (통합 의미),
+  // 'auto' (생략 시) = sim 있으면 residual, 없으면 gp_only.
+  getEstimatedCoverage: (
+    sessionId: UUID,
+    params?: { resolution_m?: number; method?: CoverageEstimationMethod | 'auto' },
+  ) =>
     api
       .get<EstimatedCoverage>(
         `/measurement-sessions/${sessionId}/estimated-coverage`,

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -1,5 +1,19 @@
 import { Loader2, Sliders } from 'lucide-react';
-import type { CalibrationRun, ParameterUpdate } from '@/types/calibration-run';
+import type {
+  CalibrationRun,
+  ParameterUpdate,
+  SpaceType,
+} from '@/types/calibration-run';
+
+/** 공간 유형 select 표시명. SpaceType literal 과 1:1. */
+const SPACE_TYPE_OPTIONS: { value: SpaceType; label: string }[] = [
+  { value: 'unknown', label: '미지정' },
+  { value: 'cafe', label: '카페' },
+  { value: 'study_room', label: '스터디룸' },
+  { value: 'classroom', label: '강의실' },
+  { value: 'office', label: '오피스' },
+  { value: 'residential', label: '원룸/주거' },
+];
 
 interface Props {
   run: CalibrationRun | null;
@@ -8,6 +22,9 @@ interface Props {
   canCalibrate: boolean;
   /** 비활성 시 사용자에게 보여줄 사유 (측정 부족 / 시뮬 부족 등). */
   disabledReason?: string | null;
+  /** 사용자가 선택한 공간 유형 — calibration 의 soft prior 로 backend 에 전달. */
+  spaceType: SpaceType;
+  onSpaceTypeChange: (next: SpaceType) => void;
   onCalibrate: () => void;
   parameterUpdates: ParameterUpdate[];
 }
@@ -22,6 +39,8 @@ export function CalibrationCard({
   isStarting,
   canCalibrate,
   disabledReason,
+  spaceType,
+  onSpaceTypeChange,
   onCalibrate,
   parameterUpdates,
 }: Props) {
@@ -39,6 +58,26 @@ export function CalibrationCard({
         실측과 시뮬레이션 결과를 비교해서 벽 흡수율 등 시뮬 파라미터를 자동 보정합니다.
         보정 후 시뮬레이션을 다시 실행하면 더 정확한 예측을 얻을 수 있습니다.
       </p>
+
+      {/* 공간 유형 select — calibration BO 의 soft prior. 잘못 골라도 BO 가 어느 정도 보정. */}
+      <label className="mt-3 block">
+        <span className="text-[11px] font-medium text-muted-foreground">공간 유형</span>
+        <select
+          value={spaceType}
+          onChange={(e) => onSpaceTypeChange(e.target.value as SpaceType)}
+          disabled={showProgress}
+          className="mt-1 block w-full rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+        >
+          {SPACE_TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <span className="mt-1 block text-[10px] leading-relaxed text-muted-foreground">
+          공간 유형은 보정의 초기 가정만 좁혀줍니다. 실제 결과는 측정 RSSI 기반으로 결정됩니다.
+        </span>
+      </label>
 
       {showProgress ? (
         <div className="mt-3 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2.5 text-xs">
@@ -79,6 +118,9 @@ function CalibrationResult({
   parameterUpdates: ParameterUpdate[];
 }) {
   const metrics = parseCalibrationMetrics(run.error_metrics_json);
+  const feedbackMessage = typeof run.error_metrics_json?.['feedback_message'] === 'string'
+    ? (run.error_metrics_json['feedback_message'] as string)
+    : null;
   return (
     <div className="mt-3 space-y-2">
       <div className="rounded-lg border bg-muted/40 p-3">
@@ -88,6 +130,11 @@ function CalibrationResult({
           <MetricCell label="MAE" value={metrics.mae} unit="dBm" />
         </div>
       </div>
+      {feedbackMessage && (
+        <div className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-[11px] leading-relaxed text-foreground/80">
+          {feedbackMessage}
+        </div>
+      )}
       <div className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2 text-xs">
         <span className="text-muted-foreground">변경된 파라미터</span>
         <span className="font-semibold tabular-nums">{parameterUpdates.length} 개</span>

--- a/frontend/src/features/floor/FloorSpaceTypeSelector.tsx
+++ b/frontend/src/features/floor/FloorSpaceTypeSelector.tsx
@@ -1,0 +1,79 @@
+/**
+ * Floor.space_type 을 읽고 변경하는 dropdown 위젯 — source of truth 는 backend Floor.
+ *
+ * 시뮬 페이지 / 측정 페이지 등 여러 곳에서 같은 UX 로 노출. 어디서 바꿔도 Floor 가
+ * 즉시 업데이트 → 다음 calibration 이 자동으로 그 값을 prior 로 사용.
+ *
+ * 사용:
+ *   <FloorSpaceTypeSelector floorId={...} projectId={...} />
+ */
+import { useEffect, useState } from 'react';
+import { Building2 } from 'lucide-react';
+import { useFloors, useUpdateFloor } from '@/hooks/use-floors';
+import type { SpaceType } from '@/types/calibration-run';
+
+const SPACE_TYPE_OPTIONS: { value: SpaceType; label: string }[] = [
+  { value: 'unknown', label: '미지정' },
+  { value: 'cafe', label: '카페' },
+  { value: 'study_room', label: '스터디룸' },
+  { value: 'classroom', label: '강의실' },
+  { value: 'office', label: '오피스' },
+  { value: 'residential', label: '원룸/주거' },
+];
+
+interface Props {
+  floorId: string | null;
+  projectId: string | null;
+  /** 추가 클래스 (배치 보조). */
+  className?: string;
+  /** 라벨 표시 여부 — compact 모드면 false. */
+  showLabel?: boolean;
+}
+
+export function FloorSpaceTypeSelector({
+  floorId,
+  projectId,
+  className,
+  showLabel = true,
+}: Props) {
+  const floorsQuery = useFloors(projectId);
+  const updateFloor = useUpdateFloor(projectId);
+  const currentFloor = floorsQuery.data?.find((f) => f.id === floorId) ?? null;
+  // 로컬 state 로 즉시 반영 (optimistic) — onChange 시 서버에도 PATCH.
+  const [value, setValue] = useState<SpaceType>(currentFloor?.space_type ?? 'unknown');
+  useEffect(() => {
+    setValue(currentFloor?.space_type ?? 'unknown');
+  }, [currentFloor?.space_type]);
+
+  const disabled = !floorId || !projectId || updateFloor.isPending;
+
+  const handleChange = (next: SpaceType) => {
+    if (!floorId) return;
+    setValue(next);  // 즉시 UI 반영
+    updateFloor.mutate({ id: floorId, body: { space_type: next } });
+  };
+
+  return (
+    <div className={'inline-flex items-center gap-1.5 ' + (className ?? '')}>
+      {showLabel && (
+        <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+          <Building2 className="h-3.5 w-3.5" />
+          공간 유형
+        </span>
+      )}
+      <select
+        value={value}
+        onChange={(e) => handleChange(e.target.value as SpaceType)}
+        disabled={disabled}
+        title="이 도면(층) 의 공간 유형 — calibration 보정의 초기 가정에 사용. 변경시 즉시 저장."
+        className="rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+      >
+        {SPACE_TYPE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/features/header/FloorSelector.tsx
+++ b/frontend/src/features/header/FloorSelector.tsx
@@ -10,6 +10,21 @@ import {
 import { useAppStore } from '@/stores/app-store';
 import { cn } from '@/lib/utils';
 import type { Floor } from '@/types/floor';
+import type { SpaceType } from '@/types/calibration-run';
+
+// 공간 유형 옵션 — CalibrationCard 와 동일 라벨 (UI 일관성).
+const SPACE_TYPE_OPTIONS: { value: SpaceType; label: string }[] = [
+  { value: 'unknown', label: '미지정' },
+  { value: 'cafe', label: '카페' },
+  { value: 'study_room', label: '스터디룸' },
+  { value: 'classroom', label: '강의실' },
+  { value: 'office', label: '오피스' },
+  { value: 'residential', label: '원룸/주거' },
+];
+
+function spaceTypeLabel(value: string | null | undefined): string {
+  return SPACE_TYPE_OPTIONS.find((o) => o.value === value)?.label ?? '미지정';
+}
 
 export function FloorSelector() {
   const projectId = useAppStore((s) => s.selectedProjectId);
@@ -154,7 +169,7 @@ function FloorMenu({
                 <div className="flex flex-col items-start">
                   <span className="truncate">{f.floor_name}</span>
                   <span className="text-[10px] text-muted-foreground">
-                    높이 {f.height_m}m
+                    높이 {f.height_m}m · {spaceTypeLabel(f.space_type)}
                   </span>
                 </div>
                 {f.id === selectedFloorId && <Check className="h-3.5 w-3.5 text-primary" />}
@@ -228,19 +243,23 @@ function EditFloorForm({
 }: {
   floor: Floor;
   isSaving: boolean;
-  onSave: (body: { floor_name?: string; height_m?: number }) => void;
+  onSave: (body: { floor_name?: string; height_m?: number; space_type?: SpaceType }) => void;
   onCancel: () => void;
 }) {
   const [name, setName] = useState(floor.floor_name);
   const [height, setHeight] = useState(floor.height_m);
+  const [spaceType, setSpaceType] = useState<SpaceType>(floor.space_type ?? 'unknown');
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = name.trim();
     if (!trimmed) return;
-    const body: { floor_name?: string; height_m?: number } = {};
+    const body: { floor_name?: string; height_m?: number; space_type?: SpaceType } = {};
     if (trimmed !== floor.floor_name) body.floor_name = trimmed;
     if (Number.isFinite(height) && height > 0 && height !== floor.height_m) {
       body.height_m = height;
+    }
+    if (spaceType !== (floor.space_type ?? 'unknown')) {
+      body.space_type = spaceType;
     }
     if (Object.keys(body).length === 0) {
       onCancel();
@@ -271,6 +290,18 @@ function EditFloorForm({
           onChange={(e) => setHeight(Number(e.target.value))}
           className="w-full rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
         />
+      </label>
+      <label className="block">
+        <span className="text-[10px] text-muted-foreground">공간 유형</span>
+        <select
+          value={spaceType}
+          onChange={(e) => setSpaceType(e.target.value as SpaceType)}
+          className="w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {SPACE_TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
       </label>
       <div className="flex gap-2">
         <button
@@ -305,6 +336,7 @@ function CreateFloorForm({
 }) {
   const [name, setName] = useState(`${nextOrder}층`);
   const [height, setHeight] = useState(3.2);
+  const [spaceType, setSpaceType] = useState<SpaceType>('unknown');
   const create = useCreateFloor(projectId);
 
   const submit = (e: React.FormEvent) => {
@@ -313,7 +345,12 @@ function CreateFloorForm({
     if (!trimmed) return;
     // floor_order 는 사용자에게 노출하지 않고 자동 부여 (마지막 + 1).
     create.mutate(
-      { floor_name: trimmed, floor_order: nextOrder, height_m: height },
+      {
+        floor_name: trimmed,
+        floor_order: nextOrder,
+        height_m: height,
+        space_type: spaceType,
+      },
       { onSuccess: (f) => onCreated(f) },
     );
   };
@@ -339,6 +376,18 @@ function CreateFloorForm({
           onChange={(e) => setHeight(Number(e.target.value))}
           className="w-full rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
         />
+      </label>
+      <label className="block">
+        <span className="text-[10px] text-muted-foreground">공간 유형 (calibration 보정에 사용)</span>
+        <select
+          value={spaceType}
+          onChange={(e) => setSpaceType(e.target.value as SpaceType)}
+          className="w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {SPACE_TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
       </label>
       <div className="flex gap-2">
         <button

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -33,11 +33,16 @@ export interface PlacedApSimple {
 
 export type MeasurementViewMode = 'route' | 'heatmap' | 'both';
 
+/** 측정점 색 모드 — heatmap 배경과 시각 통일하려면 'dbm', 신호 품질 한눈에 보려면 'quality'. */
+export type PointColorMode = 'quality' | 'dbm';
+
 interface Props {
   sceneVersion: SceneVersion | null | undefined;
   /** 원본 도면 이미지 (배경에 연하게 깔림). 공간편집/시뮬과 동일한 방식. */
   backgroundImageUrl?: string | null;
   points: MeasurementPoint[];
+  /** 실제 측정 RSSI (dBm) — dbm color mode 에서 색 계산에 사용. points 와 같은 순서/id 매핑. */
+  pointRssiByOrder?: Map<string, number>;
   aps: PlacedApSimple[];
   mode: MeasurementViewMode;
   /** 강조 표시할 측정 포인트 (불량 지점). 외곽 링이 진하게 표시됨. */
@@ -50,6 +55,10 @@ interface Props {
     url: string;
     bounds: { min_x: number; min_y: number; max_x: number; max_y: number };
   } | null;
+  /** dbm color mode 일 때 색 범위 (heatmap rssi_range 와 일치시켜야 통일). 미지정 시 -90~-30. */
+  pointColorRange?: { min: number; max: number };
+  /** 측정점 색 모드. 미지정 시 route='quality', heatmap/both='dbm' 자동. */
+  pointColorMode?: PointColorMode;
 }
 
 interface Bounds {
@@ -108,6 +117,38 @@ const QUALITY_HEATMAP_RGBA: Record<MeasurementPointQuality, string> = {
   poor: 'rgba(248, 113, 113, 0.6)',
 };
 
+// matplotlib inferno cmap stops — Sionna heatmap 과 동일 visual language.
+// HeatmapColorLegend.tsx 와 동기화 유지.
+const INFERNO_STOPS = [
+  [0, 0, 4],
+  [22, 11, 57],
+  [66, 10, 104],
+  [106, 23, 110],
+  [147, 38, 103],
+  [188, 55, 84],
+  [221, 81, 58],
+  [243, 120, 25],
+  [252, 165, 10],
+  [246, 215, 70],
+  [252, 255, 164],
+] as const;
+
+/** dBm 값 → inferno cmap RGB. min/max 범위로 정규화 후 stops 사이 선형 보간. */
+function dbmToInfernoColor(dbm: number, min: number, max: number): string {
+  if (!Number.isFinite(dbm) || max <= min) return 'rgb(255, 255, 255)';
+  const t = Math.max(0, Math.min(1, (dbm - min) / (max - min)));
+  const scaled = t * (INFERNO_STOPS.length - 1);
+  const lo = Math.floor(scaled);
+  const hi = Math.min(INFERNO_STOPS.length - 1, lo + 1);
+  const frac = scaled - lo;
+  const c0 = INFERNO_STOPS[lo];
+  const c1 = INFERNO_STOPS[hi];
+  const r = Math.round(c0[0] + frac * (c1[0] - c0[0]));
+  const g = Math.round(c0[1] + frac * (c1[1] - c0[1]));
+  const b = Math.round(c0[2] + frac * (c1[2] - c0[2]));
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
 /**
  * 실측/진단 캔버스. 확정 버전 도형 위에 측정 경로(line + 색상 dot) 와/또는
  * 실측 히트맵(radial gradient) 을 모드에 따라 토글 렌더링.
@@ -117,10 +158,13 @@ export function MeasurementCanvas({
   sceneVersion,
   backgroundImageUrl,
   points,
+  pointRssiByOrder,
   aps,
   mode,
   highlightedPointId,
   estimatedHeatmap,
+  pointColorRange,
+  pointColorMode,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const sceneId = sceneVersion?.id ?? null;
@@ -153,8 +197,15 @@ export function MeasurementCanvas({
   // 히트맵 점 반경 — viewBox 크기에 비례. 보통 ~1.5m 정도 영향권으로 보이도록.
   const heatmapRadius = Math.max(0.8, Math.min(vb.w, vb.h) * 0.15);
 
-  const showRoute = mode === 'route' || mode === 'both';
+  const showLine = mode === 'route' || mode === 'both';
   const showHeatmap = mode === 'heatmap' || mode === 'both';
+  // dots 는 모든 모드에서 표시 — 측정 데이터의 본체. heatmap 탭에서도 점 보여야 어디서 측정했는지 알 수 있음.
+  const showDots = sortedPoints.length > 0;
+  // 색 모드: 사용자 지정 > heatmap/both 면 dbm, 그 외 quality (route 또는 dots 만).
+  const effectiveColorMode: PointColorMode =
+    pointColorMode ?? (showHeatmap ? 'dbm' : 'quality');
+  const dbmMin = pointColorRange?.min ?? -90;
+  const dbmMax = pointColorRange?.max ?? -30;
 
   return (
     <div
@@ -256,8 +307,8 @@ export function MeasurementCanvas({
           <ObjectShape key={o.id} object={o} />
         ))}
 
-        {/* 측정 경로 라인 — 점들 순서대로 점선 연결. */}
-        {showRoute && sortedPoints.length >= 2 && (
+        {/* 측정 경로 라인 — route/both 모드에서만 (heatmap 모드는 점만 표시). */}
+        {showLine && sortedPoints.length >= 2 && (
           <polyline
             points={sortedPoints.map((p) => `${p.x_m},${p.y_m}`).join(' ')}
             fill="none"
@@ -269,21 +320,31 @@ export function MeasurementCanvas({
           />
         )}
 
-        {/* 측정 포인트 점. */}
-        {showRoute &&
-          sortedPoints.map((p) => (
-            <g key={`pt-${p.id}`} pointerEvents="none">
-              <circle
-                cx={p.x_m}
-                cy={p.y_m}
-                r={Math.max(0.08, vb.w * 0.008)}
-                fill={QUALITY_FILL[p.quality]}
-                stroke={highlightedPointId === p.id ? 'oklch(0.45 0.22 25)' : 'white'}
-                strokeWidth={highlightedPointId === p.id ? 0.06 : 0.04}
-                vectorEffect="non-scaling-stroke"
-              />
-            </g>
-          ))}
+        {/* 측정 포인트 점 — 모든 모드에서 표시. heatmap 모드에선 dbm 그라데이션 색 */}
+        {showDots &&
+          sortedPoints.map((p) => {
+            const fill =
+              effectiveColorMode === 'dbm'
+                ? dbmToInfernoColor(
+                    pointRssiByOrder?.get(p.id) ?? Number.NaN,
+                    dbmMin,
+                    dbmMax,
+                  )
+                : QUALITY_FILL[p.quality];
+            return (
+              <g key={`pt-${p.id}`} pointerEvents="none">
+                <circle
+                  cx={p.x_m}
+                  cy={p.y_m}
+                  r={Math.max(0.08, vb.w * 0.008)}
+                  fill={fill}
+                  stroke={highlightedPointId === p.id ? 'oklch(0.45 0.22 25)' : 'white'}
+                  strokeWidth={highlightedPointId === p.id ? 0.06 : 0.04}
+                  vectorEffect="non-scaling-stroke"
+                />
+              </g>
+            );
+          })}
 
         {/* AP 마커 — 파란 원에 흰색 wifi 아이콘. */}
         {aps.map((ap) => (

--- a/frontend/src/features/simulation/DbmColorBar.tsx
+++ b/frontend/src/features/simulation/DbmColorBar.tsx
@@ -1,0 +1,86 @@
+/**
+ * RSSI dBm → 색 그라데이션 + tick 라벨 colorbar.
+ *
+ * matplotlib horizontal colorbar 스타일 — gradient 아래에 tick 들이 정렬돼서
+ * "이 색 = 이 dBm" 한눈에 매핑. 시뮬/측정 페이지 모두에서 같은 visual language.
+ *
+ * inferno cmap 11 stops — Sionna heatmap PNG, MeasurementCanvas 측정점 색, 본 컴포넌트
+ * 모두 동일 stop 사용 (HeatmapColorLegend, MeasurementCanvas 와 동기화).
+ */
+
+const INFERNO_GRADIENT =
+  'linear-gradient(to right, ' +
+  '#000004 0%, #160b39 10%, #420a68 20%, #6a176e 30%, ' +
+  '#932667 40%, #bc3754 50%, #dd513a 60%, #f37819 70%, ' +
+  '#fca50a 80%, #f6d746 90%, #fcffa4 100%)';
+
+interface Props {
+  vmin: number;
+  vmax: number;
+  /** 표시할 tick 개수 (기본 5). 양 끝 포함. */
+  tickCount?: number;
+  /** 라벨 — 컬러바 위쪽에 작게 표시 (예: "실측 RSSI", "예측 RSSI"). 미지정시 없음. */
+  label?: string;
+  /** 데이터가 sim 기반 정확 스케일이 아닌 경우 (예: API 응답 없을때 fallback). 표시되면 "approx." 뱃지. */
+  approximate?: boolean;
+  className?: string;
+}
+
+export function DbmColorBar({
+  vmin,
+  vmax,
+  tickCount = 5,
+  label,
+  approximate = false,
+  className,
+}: Props) {
+  // tick 위치 0~100% 균등 분포 + 값 보간.
+  const ticks = Array.from({ length: tickCount }, (_, i) => {
+    const t = tickCount === 1 ? 0 : i / (tickCount - 1);
+    return {
+      pct: t * 100,
+      value: vmin + t * (vmax - vmin),
+    };
+  });
+
+  return (
+    <div
+      className={
+        'pointer-events-none flex flex-col gap-1 rounded-md border bg-card/95 px-3 py-2 shadow-sm backdrop-blur ' +
+        (className ?? '')
+      }
+      role="img"
+      aria-label={`RSSI 색 범례: ${vmin.toFixed(0)} ~ ${vmax.toFixed(0)} dBm`}
+    >
+      {(label || approximate) && (
+        <div className="flex items-center justify-between text-[10px] font-medium text-muted-foreground">
+          <span>{label ?? ''}</span>
+          {approximate && (
+            <span className="text-[9px] text-muted-foreground/70">approx.</span>
+          )}
+        </div>
+      )}
+      {/* gradient bar */}
+      <div
+        className="h-3 w-full rounded-sm border border-border/60"
+        style={{ backgroundImage: INFERNO_GRADIENT }}
+      />
+      {/* tick marks — gradient 바로 아래 short vertical line + 값 */}
+      <div className="relative h-4 w-full">
+        {ticks.map((t, i) => (
+          <div
+            key={i}
+            className="absolute top-0 -translate-x-1/2 text-center"
+            style={{ left: `${t.pct}%` }}
+          >
+            <div className="mx-auto h-1 w-px bg-border" />
+            <div className="mt-0.5 font-mono text-[10px] tabular-nums text-foreground/70">
+              {t.value.toFixed(0)}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="text-right text-[9px] text-muted-foreground">dBm</div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-measurement-session.ts
+++ b/frontend/src/hooks/use-measurement-session.ts
@@ -22,7 +22,12 @@ export function useMeasurementSession(sessionId: UUID | null) {
   });
 }
 
-/** 세션의 측정 포인트 — 페이지 1개로 한 번에 가져옴 (시각화는 보통 전체 포인트 필요). */
+/** 세션의 측정 포인트 — 페이지 1개로 한 번에 가져옴 (시각화는 보통 전체 포인트 필요).
+ *
+ * 모바일이 실시간으로 포인트를 올리는 동안 웹이 자동 반영되도록 5초 polling.
+ * 탭 백그라운드일 땐 안 돎 (`refetchIntervalInBackground: false`) — 불필요한 트래픽 차단.
+ * 세션 완료 후엔 새 포인트가 안 들어오지만 단순함 위해 polling 유지 (트래픽 미미).
+ */
 export function useMeasurementPoints(sessionId: UUID | null, pageSize = 500) {
   return useQuery({
     queryKey: ['measurement-points', sessionId, pageSize] as const,
@@ -30,6 +35,8 @@ export function useMeasurementPoints(sessionId: UUID | null, pageSize = 500) {
       measurementSessionApi.listPoints(sessionId as UUID, { page: 1, page_size: pageSize }),
     enabled: !!sessionId,
     retry: false,
+    refetchInterval: sessionId ? 5_000 : false,
+    refetchIntervalInBackground: false,
   });
 }
 
@@ -48,12 +55,25 @@ export function useDetectedAps(sessionId: UUID | null) {
  * 측정점이 충분치 않거나 백엔드가 추정 실패하면 404/422 → 빈 상태로 fallback.
  * resolution_m: 0.1~2.0. 기본 0.5 (백엔드 기본값과 동일).
  */
-export function useEstimatedCoverage(sessionId: UUID | null, resolutionM = 0.5) {
+/** method:
+ *  - 'gp_only': "실측 히트맵" 의미 — 측정값만 GP 보간
+ *  - 'residual_kriging': "통합 분석" 의미 — sim prior + residual GP
+ *  - 'auto' (생략): backend 가 알아서 (sim 있으면 residual, 없으면 gp_only)
+ *
+ *  같은 sessionId 라도 method 가 다르면 queryKey 분리 → 병렬 fetch + 독립 cache.
+ */
+export function useEstimatedCoverage(
+  sessionId: UUID | null,
+  options?: { resolutionM?: number; method?: 'gp_only' | 'residual_kriging' | 'auto' },
+) {
+  const resolutionM = options?.resolutionM ?? 0.5;
+  const method = options?.method ?? 'auto';
   return useQuery({
-    queryKey: ['estimated-coverage', sessionId, resolutionM] as const,
+    queryKey: ['estimated-coverage', sessionId, resolutionM, method] as const,
     queryFn: () =>
       measurementSessionApi.getEstimatedCoverage(sessionId as UUID, {
         resolution_m: resolutionM,
+        method,
       }),
     enabled: !!sessionId,
     retry: false,

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -15,6 +15,9 @@ import { HelpFab } from '@/components/HelpFab';
 import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
 import { Popover } from '@/components/ui/Popover';
 import { useAppStore } from '@/stores/app-store';
+import { useFloors } from '@/hooks/use-floors';
+import { FloorSpaceTypeSelector } from '@/features/floor/FloorSpaceTypeSelector';
+import { DbmColorBar } from '@/features/simulation/DbmColorBar';
 import type {
   DetectedAp,
   MeasurementPoint as ApiPoint,
@@ -40,6 +43,7 @@ import {
   useCreateCalibrationRun,
 } from '@/hooks/use-calibration-run';
 import { CalibrationCard } from '@/features/calibration/CalibrationCard';
+import type { SpaceType } from '@/types/calibration-run';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import {
   MeasurementCanvas,
@@ -75,6 +79,20 @@ export default function MeasurementPage() {
     assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
   const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
 
+  // calibration soft prior 용 공간 유형.
+  // - Source of truth: Floor.space_type (헤더의 도면 셀렉터에서 설정)
+  // - 이 페이지에서도 일회성 override 가능 — 사용자가 다른 prior 로 실험하고 싶을 때
+  // - floor 가 바뀌면 그 floor 의 값으로 자동 리셋.
+  const [spaceTypeOverride, setSpaceTypeOverride] = useState<SpaceType | null>(null);
+  useEffect(() => {
+    setSpaceTypeOverride(null);  // floor 전환 시 override 해제
+  }, [floorId]);
+  // Floor 의 space_type 을 reactive 하게 읽음 — 헤더에서 변경하면 즉시 반영.
+  const projectIdForFloors = useAppStore((s) => s.selectedProjectId);
+  const floorsList = useFloors(projectIdForFloors);
+  const currentFloor = floorsList.data?.find((f) => f.id === floorId) ?? null;
+  const spaceType: SpaceType = spaceTypeOverride ?? currentFloor?.space_type ?? 'unknown';
+
   // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
   const sessionsQuery = useFloorMeasurementSessions(floorId);
   const sessions = sessionsQuery.data?.items ?? [];
@@ -85,15 +103,28 @@ export default function MeasurementPage() {
   const points = pointsQuery.data?.items ?? [];
 
   const canvasPoints = useMemo(() => apiPointsToCanvas(points), [points]);
+  // 캔버스 dbm color mode 에서 점 색 계산용 — id → 실측 RSSI 매핑.
+  const pointRssiByOrder = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const p of points) {
+      if (p.rssi_dbm != null) map.set(p.id, p.rssi_dbm);
+    }
+    return map;
+  }, [points]);
 
   // 가장 최근 succeeded RF Run → AP layouts + RF Map metrics.
   const rfRunsQuery = useFloorRfRuns(floorId, { status: 'succeeded', page_size: 5 });
-  const latestRfRunId = rfRunsQuery.data?.items?.[0]?.id ?? null;
+  const latestRfRun = rfRunsQuery.data?.items?.[0] ?? null;
+  const latestRfRunId = latestRfRun?.id ?? null;
   const apLayoutsQuery = useApLayouts(latestRfRunId);
-  const canvasAps = useMemo(
-    () => apLayoutsToCanvas(apLayoutsQuery.data ?? []),
-    [apLayoutsQuery.data],
-  );
+  // AP 마커 우선순위: ap_layouts 테이블 > rf_run.request_json.access_points fallback.
+  // 시뮬 페이지에서 찍은 AP 는 request_json 에만 들어가고 ap_layouts 엔 자동 동기화 안 돼서,
+  // 그것만 보면 측정 캔버스에 AP 가 안 뜸 → 이 fallback 으로 메우기.
+  const canvasAps = useMemo(() => {
+    const fromLayouts = apLayoutsToCanvas(apLayoutsQuery.data ?? []);
+    if (fromLayouts.length > 0) return fromLayouts;
+    return apsFromRfRunRequest(latestRfRun?.request_json);
+  }, [apLayoutsQuery.data, latestRfRun]);
   const rfMapsQuery = useRfMaps(latestRfRunId, !!latestRfRunId);
   const predictedAvgDbm = useMemo(
     () => extractPredictedAvgDbm(rfMapsQuery.data ?? []),
@@ -105,15 +136,36 @@ export default function MeasurementPage() {
   const detectedApsQuery = useDetectedAps(activeSession?.id ?? null);
   const detectedAps = detectedApsQuery.data ?? [];
 
-  // #81 GP regression dense RSSI heatmap — 측정점 → 도면 전체 추정.
-  const coverageQuery = useEstimatedCoverage(activeSession?.id ?? null);
-  const estimatedHeatmap = useMemo(() => {
-    const c = coverageQuery.data;
-    if (!c) return null;
-    return { url: c.heatmap_url, bounds: c.bounds };
-  }, [coverageQuery.data]);
+  // #81 RSSI 맵 추정 — 탭별로 다른 method 호출 (의미 분리):
+  //   '실측 히트맵' (heatmap mode) → gp_only: 측정값만 GP 보간. sim 안 섞임.
+  //   '예측·실측 통합' (both mode)  → residual_kriging: sim prior + residual GP.
+  // 같은 sessionId 라도 method 다르면 cache 분리 → 탭 전환시 재요청 없이 즉시 표시.
+  const coverageGpOnlyQuery = useEstimatedCoverage(activeSession?.id ?? null, { method: 'gp_only' });
+  const coverageResidualQuery = useEstimatedCoverage(activeSession?.id ?? null, { method: 'residual_kriging' });
 
   const [mode, setMode] = useState<MeasurementViewMode>('route');
+
+  const activeCoverage = useMemo(() => {
+    // mode 에 맞는 데이터 우선, 없으면 다른 method 데이터로 일시 fallback —
+    // 탭 전환 시 한쪽 query 가 아직 loading 이어도 heatmap 깜빡임 없이 유지.
+    if (mode === 'both') {
+      return coverageResidualQuery.data ?? coverageGpOnlyQuery.data;
+    }
+    return coverageGpOnlyQuery.data ?? coverageResidualQuery.data;
+  }, [mode, coverageGpOnlyQuery.data, coverageResidualQuery.data]);
+  const estimatedHeatmap = useMemo(() => {
+    // route 모드는 heatmap 안 그림 → null. heatmap/both 는 mode 에 맞는 데이터 사용.
+    if (!activeCoverage) return null;
+    return { url: activeCoverage.heatmap_url, bounds: activeCoverage.bounds };
+  }, [activeCoverage]);
+  // 점 색 dbm 모드일 때 사용할 범위 — heatmap 의 rssi_range 와 동일하게 맞춰서 시각 통일.
+  const pointColorRange = useMemo(
+    () =>
+      activeCoverage
+        ? { min: activeCoverage.rssi_range.min, max: activeCoverage.rssi_range.max }
+        : undefined,
+    [activeCoverage],
+  );
   const [mobileOpen, setMobileOpen] = useState(false);
   const [actionGuideOpen, setActionGuideOpen] = useState(false);
 
@@ -129,13 +181,20 @@ export default function MeasurementPage() {
     activeCalibrationId,
     calibrationPoll.isSucceeded,
   );
+  // BO 가 9차원 fit 하므로 최소 8점 (backend 가드와 일치). 그 미만이면 overfit → 다음
+  // 시뮬이 극단적으로 왜곡됨 (벽 무한히 두꺼워짐 등). 사용자가 실수로 누르지 않도록 막음.
+  const MIN_MEASUREMENTS_FOR_CALIBRATION = 8;
+  const hasEnoughMeasurements = points.length >= MIN_MEASUREMENTS_FOR_CALIBRATION;
   const canCalibrate =
     !!activeSession?.id &&
     !!latestRfRunId &&
     !!currentVersion?.id &&
-    hasMeasurement;
+    hasEnoughMeasurements;
   const calibrationDisabledReason = !hasMeasurement
     ? '먼저 측정을 진행해주세요.'
+    : !hasEnoughMeasurements
+    ? `보정 신뢰성 확보를 위해 측정점이 ${MIN_MEASUREMENTS_FOR_CALIBRATION}개 이상 필요합니다 ` +
+      `(현재 ${points.length}개). 도면 전반 골고루 더 측정해주세요.`
     : !latestRfRunId
     ? '비교할 시뮬레이션 결과가 없습니다. 시뮬레이션 페이지에서 실행해주세요.'
     : null;
@@ -146,6 +205,8 @@ export default function MeasurementPage() {
         session_id: activeSession.id,
         rf_run_id: latestRfRunId,
         version_id: currentVersion.id,
+        // 사용자가 선택한 공간 유형 — backend 가 soft prior 로 사용. 'unknown' 도 전송 OK.
+        space_type: spaceType,
       },
       { onSuccess: (run) => setActiveCalibrationId(run.id) },
     );
@@ -156,6 +217,8 @@ export default function MeasurementPage() {
       <PageHeader
         sessions={sessions}
         activeSession={activeSession}
+        floorId={floorId ?? null}
+        projectId={projectIdForFloors}
         onSelectSession={(id) => setSelectedSessionId(id)}
         onStartMeasurement={() => setMobileOpen(true)}
       />
@@ -175,17 +238,38 @@ export default function MeasurementPage() {
           <section className="flex min-h-0 flex-col gap-3">
             <TabBar mode={mode} onChange={setMode} />
             <div className="relative flex min-h-0 flex-1 flex-col gap-2 rounded-xl border bg-card p-4 shadow-sm">
-              <Legend />
+              {/* route 모드 (양호/주의/불량) 만 카드 상단 inline 표시. dbm 모드는 캔버스 하단에 colorbar. */}
+              <div className="flex flex-wrap items-center gap-2">
+                {mode === 'route' && <Legend colorMode="quality" range={pointColorRange} />}
+                {mode !== 'route' && activeCoverage?.method && (
+                  <MethodBadge
+                    method={activeCoverage.method}
+                    expected={mode === 'both' ? 'residual_kriging' : 'gp_only'}
+                  />
+                )}
+              </div>
               <div className="relative min-h-112 flex-1">
                 <MeasurementCanvas
                   sceneVersion={sceneVersion}
                   backgroundImageUrl={backgroundImageUrl}
                   points={canvasPoints}
+                  pointRssiByOrder={pointRssiByOrder}
+                  pointColorRange={pointColorRange}
                   aps={canvasAps}
                   mode={mode}
                   estimatedHeatmap={estimatedHeatmap}
                 />
                 {!hasMeasurement && <CanvasEmptyOverlay loading={pointsQuery.isFetching} />}
+                {/* dbm 모드 colorbar — 도면 좌상단. gradient + tick 값 수직 정렬로 "이 색=이 dBm" 직관. */}
+                {mode !== 'route' && pointColorRange && (
+                  <div className="pointer-events-none absolute left-3 top-3 z-10 w-70">
+                    <DbmColorBar
+                      vmin={pointColorRange.min}
+                      vmax={pointColorRange.max}
+                      label="실측 RSSI"
+                    />
+                  </div>
+                )}
               </div>
             </div>
           </section>
@@ -202,6 +286,8 @@ export default function MeasurementPage() {
               isStarting={createCalibration.isPending}
               canCalibrate={canCalibrate}
               disabledReason={calibrationDisabledReason}
+              spaceType={spaceType}
+              onSpaceTypeChange={setSpaceTypeOverride}
               onCalibrate={handleCalibrate}
               parameterUpdates={paramUpdatesQuery.data ?? []}
             />
@@ -255,6 +341,27 @@ function apLayoutsToCanvas(layouts: ApLayout[]): PlacedApSimple[] {
   return result;
 }
 
+/** rf_run.request_json.access_points → 캔버스 AP 마커.
+ *  시뮬 페이지가 찍은 AP 는 ap_layouts 에 자동 동기화 안 되고 이쪽에만 있음 → fallback.
+ *  request_json 은 unknown 이라 방어적으로 파싱.
+ */
+function apsFromRfRunRequest(requestJson: Record<string, unknown> | undefined): PlacedApSimple[] {
+  if (!requestJson) return [];
+  const raw = (requestJson as { access_points?: unknown }).access_points;
+  if (!Array.isArray(raw)) return [];
+  const out: PlacedApSimple[] = [];
+  raw.forEach((entry, i) => {
+    if (!entry || typeof entry !== 'object') return;
+    const r = entry as Record<string, unknown>;
+    const x = Number(r['x_m'] ?? r['x']);
+    const y = Number(r['y_m'] ?? r['y']);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    const id = typeof r['id'] === 'string' ? r['id'] : `ap${i + 1}`;
+    out.push({ id, x_m: x, y_m: y, label: id.toUpperCase() });
+  });
+  return out;
+}
+
 /** RfMap.metrics_json.rss_dbm.mean 추출 (없으면 옛 avg_rssi_dbm fallback). */
 function extractPredictedAvgDbm(maps: RfMap[]): number | null {
   for (const m of maps) {
@@ -289,11 +396,15 @@ function computeMeasuredAvg(points: ApiPoint[]): number | null {
 function PageHeader({
   sessions,
   activeSession,
+  floorId,
+  projectId,
   onSelectSession,
   onStartMeasurement,
 }: {
   sessions: MeasurementSession[];
   activeSession: MeasurementSession | null;
+  floorId: string | null;
+  projectId: string | null;
   onSelectSession: (id: string) => void;
   onStartMeasurement: () => void;
 }) {
@@ -307,6 +418,7 @@ function PageHeader({
         </p>
       </div>
       <div className="flex items-center gap-2">
+        <FloorSpaceTypeSelector floorId={floorId} projectId={projectId} showLabel={false} />
         <Popover
           align="end"
           contentClassName="w-72 max-h-80 overflow-y-auto"
@@ -453,7 +565,34 @@ function TabBar({
   );
 }
 
-function Legend() {
+/** dbm 모드일 땐 inferno 그라데이션 + 양 끝/중간 dBm 표시. quality 모드면 기존 3-tier. */
+function Legend({
+  colorMode,
+  range,
+}: {
+  colorMode: 'quality' | 'dbm';
+  range?: { min: number; max: number };
+}) {
+  if (colorMode === 'dbm') {
+    const min = range?.min ?? -90;
+    const max = range?.max ?? -30;
+    const mid = (min + max) / 2;
+    return (
+      <div className="inline-flex w-fit items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-[11px] text-muted-foreground shadow-sm">
+        <span className="font-semibold text-foreground">실측 RSSI</span>
+        <div
+          className="h-2 w-32 rounded-sm border border-border/60"
+          style={{
+            backgroundImage:
+              'linear-gradient(to right, rgb(0,0,4), rgb(66,10,104), rgb(147,38,103), rgb(221,81,58), rgb(252,165,10), rgb(252,255,164))',
+          }}
+        />
+        <span className="font-mono tabular-nums text-[10px] text-foreground/70">
+          {min.toFixed(0)} · {mid.toFixed(0)} · {max.toFixed(0)} dBm
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="inline-flex w-fit items-center gap-3 rounded-md border bg-background px-3 py-1.5 text-[11px] text-muted-foreground shadow-sm">
       <span className="font-semibold text-foreground">실측 포인트 범례</span>
@@ -461,6 +600,38 @@ function Legend() {
       <LegendDot color="oklch(0.78 0.15 85)" label="주의" />
       <LegendDot color="oklch(0.62 0.22 25)" label="불량" />
     </div>
+  );
+}
+
+/** "어떤 추정 방법으로 그려진 heatmap 인지" 사용자에게 명시.
+ *  expected ≠ actual 이면 amber 색 + "기대값으로 fallback" 안내 (예: sim 없어서 gp_only 로 떨어진 경우).
+ */
+function MethodBadge({
+  method,
+  expected,
+}: {
+  method: string;
+  expected: 'gp_only' | 'residual_kriging';
+}) {
+  const matched = method === expected;
+  const label = method === 'residual_kriging' ? '🔄 시뮬 보정 적용' : '📍 측정값만';
+  const tone = matched
+    ? 'border-primary/30 bg-primary/5 text-primary'
+    : 'border-amber-300 bg-amber-50 text-amber-900';
+  const hint = matched
+    ? ''
+    : ' (시뮬 grid 없음 → 측정값만 사용. 시뮬을 한 번 다시 돌리면 더 정확)';
+  return (
+    <span
+      className={
+        'inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-medium ' +
+        tone
+      }
+      title={hint || undefined}
+    >
+      {label}
+      {!matched && <span className="font-normal opacity-80">{hint}</span>}
+    </span>
   );
 }
 

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -35,10 +35,9 @@ import {
   SimulationCanvas,
   type PlacedAp,
 } from '@/features/simulation/SimulationCanvas';
-import {
-  HeatmapColorLegend,
-  extractColorScale,
-} from '@/features/simulation/HeatmapColorLegend';
+import { extractColorScale } from '@/features/simulation/HeatmapColorLegend';
+import { DbmColorBar } from '@/features/simulation/DbmColorBar';
+import { FloorSpaceTypeSelector } from '@/features/floor/FloorSpaceTypeSelector';
 import { toast } from '@/stores/toast-store';
 import type { ApCandidate, ApLayout } from '@/types/ap-layout';
 import type { RfBackend } from '@/types/rf';
@@ -48,6 +47,7 @@ type SimulationState = 'idle' | 'running' | 'complete';
 
 export default function SimulationPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
+  const selectedProjectId = useAppStore((s) => s.selectedProjectId);
   const versionsQuery = useFloorVersions(floorId);
   // 현재 활성 버전 (없으면 가장 최근 버전)
   const currentVersion =
@@ -226,10 +226,16 @@ export default function SimulationPage() {
       pastRuns
         .filter((r) => r.status === 'succeeded')
         .map((r) => {
-          const m =
-            r.id === activeRunId
-              ? parseMetrics(r.metrics_json, activeMapMetrics)
-              : parseMetrics(r.metrics_json);
+          // rf_run.metrics_json 은 `{ radio_map: { rss_dbm, coverage_summary, ... }, ... }` 형태로
+          // 한 단계 nested. parseMetrics 는 top-level 키만 찾으므로 radio_map 도 같이 풀어 넘김.
+          // active 일 땐 RfMap.metrics_json (flat) 도 함께 — 그쪽이 더 풍부할 수 있음.
+          const radioMap = (r.metrics_json?.['radio_map'] ?? null) as
+            | Record<string, unknown>
+            | null;
+          const sources: Array<Record<string, unknown> | undefined> = [r.metrics_json];
+          if (radioMap) sources.push(radioMap);
+          if (r.id === activeRunId && activeMapMetrics) sources.push(activeMapMetrics);
+          const m = parseMetrics(...sources);
           return {
             id: r.id,
             label: `시뮬레이션 결과 #${r.id.slice(0, 6)}`,
@@ -251,6 +257,8 @@ export default function SimulationPage() {
         apsCount={aps.length}
         backend={backend}
         onBackendChange={setBackend}
+        floorId={floorId ?? null}
+        projectId={selectedProjectId}
         onStart={handleStart}
         onReset={handleReset}
       />
@@ -318,8 +326,15 @@ export default function SimulationPage() {
                   readOnly
                 />
                 {heatmapUrl && isRunForCurrentVersion && (
-                  <div className="absolute bottom-3 right-3 z-10">
-                    <HeatmapColorLegend scale={heatmapColorScale} />
+                  // 좌상단 — gradient + tick 값이 수직 정렬돼 "이 색 = 이 dBm" 직관적.
+                  // MeasurementPage 와 동일 위치/크기로 통일.
+                  <div className="pointer-events-none absolute left-3 top-3 z-10 w-70">
+                    <DbmColorBar
+                      vmin={heatmapColorScale?.vminDbm ?? -85}
+                      vmax={heatmapColorScale?.vmaxDbm ?? -30}
+                      label="예측 RSSI (시뮬)"
+                      approximate={!heatmapColorScale}
+                    />
                   </div>
                 )}
               </>
@@ -441,6 +456,8 @@ function PageHeader({
   apsCount,
   backend,
   onBackendChange,
+  floorId,
+  projectId,
   onStart,
   onReset,
 }: {
@@ -450,6 +467,8 @@ function PageHeader({
   apsCount: number;
   backend: RfBackend;
   onBackendChange: (b: RfBackend) => void;
+  floorId: string | null;
+  projectId: string | null;
   onStart: () => void;
   onReset: () => void;
 }) {
@@ -464,7 +483,16 @@ function PageHeader({
 
       <div className="flex shrink-0 items-center gap-3">
         {state === 'idle' && (
-          <BackendToggle value={backend} onChange={onBackendChange} disabled={isStarting} />
+          <>
+            {/* 공간 유형 — Floor.space_type 직접 수정. 변경 시 즉시 저장 (다음 calibration 에 자동 반영).
+                현재 sim 동작에는 영향 없지만 사용자는 "이 공간을 시뮬한다" 라는 멘탈모델로 여기서 정함. */}
+            <FloorSpaceTypeSelector
+              floorId={floorId}
+              projectId={projectId}
+              showLabel={false}
+            />
+            <BackendToggle value={backend} onChange={onBackendChange} disabled={isStarting} />
+          </>
         )}
         {state === 'idle' ? (
           <button

--- a/frontend/src/types/calibration-run.ts
+++ b/frontend/src/types/calibration-run.ts
@@ -9,6 +9,15 @@ export type CalibrationRunStatus =
   | 'failed'
   | string;
 
+/** 공간 유형 — calibration 의 soft prior 로 사용. 백엔드 SpaceTypeLiteral 과 정합. */
+export type SpaceType =
+  | 'cafe'
+  | 'study_room'
+  | 'classroom'
+  | 'office'
+  | 'residential'
+  | 'unknown';
+
 export interface CalibrationRun {
   id: UUID;
   status: CalibrationRunStatus;
@@ -27,6 +36,8 @@ export interface CalibrationRunCreateRequest {
   session_id: UUID;
   rf_run_id: UUID;
   version_id: UUID;
+  /** 공간 유형 soft prior. 미지정 시 백엔드가 'unknown' 으로 fallback. */
+  space_type?: SpaceType;
 }
 
 /** §11.3 파라미터 변경 이력 — 어떤 wall/object 의 무슨 파라미터가 어떤 값으로 바뀌었는지. */

--- a/frontend/src/types/floor.ts
+++ b/frontend/src/types/floor.ts
@@ -1,4 +1,5 @@
 import type { ISODateString, UUID } from './common';
+import type { SpaceType } from './calibration-run';
 
 export interface Floor {
   id: UUID;
@@ -6,6 +7,8 @@ export interface Floor {
   floor_name: string;
   floor_order: number;
   height_m: number;
+  /** 공간 유형 — calibration BO prior + 향후 sim defaults 의 source of truth. */
+  space_type: SpaceType;
   created_at: ISODateString;
 }
 
@@ -13,12 +16,14 @@ export interface CreateFloorRequest {
   floor_name: string;
   floor_order: number;
   height_m: number;
+  space_type?: SpaceType;
 }
 
 export interface UpdateFloorRequest {
   floor_name?: string;
   floor_order?: number;
   height_m?: number;
+  space_type?: SpaceType;
 }
 
 /** Floor list response is a plain `{ items }` envelope (not paginated). */

--- a/frontend/src/types/measurement-session.ts
+++ b/frontend/src/types/measurement-session.ts
@@ -67,6 +67,10 @@ export interface EstimatedRssiRange {
   mean: number;
 }
 
+/** 'gp_only': 측정점만으로 GP — sparse 면 prior mean 으로 단조롭게 깔림.
+ *  'residual_kriging': 최근 시뮬 grid 를 prior, GP 는 residual 만 보간 — 더 현실적. */
+export type CoverageEstimationMethod = 'gp_only' | 'residual_kriging';
+
 export interface EstimatedCoverage {
   heatmap_url: string;
   uncertainty_url: string;
@@ -77,4 +81,6 @@ export interface EstimatedCoverage {
   uncertainty_max_db: number;
   input_point_count: number;
   kernel_repr: string;
+  /** 추정 방식 — UI 가 "시뮬 기반 보정" vs "단순 GP" 구분 표시. */
+  method?: CoverageEstimationMethod;
 }


### PR DESCRIPTION
## 개요
- 층별 공간 유형을 설정할 수 있도록 `Floor.space_type`을 추가
- 해당 값을 RF 보정 작업의 입력으로 전달하여 공간 유형별 path-loss prior를 적용하도록 개선

**기존 문제**
실내 환경의 차이와 관계없이 고정된 path-loss exponent를 사용했기 때문에, 거리 감쇠 오차가 material scale이나 tx power offset으로 잘못 흡수될 수 있었다.

-> 이를 개선하기 위해 카페, 스터디룸, 강의실, 오피스, 주거 공간, 미지정 유형별로 path-loss exponent 초기값과 탐색 범위를 다르게 설정
또한 보정 파라미터에 path_loss_exp를 추가하여 RSSI 예측식에서 고정 상수 대신 보정된 exponent를 사용하도록 변경
calibration 결과에는 적용된 prior, 개선된 RMSE/MAE, 공간 유형별 사용자 피드백 메시지, 변경된 파라미터 이력이 저장되도록 수정

## 변경 사항
### 1. Floor 공간 유형 저장 및 API 반영
- Floor 모델에 `space_type` 컬럼을 추가하고 기본값을 unknown으로 설정
- DTO에도 cafe, study_room, classroom, office, residential, unknown 타입을 추가하여 층 생성/수정/조회 시 공간 유형을 주고 받을 수 있게 수정

### 2. 공간 유형별 RF 보정 prior 추가
- 공간 유형에 따라 Wi-Fi 신호가 약해지는 정도가 달라질 수 있으므로,
카페/강의실/주거 공간별로 보정 알고리즘이 탐색할 파라미터 범위를 다르게 설정
- `space_priors.py`를 추가하여 공간 유형별 path-loss exponent 초기값, 탐색 범위, furniture thickness 초기값, material scale bounds를 정의
- 예를 들어 카페는 사람과 가구가 많아 신호 감쇠가 클 수 있으므로
path-loss exponent를 비교적 높은 범위에서 탐색하고,
강의실은 개방적인 공간일 가능성이 높아 더 낮은 범위에서 탐색
(다만 이 값들은 고정 규칙이 아니라 초기 힌트일 뿐, 최종 파라미터는 실제 측정 RSSI와 예측 RSSI의 오차가 가장 작아지는 방향으로 BO가 선택)

### 3. calibration BO에 path-loss exponent 포함
- 기존 calibration 파라미터에 `physical.path_loss_exp`를 추가하고, BO 탐색 공간을 공간 유형 prior 기반으로 동적으로 생성하도록 수정
- 탐색 대상은 `path-loss exponent`, `material attenuation scales`, `tx power offset`, `floor thickness`, `furniture thickness`로 구성
- 또한 같은 scene version의 이전 calibration 결과가 있으면 이전 best params를 baseline으로 사용하고, 그 위에 delta를 적용하는 warm-start / 누적 refinement 구조를 추가
- 단, `path_loss_exp`는 delta가 아니라 absolute value로 overwrite하도록 처리하여 해석 가능성을 유지

### 4. 보정 결과 피드백 및 파라미터 이력 개선
- Calibration 결과 metrics에 `space_type`, `applied_prior`, `feedback_message`, `previous_calibration_run_id`, `delta_from_previous` 등을 저장하도록 확장
- UI에서는 이 값을 읽어 RMSE/MAE뿐 아니라 공간 유형별 설명 문구와 변경된 파라미터 개수를 보여준다
- 또한 ParameterUpdate에 material scale, physical.path_loss_exp, tx power offset, floor/furniture thickness 변경 내역을 각각 row로 저장하여 어떤 파라미터가 어떻게 바뀌었는지 추적할 수 있게 변경

### 5. 실측 히트맵과 예측/실측 통합 분석 분리
실측 히트맵은 두 가지 방식으로 제공
1.  gp_only 방식은 모바일로 측정한 RSSI 값만 사용해 측정하지 않은 위치의 신호 세기를 Gaussian Process로 보간 -> 이는 순수 실측 기반 히트맵
2.  residual_kriging 방식은 기존 SionnaRT 시뮬레이션 결과를 기준 맵으로 사용
각 측정 위치에서 실제 RSSI와 시뮬레이션 RSSI의 차이를 residual로 계산하고,
이 residual만 GP로 보간한 뒤 기존 시뮬레이션 맵에 더한다.

**residual_kriging: SionnaRT의 물리적 패턴 유지+ 실측값으로 오차만 보정**
**`auto`, `gp_only`, `residual_kriging` 차이**
method | 의미 | 언제 쓰면 좋은지
-- | -- | --
gp_only | 실측값만 GP로 보간 | 시뮬레이션 결과가 없거나, 순수 실측 히트맵을 보고 싶을 때
residual_kriging | 시뮬레이션 맵 + 실측 오차 보정 | 시뮬레이션 결과가 있고, 예측·실측을 통합해서 보고 싶을 때
auto | 가능하면 residual kriging, 안 되면 gp_only | 사용자가 방식 몰라도 자동 선택하게 하고 싶을 때

**참고**
residual_kriging = 결과 맵 보정 / 분석용
calibration = 파라미터 보정 / 다음 시뮬레이션 반영용

### 6. 모바일 로컬 도면 이미지 접근 문제 해결
- 모바일 앱은 PC의 file:// 로컬 도면 이미지를 직접 열 수 없기 때문에, 측정 link token으로 인증되는 /measurement-links/{token}/floorplan-image 스트리밍 라우트를 추가
- /context 응답에서는 request.base_url을 이용해 모바일이 접근 가능한 absolute URL을 내려주도록 수정

## 테스트
### 시뮬레이션
<img width="2177" height="1204" alt="스크린샷 2026-05-27 141431" src="https://github.com/user-attachments/assets/dd1c7528-f8e7-4c5c-a066-7dc7123cb3b5" />

### 실측/보정
<img width="2559" height="1599" alt="스크린샷 2026-05-27 142623" src="https://github.com/user-attachments/assets/fe21bc3e-e3be-4ed6-9264-23642dbe3365" />

### 실측만
<img width="2200" height="1312" alt="스크린샷 2026-05-27 141450" src="https://github.com/user-attachments/assets/74098da9-f9e1-4954-95e9-b3098ffd0c95" />

## 참고
같은 도면인데 파라미터 조정 때문인지 벽 위로 갑자기 흰색만 뜨는데 
파라미터 조정 시 실측구간에만 오버핏을 하는지 점검 필요
### 처음 돌렸을 때
<img width="2141" height="1342" alt="스크린샷 2026-05-27 132748" src="https://github.com/user-attachments/assets/d0dbdb65-24e4-48f1-8146-19ff96f3d969" />

### 두번째 시뮬레이션 때
<img width="2548" height="1418" alt="스크린샷 2026-05-27 132715" src="https://github.com/user-attachments/assets/a8408ab6-510d-4e14-a5db-3fe41a3319aa" />

