### PR TITLE
[Feat] 와이파이 실측 보정 평가 구현

### DIFF
--- a/backend/app/models/measurement_point.py
+++ b/backend/app/models/measurement_point.py
@@ -32,6 +32,7 @@ class MeasurementPoint(Base):
     latency_ms: Mapped[Decimal | None] = mapped_column(Numeric(8, 2), nullable=True)
     throughput_mbps: Mapped[Decimal | None] = mapped_column(Numeric(10, 3), nullable=True)
     ap_bssid: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    measurement_purpose: Mapped[str | None] = mapped_column(String(20), nullable=True)
     metadata_json: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )

--- a/backend/app/models/measurement_session.py
+++ b/backend/app/models/measurement_session.py
@@ -29,6 +29,9 @@ class MeasurementSession(Base):
     measurement_type: Mapped[str] = mapped_column(
         String(30), nullable=False, server_default=text("'rssi'")
     )
+    measurement_purpose: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'unknown'")
+    )
     device_info_json: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )

--- a/backend/app/routers/rf/calibration_runs.py
+++ b/backend/app/routers/rf/calibration_runs.py
@@ -10,6 +10,8 @@ from app.api.deps import get_current_user, verify_internal_api_key
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.rf.calibration_run import (
+    CalibrationEvaluationRequest,
+    CalibrationEvaluationResponse,
     CalibrationRunCreate,
     CalibrationRunResponse,
     CalibrationRunUpdate,
@@ -34,6 +36,22 @@ def create_calibration_run(
     current_user: User = Depends(get_current_user),
 ) -> CalibrationRunResponse:
     return calibration_run_service.create_calibration_run(
+        db, payload=payload, user=current_user
+    )
+
+
+@router.post(
+    "/evaluate",
+    response_model=CalibrationEvaluationResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Evaluate global-offset calibration with held-out validation points and 3-way RSSI maps.",
+)
+def evaluate_calibration_run(
+    payload: CalibrationEvaluationRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalibrationEvaluationResponse:
+    return calibration_run_service.evaluate_calibration_run(
         db, payload=payload, user=current_user
     )
 

--- a/backend/app/schemas/rf/calibration_run.py
+++ b/backend/app/schemas/rf/calibration_run.py
@@ -15,6 +15,8 @@ SpaceTypeLiteral = Literal[
     "cafe", "study_room", "classroom", "office", "residential", "unknown"
 ]
 
+MeasurementPurposeLiteral = Literal["calibration", "validation", "reference", "unknown"]
+
 
 class CalibrationRunCreate(BaseModel):
     """POST /calibration-runs — 명세 §11.1"""
@@ -25,6 +27,49 @@ class CalibrationRunCreate(BaseModel):
     version_id: UUID
     # 공간 유형 (soft prior). 미지정 시 backend runner 가 "unknown" 으로 fallback.
     space_type: Optional[SpaceTypeLiteral] = None
+
+
+class CalibrationEvaluationSplit(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    strategy: Literal["purpose_or_random", "random"] = "purpose_or_random"
+    holdout_ratio: float = Field(default=0.3, gt=0.0, lt=1.0)
+    seed: int = 42
+
+
+class CalibrationEvaluationVisualization(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    include_reference_map: bool = True
+    reference_map_method: Literal["idw"] = "idw"
+    rssi_min_dbm: float = -90.0
+    rssi_max_dbm: float = -30.0
+
+
+class CalibrationEvaluationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    floor_id: UUID
+    scene_version_id: UUID
+    rf_run_id: UUID
+    measurement_session_ids: list[UUID] = Field(default_factory=list, min_length=1)
+    method: Literal["global_offset"] = "global_offset"
+    split: CalibrationEvaluationSplit = Field(default_factory=CalibrationEvaluationSplit)
+    visualization: CalibrationEvaluationVisualization = Field(
+        default_factory=CalibrationEvaluationVisualization
+    )
+
+
+class CalibrationEvaluationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    calibration_run_id: UUID
+    status: str
+    maps: dict[str, Any]
+    color_scale: dict[str, float]
+    points: dict[str, list[dict[str, Any]]]
+    metrics: dict[str, float]
+    evaluation: dict[str, Any]
 
 
 class CalibrationRunResponse(BaseModel):

--- a/backend/app/schemas/rf/measurement.py
+++ b/backend/app/schemas/rf/measurement.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -55,6 +55,7 @@ class MeasurementLinkContextResponseDTO(BaseModel):
     bounds: FloorBoundsDTO = Field(default_factory=FloorBoundsDTO)
     anchor_points: list[dict[str, Any]] = Field(default_factory=list)
     existing_ap_layouts: list[dict[str, Any]] = Field(default_factory=list)
+    recommended_measurement_purpose: str = "calibration"
 
     @field_serializer("expires_at")
     def _serialize_expires_at(self, value: datetime) -> str:
@@ -82,6 +83,7 @@ class CalibrationDTO(BaseModel):
 class MeasurementSessionCreateRequestDTO(BaseModel):
     measurement_link_token: str
     measurement_type: str = "rssi"
+    measurement_purpose: Literal["calibration", "validation", "reference", "unknown"] = "unknown"
     device_info: DeviceInfoDTO = Field(default_factory=DeviceInfoDTO)
     calibration: CalibrationDTO = Field(default_factory=CalibrationDTO)
 
@@ -93,6 +95,7 @@ class MeasurementSessionResponseDTO(BaseModel):
     scene_version_id: str | None = None
     asset_id: str | None = None
     measurement_type: str
+    measurement_purpose: str = "unknown"
     status: str
     created_at: datetime
 
@@ -105,6 +108,7 @@ class MeasurementPointInputDTO(BaseModel):
     client_point_id: str | None = None
     floor_position: FloorPositionDTO
     rssi_dbm: float | None = None
+    measurement_purpose: Literal["calibration", "validation", "reference", "unknown"] | None = None
     ap_bssid: str | None = None
     ap_ssid: str | None = None
     channel: int | None = None
@@ -157,6 +161,7 @@ class MeasurementPointResponseDTO(BaseModel):
     batch_id: str | None = None
     floor_position: FloorPositionDTO
     rssi_dbm: float | None = None
+    measurement_purpose: str | None = None
     ap_bssid: str | None = None
     ap_ssid: str | None = None
     channel: int | None = None

--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -1,7 +1,10 @@
 """§11 Calibration: 실행 / 조회 / 파라미터 변경 이력 / 시스템 갱신"""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
+import math
+import random
 from typing import Any
 from uuid import UUID
 
@@ -12,18 +15,22 @@ from app.core.errors import AppError, ErrorCode
 from app.models.calibration_run import CalibrationRun
 from app.models.job import Job
 from app.models.measurement_session import MeasurementSession
+from app.models.measurement_point import MeasurementPoint
 from app.models.parameter_update import ParameterUpdate
 from app.models.project import Project
 from app.models.rf_run import RfRun
 from app.models.scene_version import SceneVersion
 from app.models.user import User
 from app.schemas.rf.calibration_run import (
+    CalibrationEvaluationRequest,
+    CalibrationEvaluationResponse,
     CalibrationRunCreate,
     CalibrationRunResponse,
     CalibrationRunUpdate,
     ParameterUpdateCreate,
     ParameterUpdateResponse,
 )
+from app.core.geom import wkb_to_geojson
 
 
 JOB_TYPE_CALIBRATION = "calibration"
@@ -89,6 +96,15 @@ def _get_owned_session(
             status_code=404,
         )
     return s
+
+
+def _get_owned_sessions(
+    db: Session, session_ids: list[UUID], user: User
+) -> list[MeasurementSession]:
+    sessions: list[MeasurementSession] = []
+    for session_id in session_ids:
+        sessions.append(_get_owned_session(db, session_id, user))
+    return sessions
 
 
 def _get_owned_calibration_run(
@@ -223,6 +239,479 @@ def create_calibration_run(
         db.rollback()
         raise
     return _to_response(cr)
+
+
+@dataclass(frozen=True)
+class _RadioMap:
+    values: list[list[float]]
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+
+    @property
+    def height(self) -> int:
+        return len(self.values)
+
+    @property
+    def width(self) -> int:
+        return len(self.values[0]) if self.values else 0
+
+
+@dataclass(frozen=True)
+class _EvalPoint:
+    point_id: str
+    session_id: str
+    x_m: float
+    y_m: float
+    measured_rssi_dbm: float
+    purpose: str
+    split: str
+    baseline_pred_dbm: float | None = None
+    calibrated_pred_dbm: float | None = None
+    invalid_reason: str | None = None
+
+
+def _load_radio_map(rf_run: RfRun) -> _RadioMap:
+    radio_map = (rf_run.metrics_json or {}).get("radio_map") or {}
+    values_raw = radio_map.get("values_dbm")
+    bounds = radio_map.get("bounds_m") or {}
+    if not isinstance(values_raw, list) or not values_raw:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "RF run does not contain radio_map.values_dbm.",
+            status_code=400,
+        )
+
+    values: list[list[float]] = []
+    width: int | None = None
+    for row in values_raw:
+        if not isinstance(row, list) or not row:
+            raise AppError(
+                ErrorCode.INVALID_REQUEST_BODY,
+                "radio_map.values_dbm must be a non-empty 2D array.",
+                status_code=400,
+            )
+        parsed = [float(v) for v in row]
+        width = len(parsed) if width is None else width
+        if len(parsed) != width:
+            raise AppError(
+                ErrorCode.INVALID_REQUEST_BODY,
+                "radio_map.values_dbm rows must have the same width.",
+                status_code=400,
+            )
+        values.append(parsed)
+
+    min_x = float(bounds.get("min_x", 0.0))
+    min_y = float(bounds.get("min_y", 0.0))
+    max_x = float(bounds.get("max_x", float(width or 0)))
+    max_y = float(bounds.get("max_y", float(len(values))))
+    if max_x <= min_x or max_y <= min_y:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "radio_map.bounds_m is missing or invalid.",
+            status_code=400,
+        )
+    return _RadioMap(values=values, min_x=min_x, min_y=min_y, max_x=max_x, max_y=max_y)
+
+
+def _sample_radio_map(radio_map: _RadioMap, x_m: float, y_m: float) -> tuple[float | None, str | None]:
+    if x_m < radio_map.min_x or x_m > radio_map.max_x or y_m < radio_map.min_y or y_m > radio_map.max_y:
+        return None, "outside_bounds"
+    col = int(math.floor((x_m - radio_map.min_x) / (radio_map.max_x - radio_map.min_x) * radio_map.width))
+    row = int(math.floor((y_m - radio_map.min_y) / (radio_map.max_y - radio_map.min_y) * radio_map.height))
+    col = min(max(col, 0), radio_map.width - 1)
+    row = min(max(row, 0), radio_map.height - 1)
+    value = float(radio_map.values[row][col])
+    if not math.isfinite(value) or value <= -200.0:
+        return None, "invalid_radio_cell"
+    return value, None
+
+
+def _point_coords(row: MeasurementPoint) -> tuple[float, float]:
+    gj = wkb_to_geojson(row.point_geom)
+    coords = (gj or {}).get("coordinates") or [0.0, 0.0]
+    return float(coords[0]), float(coords[1])
+
+
+def _effective_purpose(point: MeasurementPoint, session_by_id: dict[str, MeasurementSession]) -> str:
+    value = point.measurement_purpose or session_by_id[point.session_id].measurement_purpose or "unknown"
+    return value if value in {"calibration", "validation", "reference", "unknown"} else "unknown"
+
+
+def _split_points(
+    points: list[MeasurementPoint],
+    session_by_id: dict[str, MeasurementSession],
+    *,
+    strategy: str,
+    holdout_ratio: float,
+    seed: int,
+) -> tuple[list[_EvalPoint], dict[str, Any]]:
+    rows: list[tuple[MeasurementPoint, str]] = [
+        (p, _effective_purpose(p, session_by_id))
+        for p in points
+        if p.rssi_dbm is not None
+    ]
+    if len(rows) < 5:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            f"Need at least 5 measurement points with RSSI for evaluation (got {len(rows)}).",
+            status_code=400,
+        )
+
+    has_explicit_split = strategy == "purpose_or_random" and any(
+        purpose in {"calibration", "validation"} for _, purpose in rows
+    )
+    split_by_id: dict[str, str] = {}
+    if has_explicit_split:
+        for p, purpose in rows:
+            if purpose in {"calibration", "validation", "reference"}:
+                split_by_id[p.id] = purpose
+            else:
+                split_by_id[p.id] = "calibration"
+    else:
+        sorted_rows = sorted(rows, key=lambda item: (str(item[0].session_id), str(item[0].id)))
+        rng = random.Random(seed)
+        shuffled = sorted_rows[:]
+        rng.shuffle(shuffled)
+        n_validation = max(1, int(round(len(shuffled) * holdout_ratio)))
+        n_validation = min(n_validation, len(shuffled) - 1)
+        validation_ids = {p.id for p, _ in shuffled[:n_validation]}
+        for p, _ in sorted_rows:
+            split_by_id[p.id] = "validation" if p.id in validation_ids else "calibration"
+
+    result: list[_EvalPoint] = []
+    for p, purpose in rows:
+        x_m, y_m = _point_coords(p)
+        split = split_by_id[p.id]
+        result.append(
+            _EvalPoint(
+                point_id=p.id,
+                session_id=p.session_id,
+                x_m=x_m,
+                y_m=y_m,
+                measured_rssi_dbm=float(p.rssi_dbm),
+                purpose=purpose,
+                split=split,
+            )
+        )
+
+    calibration_count = sum(1 for p in result if p.split == "calibration")
+    validation_count = sum(1 for p in result if p.split == "validation")
+    if calibration_count == 0:
+        raise AppError(ErrorCode.INVALID_REQUEST_BODY, "No calibration points available.", 400)
+    if validation_count == 0:
+        raise AppError(ErrorCode.INVALID_REQUEST_BODY, "No validation points available.", 400)
+
+    return result, {
+        "strategy": strategy,
+        "holdout_ratio": holdout_ratio,
+        "seed": seed,
+        "source": "purpose" if has_explicit_split else "random",
+        "n_total_points": len(result),
+        "n_calibration_points": calibration_count,
+        "n_validation_points": validation_count,
+    }
+
+
+def _with_predictions(points: list[_EvalPoint], radio_map: _RadioMap) -> list[_EvalPoint]:
+    sampled: list[_EvalPoint] = []
+    for p in points:
+        pred, invalid_reason = _sample_radio_map(radio_map, p.x_m, p.y_m)
+        sampled.append(
+            _EvalPoint(
+                **{
+                    **p.__dict__,
+                    "baseline_pred_dbm": pred,
+                    "invalid_reason": invalid_reason,
+                }
+            )
+        )
+    return sampled
+
+
+def _calc_metrics(points: list[_EvalPoint]) -> dict[str, float]:
+    baseline_errors = [abs(p.baseline_pred_dbm - p.measured_rssi_dbm) for p in points if p.baseline_pred_dbm is not None]
+    calibrated_errors = [abs(p.calibrated_pred_dbm - p.measured_rssi_dbm) for p in points if p.calibrated_pred_dbm is not None]
+    baseline_signed = [p.baseline_pred_dbm - p.measured_rssi_dbm for p in points if p.baseline_pred_dbm is not None]
+    calibrated_signed = [p.calibrated_pred_dbm - p.measured_rssi_dbm for p in points if p.calibrated_pred_dbm is not None]
+    if not baseline_errors or not calibrated_errors:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "No valid validation points remain after radio map sampling.",
+            400,
+        )
+
+    def mean(vals: list[float]) -> float:
+        return sum(vals) / len(vals)
+
+    baseline_mae = mean(baseline_errors)
+    calibrated_mae = mean(calibrated_errors)
+    baseline_rmse = math.sqrt(mean([v * v for v in baseline_errors]))
+    calibrated_rmse = math.sqrt(mean([v * v for v in calibrated_errors]))
+    return {
+        "baseline_mae_db": baseline_mae,
+        "baseline_rmse_db": baseline_rmse,
+        "baseline_bias_db": mean(baseline_signed),
+        "calibrated_mae_db": calibrated_mae,
+        "calibrated_rmse_db": calibrated_rmse,
+        "calibrated_bias_db": mean(calibrated_signed),
+        "mae_improvement_db": baseline_mae - calibrated_mae,
+        "rmse_improvement_db": baseline_rmse - calibrated_rmse,
+        "mae_improvement_ratio": (baseline_mae - calibrated_mae) / baseline_mae if baseline_mae else 0.0,
+    }
+
+
+def _calibrated_map(values: list[list[float]], offset_db: float) -> list[list[float]]:
+    return [
+        [float(v) + offset_db if math.isfinite(float(v)) else float(v) for v in row]
+        for row in values
+    ]
+
+
+def _idw_reference_map(radio_map: _RadioMap, points: list[_EvalPoint]) -> list[list[float]]:
+    power = 2.0
+    epsilon = 1e-6
+    out: list[list[float]] = []
+    for row_idx in range(radio_map.height):
+        y = radio_map.min_y if radio_map.height == 1 else radio_map.min_y + (radio_map.max_y - radio_map.min_y) * row_idx / (radio_map.height - 1)
+        row: list[float] = []
+        for col_idx in range(radio_map.width):
+            x = radio_map.min_x if radio_map.width == 1 else radio_map.min_x + (radio_map.max_x - radio_map.min_x) * col_idx / (radio_map.width - 1)
+            numerator = 0.0
+            denominator = 0.0
+            exact: float | None = None
+            for p in points:
+                dist = math.hypot(x - p.x_m, y - p.y_m)
+                if dist < epsilon:
+                    exact = p.measured_rssi_dbm
+                    break
+                weight = 1.0 / (dist ** power)
+                numerator += weight * p.measured_rssi_dbm
+                denominator += weight
+            row.append(exact if exact is not None else numerator / denominator)
+        out.append(row)
+    return out
+
+
+def _point_payload(p: _EvalPoint) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "point_id": p.point_id,
+        "session_id": p.session_id,
+        "x_m": p.x_m,
+        "y_m": p.y_m,
+        "rssi_dbm": p.measured_rssi_dbm,
+        "measurement_purpose": p.purpose,
+        "split": p.split,
+    }
+    if p.baseline_pred_dbm is not None:
+        payload["baseline_pred_dbm"] = p.baseline_pred_dbm
+        payload["baseline_error_db"] = abs(p.baseline_pred_dbm - p.measured_rssi_dbm)
+    if p.calibrated_pred_dbm is not None:
+        payload["calibrated_pred_dbm"] = p.calibrated_pred_dbm
+        payload["calibrated_error_db"] = abs(p.calibrated_pred_dbm - p.measured_rssi_dbm)
+    if p.invalid_reason is not None:
+        payload["invalid_reason"] = p.invalid_reason
+    return payload
+
+
+def evaluate_calibration_run(
+    db: Session, payload: CalibrationEvaluationRequest, user: User
+) -> CalibrationEvaluationResponse:
+    sv = _get_owned_scene_version(db, payload.scene_version_id, user)
+    rr = _get_owned_rf_run(db, payload.rf_run_id, user)
+    sessions = _get_owned_sessions(db, payload.measurement_session_ids, user)
+
+    if sv.floor_id != str(payload.floor_id) or rr.floor_id != str(payload.floor_id):
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "floor_id, scene_version_id, and rf_run_id must refer to the same floor.",
+            status_code=400,
+        )
+    for session in sessions:
+        if session.floor_id != str(payload.floor_id):
+            raise AppError(
+                ErrorCode.INVALID_REQUEST_BODY,
+                "All measurement sessions must belong to the requested floor.",
+                status_code=400,
+            )
+
+    radio_map = _load_radio_map(rr)
+    session_ids = [str(s.id) for s in sessions]
+    rows = (
+        db.execute(
+            select(MeasurementPoint).where(
+                MeasurementPoint.session_id.in_(session_ids),
+                MeasurementPoint.rssi_dbm.isnot(None),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    split_points, split_meta = _split_points(
+        rows,
+        {str(s.id): s for s in sessions},
+        strategy=payload.split.strategy,
+        holdout_ratio=payload.split.holdout_ratio,
+        seed=payload.split.seed,
+    )
+    sampled = _with_predictions(split_points, radio_map)
+    valid_calibration = [
+        p for p in sampled if p.split == "calibration" and p.baseline_pred_dbm is not None
+    ]
+    valid_validation = [
+        p for p in sampled if p.split == "validation" and p.baseline_pred_dbm is not None
+    ]
+    invalid_points = [p for p in sampled if p.invalid_reason is not None]
+    if not valid_calibration:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "No valid calibration points remain after radio map sampling.",
+            400,
+        )
+    if not valid_validation:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "No valid validation points remain after radio map sampling.",
+            400,
+        )
+
+    offset_db = sum(p.measured_rssi_dbm - float(p.baseline_pred_dbm) for p in valid_calibration) / len(valid_calibration)
+    calibrated_points: list[_EvalPoint] = []
+    for p in sampled:
+        calibrated_pred = p.baseline_pred_dbm + offset_db if p.baseline_pred_dbm is not None else None
+        calibrated_points.append(
+            _EvalPoint(
+                **{
+                    **p.__dict__,
+                    "calibrated_pred_dbm": calibrated_pred,
+                }
+            )
+        )
+
+    validation_points = [
+        p for p in calibrated_points if p.split == "validation" and p.baseline_pred_dbm is not None
+    ]
+    metrics = _calc_metrics(validation_points)
+    rounded_metrics = {k: round(v, 4) for k, v in metrics.items()}
+
+    reference_points = [p for p in calibrated_points if p.split == "reference"]
+    if not reference_points:
+        reference_points = [
+            p for p in calibrated_points if p.split in {"calibration", "validation"}
+        ]
+    reference_points = [p for p in reference_points if p.invalid_reason is None]
+    measured_reference: dict[str, Any] | None = None
+    warnings: list[str] = []
+    if payload.visualization.include_reference_map:
+        if len(reference_points) < 3:
+            warnings.append("Measured reference map skipped because fewer than 3 valid reference points are available.")
+        else:
+            measured_reference = {
+                "label": "Measured Reference Map",
+                "method": "idw",
+                "values_dbm": _idw_reference_map(radio_map, reference_points),
+                "metadata": {
+                    "point_count": len(reference_points),
+                    "is_interpolated_reference": True,
+                    "not_absolute_ground_truth": True,
+                },
+            }
+
+    maps: dict[str, Any] = {
+        "baseline": {
+            "label": "Baseline Simulation",
+            "values_dbm": radio_map.values,
+            "bounds_m": {
+                "min_x": radio_map.min_x,
+                "min_y": radio_map.min_y,
+                "max_x": radio_map.max_x,
+                "max_y": radio_map.max_y,
+            },
+        },
+        "calibrated": {
+            "label": "Calibrated Simulation",
+            "values_dbm": _calibrated_map(radio_map.values, offset_db),
+            "bounds_m": {
+                "min_x": radio_map.min_x,
+                "min_y": radio_map.min_y,
+                "max_x": radio_map.max_x,
+                "max_y": radio_map.max_y,
+            },
+            "offset_db": offset_db,
+        },
+    }
+    if measured_reference is not None:
+        measured_reference["bounds_m"] = maps["baseline"]["bounds_m"]
+        maps["measured_reference"] = measured_reference
+
+    split_meta = {
+        **split_meta,
+        "n_reference_points": len(reference_points),
+        "n_invalid_points": len(invalid_points),
+    }
+    evaluation = {
+        "split": split_meta,
+        "calibration": {"method": payload.method, "offset_db": round(offset_db, 4)},
+        "visualization": {
+            "map_type": "three_way_comparison",
+            "reference_map_method": payload.visualization.reference_map_method,
+            "rssi_min_dbm": payload.visualization.rssi_min_dbm,
+            "rssi_max_dbm": payload.visualization.rssi_max_dbm,
+            "reference_map_is_visual_only": True,
+            "warnings": warnings,
+        },
+        "metrics": rounded_metrics,
+    }
+
+    response_payload = {
+        "calibration_run_id": "",
+        "status": "completed",
+        "maps": maps,
+        "color_scale": {
+            "min_dbm": payload.visualization.rssi_min_dbm,
+            "max_dbm": payload.visualization.rssi_max_dbm,
+        },
+        "points": {
+            "calibration": [_point_payload(p) for p in calibrated_points if p.split == "calibration"],
+            "validation": [_point_payload(p) for p in validation_points],
+            "reference": [_point_payload(p) for p in reference_points],
+            "invalid": [_point_payload(p) for p in invalid_points],
+        },
+        "metrics": rounded_metrics,
+        "evaluation": evaluation,
+    }
+
+    cr = CalibrationRun(
+        project_id=sv.project_id,
+        floor_id=sv.floor_id,
+        scene_version_id=sv.id,
+        rf_run_id=rr.id,
+        measurement_session_id=session_ids[0],
+        status="completed",
+        finished_at=datetime.now(timezone.utc),
+        metrics_json={
+            **rounded_metrics,
+            "evaluation": evaluation,
+            "evaluation_response": response_payload,
+        },
+    )
+    db.add(cr)
+    db.flush()
+    response_payload["calibration_run_id"] = cr.id
+    cr.metrics_json = {
+        **rounded_metrics,
+        "evaluation": evaluation,
+        "evaluation_response": response_payload,
+    }
+    try:
+        db.commit()
+        db.refresh(cr)
+    except Exception:
+        db.rollback()
+        raise
+
+    return CalibrationEvaluationResponse(**response_payload)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/rf/measurement_service.py
+++ b/backend/app/services/rf/measurement_service.py
@@ -399,6 +399,7 @@ def get_measurement_link_context(
         bounds=bounds,
         anchor_points=[],
         existing_ap_layouts=[],
+        recommended_measurement_purpose="calibration",
     )
 
 
@@ -412,6 +413,7 @@ def create_measurement_session(
         project_id=link.project_id,
         floor_id=link.floor_id,
         measurement_type=request.measurement_type,
+        measurement_purpose=request.measurement_purpose,
         device_info_json=request.device_info.model_dump(exclude_none=True),
         calibration_json=request.calibration.model_dump(exclude_none=True),
         status="in_progress",
@@ -427,6 +429,7 @@ def create_measurement_session(
         scene_version_id=link.scene_version_id,
         asset_id=link.asset_id,
         measurement_type=session_row.measurement_type,
+        measurement_purpose=session_row.measurement_purpose,
         status=session_row.status,
         created_at=session_row.created_at,
     )
@@ -456,6 +459,7 @@ def upload_measurement_points(
             point_geom=wkt_geom,
             z_m=point.floor_position.z,
             rssi_dbm=point.rssi_dbm,
+            measurement_purpose=point.measurement_purpose,
             ap_bssid=point.ap_bssid,
             ap_ssid=point.ap_ssid,
             channel=point.channel,
@@ -590,6 +594,7 @@ def _session_to_response(row: MeasurementSession) -> MeasurementSessionResponseD
         scene_version_id=None,
         asset_id=None,
         measurement_type=row.measurement_type,
+        measurement_purpose=row.measurement_purpose,
         status=row.status,
         created_at=row.created_at,
     )
@@ -615,6 +620,7 @@ def _point_to_response(row: MeasurementPoint) -> MeasurementPointResponseDTO:
             x=float(coords[0]), y=float(coords[1]), z=z
         ),
         rssi_dbm=float(row.rssi_dbm) if row.rssi_dbm is not None else None,
+        measurement_purpose=row.measurement_purpose,
         ap_bssid=row.ap_bssid,
         ap_ssid=row.ap_ssid,
         channel=row.channel,

--- a/backend/migrations/versions/20260529_0011_measurement_purpose.py
+++ b/backend/migrations/versions/20260529_0011_measurement_purpose.py
@@ -1,0 +1,37 @@
+"""add measurement purpose fields
+
+Revision ID: 20260529_0011
+Revises: 20260527_0010
+Create Date: 2026-05-29 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260529_0011"
+down_revision: Union[str, Sequence[str], None] = "20260527_0010"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "measurement_sessions",
+        sa.Column(
+            "measurement_purpose",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'unknown'"),
+        ),
+    )
+    op.add_column(
+        "measurement_points",
+        sa.Column("measurement_purpose", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("measurement_points", "measurement_purpose")
+    op.drop_column("measurement_sessions", "measurement_purpose")

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=http://43.201.65.165:8000
 
 # Dev-only: skip auth guard so you can browse all pages without logging in.
 # Set to "true" in .env.local during development. Ignored in production builds.

--- a/frontend/src/api/calibration-run.ts
+++ b/frontend/src/api/calibration-run.ts
@@ -3,6 +3,8 @@ import type { UUID } from '@/types/common';
 import type {
   CalibrationRun,
   CalibrationRunCreateRequest,
+  CalibrationEvaluationRequest,
+  CalibrationEvaluationResponse,
   ParameterUpdate,
 } from '@/types/calibration-run';
 
@@ -10,6 +12,9 @@ export const calibrationRunApi = {
   // §11.1 POST /calibration-runs — Job 큐 등록 (HTTP 202).
   create: (body: CalibrationRunCreateRequest) =>
     api.post<CalibrationRun>('/calibration-runs', body).then((r) => r.data),
+
+  evaluate: (body: CalibrationEvaluationRequest) =>
+    api.post<CalibrationEvaluationResponse>('/calibration-runs/evaluate', body).then((r) => r.data),
 
   // §11.2 GET /calibration-runs/{id} — 결과/상태 조회.
   get: (id: UUID) =>

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -1,5 +1,7 @@
-import { Loader2, Sliders } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Loader2, Maximize2, Sliders, X } from 'lucide-react';
 import type {
+  CalibrationEvaluationResponse,
   CalibrationRun,
   ParameterUpdate,
   SpaceType,
@@ -27,6 +29,8 @@ interface Props {
   onSpaceTypeChange: (next: SpaceType) => void;
   onCalibrate: () => void;
   parameterUpdates: ParameterUpdate[];
+  evaluation?: CalibrationEvaluationResponse | null;
+  backgroundImageUrl?: string | null;
 }
 
 /**
@@ -43,6 +47,8 @@ export function CalibrationCard({
   onSpaceTypeChange,
   onCalibrate,
   parameterUpdates,
+  evaluation,
+  backgroundImageUrl,
 }: Props) {
   const succeeded = run?.status === 'succeeded';
   const failed = run?.status === 'failed';
@@ -93,6 +99,11 @@ export function CalibrationCard({
           보정에 실패했습니다. 측정 데이터가 충분한지 확인해주세요.
         </p>
       ) : null}
+
+      <CalibrationEvaluationPanel
+        evaluation={evaluation ?? extractEvaluationResponse(run)}
+        backgroundImageUrl={backgroundImageUrl}
+      />
 
       <button
         type="button"
@@ -167,6 +178,407 @@ function CalibrationResult({
       </p>
     </div>
   );
+}
+
+function CalibrationEvaluationPanel({
+  evaluation,
+  backgroundImageUrl,
+}: {
+  evaluation: CalibrationEvaluationResponse | null;
+  backgroundImageUrl?: string | null;
+}) {
+  const [detailOpen, setDetailOpen] = useState(false);
+  if (!evaluation) return null;
+  const maps = [
+    evaluation.maps.baseline,
+    evaluation.maps.calibrated,
+    evaluation.maps.measured_reference,
+  ].filter((map): map is NonNullable<typeof map> => map != null);
+  const m = evaluation.metrics;
+  const fmt = (v: unknown, digits = 1) =>
+    typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
+  return (
+    <section className="mt-3 space-y-3 rounded-lg border bg-muted/30 p-3">
+      <div>
+        <p className="text-[11px] font-semibold text-foreground">
+          Validation points 기준
+        </p>
+        <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+          Validation points are held out from the offset calculation. The measured reference map is an interpolated measurement map, not absolute ground truth.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setDetailOpen(true)}
+        className="inline-flex w-full items-center justify-center gap-1 rounded-md border bg-background px-2 py-1.5 text-[11px] font-medium hover:bg-accent"
+      >
+        <Maximize2 className="h-3 w-3" />
+        Detail view
+      </button>
+
+      <div className="overflow-x-auto">
+        <div className="grid min-w-[620px] grid-cols-3 gap-2">
+          {maps.map((map) => (
+            <MiniRssiMap
+              key={map.label}
+              map={map}
+              colorScale={evaluation.color_scale}
+              calibrationPoints={evaluation.points.calibration}
+              validationPoints={evaluation.points.validation}
+              backgroundImageUrl={backgroundImageUrl}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-background p-2 text-[11px]">
+        <div className="grid grid-cols-4 gap-2 font-semibold text-muted-foreground">
+          <span>Metric</span>
+          <span>Before</span>
+          <span>After</span>
+          <span>Improvement</span>
+        </div>
+        <MetricRow
+          label="MAE"
+          before={fmt(m.baseline_mae_db)}
+          after={fmt(m.calibrated_mae_db)}
+          improvement={`${fmt(m.mae_improvement_db)} dB`}
+        />
+        <MetricRow
+          label="RMSE"
+          before={fmt(m.baseline_rmse_db)}
+          after={fmt(m.calibrated_rmse_db)}
+          improvement={`${fmt(m.rmse_improvement_db)} dB`}
+        />
+      </div>
+
+      <details className="rounded-md border bg-background text-[11px]">
+        <summary className="cursor-pointer px-3 py-2 font-medium">
+          Validation point errors ({evaluation.points.validation.length})
+        </summary>
+        <div className="max-h-48 overflow-auto">
+          <table className="w-full min-w-[520px] text-left">
+            <thead className="sticky top-0 bg-background text-muted-foreground">
+              <tr>
+                <th className="px-2 py-1">Point</th>
+                <th className="px-2 py-1">Measured</th>
+                <th className="px-2 py-1">Baseline</th>
+                <th className="px-2 py-1">Calibrated</th>
+                <th className="px-2 py-1">Before</th>
+                <th className="px-2 py-1">After</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evaluation.points.validation.map((p, idx) => (
+                <tr key={p.point_id} className="border-t">
+                  <td className="px-2 py-1">P{String(idx + 1).padStart(2, '0')}</td>
+                  <td className="px-2 py-1">{fmt(p.rssi_dbm)} dBm</td>
+                  <td className="px-2 py-1">{fmt(p.baseline_pred_dbm)} dBm</td>
+                  <td className="px-2 py-1">{fmt(p.calibrated_pred_dbm)} dBm</td>
+                  <td className="px-2 py-1">{fmt(p.baseline_error_db)} dB</td>
+                  <td className="px-2 py-1">{fmt(p.calibrated_error_db)} dB</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <CalibrationEvaluationDetailModal
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        evaluation={evaluation}
+        backgroundImageUrl={backgroundImageUrl}
+      />
+    </section>
+  );
+}
+
+function CalibrationEvaluationDetailModal({
+  open,
+  onClose,
+  evaluation,
+  backgroundImageUrl,
+}: {
+  open: boolean;
+  onClose: () => void;
+  evaluation: CalibrationEvaluationResponse;
+  backgroundImageUrl?: string | null;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const maps = [
+    evaluation.maps.baseline,
+    evaluation.maps.calibrated,
+    evaluation.maps.measured_reference,
+  ].filter((map): map is NonNullable<typeof map> => map != null);
+  const m = evaluation.metrics;
+  const fmt = (v: unknown, digits = 1) =>
+    typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[92vh] w-full max-w-7xl flex-col overflow-hidden rounded-xl border bg-background shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-center justify-between gap-3 border-b px-5 py-3">
+          <div>
+            <h2 className="text-base font-semibold">3-way RSSI map comparison</h2>
+            <p className="text-xs text-muted-foreground">
+              Same floorplan, grid, bounds, and RSSI color scale. Validation points are not used for calibration.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border hover:bg-accent"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-auto p-5">
+          <div className="grid gap-4 xl:grid-cols-3">
+            {maps.map((map) => (
+              <MiniRssiMap
+                key={map.label}
+                map={map}
+                colorScale={evaluation.color_scale}
+                calibrationPoints={evaluation.points.calibration}
+                validationPoints={evaluation.points.validation}
+                backgroundImageUrl={backgroundImageUrl}
+                size="large"
+              />
+            ))}
+          </div>
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-[24rem_1fr]">
+            <div className="rounded-lg border bg-muted/20 p-4 text-sm">
+              <p className="font-semibold">Validation metrics</p>
+              <div className="mt-3 grid grid-cols-4 gap-2 text-xs font-semibold text-muted-foreground">
+                <span>Metric</span>
+                <span>Before</span>
+                <span>After</span>
+                <span>Improvement</span>
+              </div>
+              <MetricRow
+                label="MAE"
+                before={fmt(m.baseline_mae_db)}
+                after={fmt(m.calibrated_mae_db)}
+                improvement={`${fmt(m.mae_improvement_db)} dB`}
+              />
+              <MetricRow
+                label="RMSE"
+                before={fmt(m.baseline_rmse_db)}
+                after={fmt(m.calibrated_rmse_db)}
+                improvement={`${fmt(m.rmse_improvement_db)} dB`}
+              />
+              <div className="mt-4 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                <span className="inline-flex items-center gap-1">
+                  <span className="h-2.5 w-2.5 rounded-full bg-[#0f766e]" />
+                  calibration
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <span className="h-0 w-0 border-x-[5px] border-b-[9px] border-x-transparent border-b-[#dc2626]" />
+                  validation
+                </span>
+              </div>
+            </div>
+
+            <div className="rounded-lg border bg-background text-xs">
+              <div className="border-b px-4 py-3 font-semibold">
+                Validation point errors ({evaluation.points.validation.length})
+              </div>
+              <div className="max-h-72 overflow-auto">
+                <table className="w-full min-w-[640px] text-left">
+                  <thead className="sticky top-0 bg-background text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-2">Point</th>
+                      <th className="px-3 py-2">Measured</th>
+                      <th className="px-3 py-2">Baseline Pred</th>
+                      <th className="px-3 py-2">Calibrated Pred</th>
+                      <th className="px-3 py-2">Before Error</th>
+                      <th className="px-3 py-2">After Error</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {evaluation.points.validation.map((p, idx) => (
+                      <tr key={p.point_id} className="border-t">
+                        <td className="px-3 py-2">P{String(idx + 1).padStart(2, '0')}</td>
+                        <td className="px-3 py-2">{fmt(p.rssi_dbm)} dBm</td>
+                        <td className="px-3 py-2">{fmt(p.baseline_pred_dbm)} dBm</td>
+                        <td className="px-3 py-2">{fmt(p.calibrated_pred_dbm)} dBm</td>
+                        <td className="px-3 py-2">{fmt(p.baseline_error_db)} dB</td>
+                        <td className="px-3 py-2">{fmt(p.calibrated_error_db)} dB</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricRow({
+  label,
+  before,
+  after,
+  improvement,
+}: {
+  label: string;
+  before: string;
+  after: string;
+  improvement: string;
+}) {
+  return (
+    <div className="mt-1 grid grid-cols-4 gap-2 tabular-nums">
+      <span className="font-medium">{label}</span>
+      <span>{before} dB</span>
+      <span>{after} dB</span>
+      <span>{improvement}</span>
+    </div>
+  );
+}
+
+function MiniRssiMap({
+  map,
+  colorScale,
+  calibrationPoints,
+  validationPoints,
+  backgroundImageUrl,
+  size = 'compact',
+}: {
+  map: CalibrationEvaluationResponse['maps']['baseline'];
+  colorScale: { min_dbm: number; max_dbm: number };
+  calibrationPoints: CalibrationEvaluationResponse['points']['calibration'];
+  validationPoints: CalibrationEvaluationResponse['points']['validation'];
+  backgroundImageUrl?: string | null;
+  size?: 'compact' | 'large';
+}) {
+  const bounds = map.bounds_m;
+  const w = Math.max(bounds.max_x - bounds.min_x, 1);
+  const h = Math.max(bounds.max_y - bounds.min_y, 1);
+  const rows = map.values_dbm.length;
+  const cols = map.values_dbm[0]?.length ?? 0;
+  return (
+    <div className={size === 'large' ? 'rounded-lg border bg-background p-3' : 'rounded-md border bg-background p-2'}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className={size === 'large' ? 'truncate text-sm font-semibold' : 'truncate text-[11px] font-semibold'}>
+          {map.label}
+        </p>
+        {size === 'large' && (
+          <span className="text-[11px] text-muted-foreground">
+            {colorScale.min_dbm} to {colorScale.max_dbm} dBm
+          </span>
+        )}
+      </div>
+      <svg viewBox={`${bounds.min_x} ${bounds.min_y} ${w} ${h}`} className={size === 'large' ? 'aspect-[4/3] w-full overflow-hidden rounded-md border bg-white' : 'aspect-[4/3] w-full overflow-hidden rounded border bg-white'}>
+        {backgroundImageUrl && (
+          <image
+            href={backgroundImageUrl}
+            x={bounds.min_x}
+            y={bounds.min_y}
+            width={w}
+            height={h}
+            preserveAspectRatio="none"
+            opacity="0.28"
+          />
+        )}
+        {map.values_dbm.map((row, r) =>
+          row.map((value, c) => {
+            const x = bounds.min_x + (w * c) / Math.max(cols, 1);
+            const y = bounds.min_y + (h * r) / Math.max(rows, 1);
+            return (
+              <rect
+                key={`${r}-${c}`}
+                x={x}
+                y={y}
+                width={w / Math.max(cols, 1)}
+                height={h / Math.max(rows, 1)}
+                fill={rssiColor(value, colorScale.min_dbm, colorScale.max_dbm)}
+                opacity="0.72"
+              />
+            );
+          }),
+        )}
+        {calibrationPoints.map((p) => (
+          <circle key={`c-${p.point_id}`} cx={p.x_m} cy={p.y_m} r={w * 0.012} fill="#0f766e" stroke="white" strokeWidth={w * 0.004} />
+        ))}
+        {validationPoints.map((p) => (
+          <path
+            key={`v-${p.point_id}`}
+            d={`M ${p.x_m} ${p.y_m - w * 0.014} L ${p.x_m - w * 0.014} ${p.y_m + w * 0.014} L ${p.x_m + w * 0.014} ${p.y_m + w * 0.014} Z`}
+            fill="#dc2626"
+            stroke="white"
+            strokeWidth={w * 0.004}
+          />
+        ))}
+      </svg>
+      {size === 'large' && <RssiScaleBar min={colorScale.min_dbm} max={colorScale.max_dbm} />}
+    </div>
+  );
+}
+
+function RssiScaleBar({ min, max }: { min: number; max: number }) {
+  return (
+    <div className="mt-2">
+      <div
+        className="h-2 rounded-full"
+        style={{
+          background:
+            'linear-gradient(90deg, rgb(12,7,134), rgb(75,3,161), rgb(125,3,168), rgb(203,71,119), rgb(248,149,64), rgb(240,249,33))',
+        }}
+      />
+      <div className="mt-1 flex justify-between text-[10px] text-muted-foreground">
+        <span>{min} dBm</span>
+        <span>{max} dBm</span>
+      </div>
+    </div>
+  );
+}
+
+function rssiColor(value: number, min: number, max: number): string {
+  const t = Math.max(0, Math.min(1, (value - min) / Math.max(max - min, 1)));
+  const stops = [
+    [12, 7, 134],
+    [75, 3, 161],
+    [125, 3, 168],
+    [203, 71, 119],
+    [248, 149, 64],
+    [240, 249, 33],
+  ];
+  const pos = t * (stops.length - 1);
+  const i = Math.min(stops.length - 2, Math.floor(pos));
+  const local = pos - i;
+  const a = stops[i];
+  const b = stops[i + 1];
+  const rgb = a.map((v, idx) => Math.round(v + (b[idx] - v) * local));
+  return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+}
+
+function extractEvaluationResponse(run: CalibrationRun | null): CalibrationEvaluationResponse | null {
+  const value = run?.error_metrics_json?.['evaluation_response'];
+  if (!value || typeof value !== 'object') return null;
+  return value as CalibrationEvaluationResponse;
 }
 
 function MetricCell({

--- a/frontend/src/hooks/use-calibration-run.ts
+++ b/frontend/src/hooks/use-calibration-run.ts
@@ -7,6 +7,7 @@ import type { UUID } from '@/types/common';
 import type {
   CalibrationRun,
   CalibrationRunCreateRequest,
+  CalibrationEvaluationRequest,
 } from '@/types/calibration-run';
 import { isJobFailed, isJobSucceeded, isJobTerminal } from '@/types/job';
 
@@ -24,6 +25,22 @@ export function useCreateCalibrationRun() {
     onError: (err) => {
       const e = err as HttpError | null;
       toast.error('시뮬레이션 보정 요청 실패', e?.message ?? '잠시 후 다시 시도해주세요.');
+    },
+  });
+}
+
+export function useEvaluateCalibrationRun() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CalibrationEvaluationRequest) => calibrationRunApi.evaluate(body),
+    onSuccess: (result) => {
+      qc.invalidateQueries({ queryKey: ['calibration-run'] });
+      toast.success('Calibration evaluation complete', 'Validation metrics and 3-way maps are ready.');
+      return result;
+    },
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error('Calibration evaluation failed', e?.message ?? 'Please check RF map and measurement points.');
     },
   });
 }

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -38,12 +38,12 @@ import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import {
+  useEvaluateCalibrationRun,
   useCalibrationParameterUpdates,
   useCalibrationRun,
-  useCreateCalibrationRun,
 } from '@/hooks/use-calibration-run';
 import { CalibrationCard } from '@/features/calibration/CalibrationCard';
-import type { SpaceType } from '@/types/calibration-run';
+import type { CalibrationEvaluationResponse, SpaceType } from '@/types/calibration-run';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import {
   MeasurementCanvas,
@@ -174,8 +174,10 @@ export default function MeasurementPage() {
 
   // §11 캘리브레이션 — 현재 측정 세션 + 최근 RF Run + 현재 버전을 입력으로 사용.
   // 측정 페이지에 둠: 진단 카드에서 차이를 발견한 직후 보정 가능.
-  const createCalibration = useCreateCalibrationRun();
+  const evaluateCalibration = useEvaluateCalibrationRun();
   const [activeCalibrationId, setActiveCalibrationId] = useState<string | null>(null);
+  const [calibrationEvaluation, setCalibrationEvaluation] =
+    useState<CalibrationEvaluationResponse | null>(null);
   const calibrationPoll = useCalibrationRun(activeCalibrationId);
   const paramUpdatesQuery = useCalibrationParameterUpdates(
     activeCalibrationId,
@@ -200,17 +202,30 @@ export default function MeasurementPage() {
     : null;
   const handleCalibrate = () => {
     if (!canCalibrate || !activeSession || !latestRfRunId || !currentVersion) return;
-    createCalibration.mutate(
+    evaluateCalibration.mutate(
       {
-        session_id: activeSession.id,
+        floor_id: activeSession.floor_id,
         rf_run_id: latestRfRunId,
-        version_id: currentVersion.id,
-        // 사용자가 선택한 공간 유형 — backend 가 soft prior 로 사용. 'unknown' 도 전송 OK.
-        space_type: spaceType,
+        scene_version_id: currentVersion.id,
+        measurement_session_ids: [activeSession.id],
+        method: 'global_offset',
+        split: { strategy: 'purpose_or_random', holdout_ratio: 0.3, seed: 42 },
+        visualization: {
+          include_reference_map: true,
+          reference_map_method: 'idw',
+          rssi_min_dbm: -90,
+          rssi_max_dbm: -30,
+        },
       },
-      { onSuccess: (run) => setActiveCalibrationId(run.id) },
+      {
+        onSuccess: (result) => {
+          setActiveCalibrationId(result.calibration_run_id);
+          setCalibrationEvaluation(result);
+        },
+      },
     );
   };
+
 
   return (
     <div className="relative flex h-full flex-col gap-5 p-6">
@@ -283,13 +298,15 @@ export default function MeasurementPage() {
             <CalibrationCard
               run={calibrationPoll.run}
               isPolling={calibrationPoll.isPolling}
-              isStarting={createCalibration.isPending}
+              isStarting={evaluateCalibration.isPending}
               canCalibrate={canCalibrate}
               disabledReason={calibrationDisabledReason}
               spaceType={spaceType}
               onSpaceTypeChange={setSpaceTypeOverride}
               onCalibrate={handleCalibrate}
               parameterUpdates={paramUpdatesQuery.data ?? []}
+              evaluation={calibrationEvaluation}
+              backgroundImageUrl={backgroundImageUrl}
             />
             <CauseAnalysisCard
               hasData={hasMeasurement}

--- a/frontend/src/types/calibration-run.ts
+++ b/frontend/src/types/calibration-run.ts
@@ -32,6 +32,70 @@ export interface CalibrationRun {
   finished_at: ISODateString | null;
 }
 
+export type MeasurementPurpose = 'calibration' | 'validation' | 'reference' | 'unknown';
+
+export interface CalibrationEvaluationRequest {
+  floor_id: UUID;
+  scene_version_id: UUID;
+  rf_run_id: UUID;
+  measurement_session_ids: UUID[];
+  method?: 'global_offset';
+  split?: {
+    strategy: 'purpose_or_random' | 'random';
+    holdout_ratio: number;
+    seed: number;
+  };
+  visualization?: {
+    include_reference_map: boolean;
+    reference_map_method: 'idw';
+    rssi_min_dbm: number;
+    rssi_max_dbm: number;
+  };
+}
+
+export interface CalibrationEvaluationPoint {
+  point_id: UUID;
+  session_id: UUID;
+  x_m: number;
+  y_m: number;
+  rssi_dbm: number;
+  measurement_purpose: MeasurementPurpose;
+  split: MeasurementPurpose;
+  baseline_pred_dbm?: number;
+  calibrated_pred_dbm?: number;
+  baseline_error_db?: number;
+  calibrated_error_db?: number;
+  invalid_reason?: string;
+}
+
+export interface CalibrationEvaluationMap {
+  label: string;
+  values_dbm: number[][];
+  bounds_m: { min_x: number; min_y: number; max_x: number; max_y: number };
+  method?: string;
+  offset_db?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CalibrationEvaluationResponse {
+  calibration_run_id: UUID;
+  status: string;
+  maps: {
+    baseline: CalibrationEvaluationMap;
+    calibrated: CalibrationEvaluationMap;
+    measured_reference?: CalibrationEvaluationMap;
+  };
+  color_scale: { min_dbm: number; max_dbm: number };
+  points: {
+    calibration: CalibrationEvaluationPoint[];
+    validation: CalibrationEvaluationPoint[];
+    reference: CalibrationEvaluationPoint[];
+    invalid: CalibrationEvaluationPoint[];
+  };
+  metrics: Record<string, number>;
+  evaluation: Record<string, unknown>;
+}
+
 export interface CalibrationRunCreateRequest {
   session_id: UUID;
   rf_run_id: UUID;

--- a/frontend/src/types/measurement-session.ts
+++ b/frontend/src/types/measurement-session.ts
@@ -3,6 +3,7 @@ import type { ISODateString, UUID } from './common';
 // §10 실측 세션 / 포인트 — 백엔드 schemas/measurement.py 응답과 정합.
 
 export type MeasurementSessionStatus = 'in_progress' | 'completed' | string;
+export type MeasurementPurpose = 'calibration' | 'validation' | 'reference' | 'unknown';
 
 export interface MeasurementSession {
   id: UUID;
@@ -11,6 +12,7 @@ export interface MeasurementSession {
   scene_version_id: UUID | null;
   asset_id: UUID | null;
   measurement_type: string;
+  measurement_purpose: MeasurementPurpose;
   status: MeasurementSessionStatus;
   created_at: ISODateString;
 }
@@ -28,6 +30,7 @@ export interface MeasurementPoint {
   batch_id: string | null;
   floor_position: FloorPosition;
   rssi_dbm: number | null;
+  measurement_purpose: MeasurementPurpose | null;
   ap_bssid: string | null;
   ap_ssid: string | null;
   channel: number | null;


### PR DESCRIPTION
## 개요
- 와이파이 실측 보정 효과를 검증하기 위한 평가 파이프라인 구현
- 측정 데이터에 `measurement_purpose`를 추가하여 보정용/검증용/참조용 실측 데이터를 구분할 수 있도록 했고, RF/Sionna 예측 맵과 실제 측정값을 비교해 global offset 기반 보정을 수행하는 API를 추가
- 또한 보정 전 시뮬레이션 맵, 보정 후 맵, 실측 기반 참조맵을 세가지 RSSI map 형태로 비교할 수 있는 프론트 UI 추가

<img width="1894" height="1219" alt="스크린샷 2026-05-29 165525" src="https://github.com/user-attachments/assets/177ddade-3812-4a53-8650-1685c9ce3917" />


## 변경 사항
### backend
- `measurement_sessions`, `measurement_points`에 measurement_purpose 필드 추가 (calibration, validation, reference, unknown)
- Alembic migration 추가
    - `measurement_sessions.measurement_purpose`
    - `measurement_points.measurement_purpose`
- 측정 관련 DTO 확장
    -  `recommended_measurement_purpose` 
- `/calibration-runs/evaluate API` 추가
    - RF run의 `radio_map.values_dbm`에서 측정점 위치의 baseline RSSI를 샘플링
    - measurement purpose 기반으로 calibration/validation/reference point 분리
    - purpose가 명시되지 않은 경우 deterministic random split fallback 지원
    - calibration point만 사용해 global offset 계산
    - validation point 기준 MAE/RMSE/bias 및 개선량 계산
    - IDW 기반 measured reference map 생성
    - baseline/calibrated/measured reference 3-way map payload 반환
- CalibrationRun.metrics_json에 평가 결과 저장

### Frontend
- calibration evaluation API client 추가
    - `POST /calibration-runs/evaluate`
- React Query mutation 추가
    - calibration evaluation 요청
    - 성공/실패 toast 처리
- 측정 페이지에서 보정 평가 실행 연결 (현재 floor, 현재 scene version, 최신 RF run, 현재 measurement session)
    - fixed RSSI color scale -90 ~ -30 dBm
- `CalibrationCard`에 3-way RSSI map comparison UI 추가
- Validation metrics 표시 (보정 전 MAE/RMSE, 보정 후 MAE/RMSE, 개선량)
- Validation point별 오차 테이블 추가 (measured RSSI, baseline prediction, calibrated prediction, before error, after error)
- Detail modal 추가
    - 3-way map을 크게 확인
    - validation point error table 확인
    - calibration/validation point legend 표시
