### PR TITLE
fix: scale 보정 시 asset scale 동기화 및 calibration tx_offset Sionna 적용 제거

### DIFF
--- a/backend/app/services/rf/calibration_worker/apply.py
+++ b/backend/app/services/rf/calibration_worker/apply.py
@@ -75,24 +75,21 @@ def apply_to_scene_and_sim(
             w["thickness"] = float(w.get("thickness") or 0.12) * float(scale)
             scaled_count += 1
 
-    # 2) tx_power_offset_db → simulation.tx_power_dbm
-    tx_applied = False
-    if tx_offset and "tx_power_dbm" in simulation:
-        simulation["tx_power_dbm"] = float(simulation["tx_power_dbm"]) + tx_offset
-        tx_applied = True
-
+    # tx_power_offset_db 는 Sionna 에 적용하지 않음.
+    # BO 가 찾은 offset 은 단순 path-loss 수식 모델의 오차를 보정한 값이므로,
+    # 이미 물리적으로 정확한 Sionna 레이트레이싱에 그대로 더하면 신호가 크게 낮아짐.
     summary = {
         "walls_scaled": scaled_count,
-        "tx_power_offset_db_applied": tx_offset if tx_applied else 0.0,
+        "tx_power_offset_db_applied": 0.0,
         "material_scales": scales,
-        # SageMaker 경로에선 미반영 (참고용 — 컨테이너가 correction_profile 지원하면 활성)
         "unapplied": {
+            "tx_power_offset_db": tx_offset,
             "floor_thickness_m": best_params.get("floor_thickness_m"),
             "furniture_default_thickness_m": best_params.get("furniture_default_thickness_m"),
         },
     }
     logger.info(
         "calibration applied to RF input: %d walls scaled, tx_offset=%.2f",
-        scaled_count, tx_offset if tx_applied else 0.0,
+        scaled_count, 0.0,
     )
     return summary

--- a/backend/app/services/scene/scene_draft_service.py
+++ b/backend/app/services/scene/scene_draft_service.py
@@ -37,6 +37,7 @@ from app.models import (
     SceneDraft,
     User,
 )
+from app.models.asset import Asset
 from app.schemas.scene.scene_draft import (
     AnalyzeFromAssetResponse,
     DraftObjectResponse,
@@ -746,6 +747,32 @@ def rescale_scene_draft(
         wp["scale_source"] = scale_source
         summary["wall_postprocess"] = wp
     scene_draft.summary_json = summary
+
+    # 6) asset.metadata_json["scale_m_per_px"] 동기화.
+    # Android bounds 계산이 이 값에 의존하므로, scale 보정 시 반드시 같이 갱신해야
+    # 측정점이 도면 좌표계와 일치함. source_asset_id 없으면 floor의 최신 floorplan_image fallback.
+    asset_id = scene_draft.source_asset_id
+    if asset_id is None:
+        from sqlalchemy import select as _select
+        from app.models.asset import Asset as _Asset
+        fallback = db.execute(
+            _select(_Asset)
+            .where(
+                _Asset.floor_id == scene_draft.floor_id,
+                _Asset.asset_type == "floorplan_image",
+            )
+            .order_by(_Asset.created_at.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        asset_id = str(fallback.id) if fallback else None
+    if asset_id:
+        asset = db.get(Asset, str(asset_id))
+        if asset is not None:
+            asset_meta = dict(asset.metadata_json or {})
+            old_asset_scale = asset_meta.get("scale_m_per_px")
+            if isinstance(old_asset_scale, (int, float)) and old_asset_scale > 0:
+                asset_meta["scale_m_per_px"] = float(old_asset_scale) * f
+                asset.metadata_json = asset_meta
 
     # 1~5 모든 mutation 은 in-memory ORM 상태만 변경 — commit 에서 한 트랜잭션으로 flush.
     # 실패 시 좌표·metadata·summary 가 부분 적용되지 않게 전체 rollback (save_scene_draft 와 동일 패턴).


### PR DESCRIPTION
- scene_draft_service.py: rescale_walls 에서 asset.metadata_json["scale_m_per_px"] 업데이트 추가. source_asset_id 없으면 floor의 최신 floorplan_image asset fallback. Android bounds 계산이 이 값에 의존하므로 scale 보정 시 반드시 동기화 필요.

- calibration_worker/apply.py: BO가 찾은 tx_power_offset_db 를 Sionna에 적용하지 않음. 해당 offset 은 단순 path-loss 수식 모델의 오차 보정값으로, 이미 정확한 Sionna 레이트레이싱에 그대로 적용하면 예측 RSSI 가 크게 낮아지는 부작용 발생.