### PR TITLE
[Feat] 실측 RSSI 기반 예측 보정 및 3-way RSSI 비교 맵 추가

### DIFF
--- a/backend/app/routers/rf/measurements.py
+++ b/backend/app/routers/rf/measurements.py
@@ -30,9 +30,14 @@ router = APIRouter(tags=["measurement"])
 )
 def create_measurement_link(
     floor_id: str,
+    recommended_measurement_purpose: str = Query("calibration"),
     db: Session = Depends(get_db),
 ) -> MeasurementLinkCreateResponseDTO:
-    return measurement_service.create_measurement_link(db, floor_id)
+    return measurement_service.create_measurement_link(
+        db,
+        floor_id,
+        recommended_measurement_purpose=recommended_measurement_purpose,
+    )
 
 
 @router.get(

--- a/backend/app/schemas/rf/calibration_run.py
+++ b/backend/app/schemas/rf/calibration_run.py
@@ -53,7 +53,7 @@ class CalibrationEvaluationRequest(BaseModel):
     scene_version_id: UUID
     rf_run_id: UUID
     measurement_session_ids: list[UUID] = Field(default_factory=list, min_length=1)
-    method: Literal["global_offset"] = "global_offset"
+    method: Literal["affine_rssi_transfer", "global_offset"] = "affine_rssi_transfer"
     split: CalibrationEvaluationSplit = Field(default_factory=CalibrationEvaluationSplit)
     visualization: CalibrationEvaluationVisualization = Field(
         default_factory=CalibrationEvaluationVisualization

--- a/backend/app/schemas/rf/rf_run.py
+++ b/backend/app/schemas/rf/rf_run.py
@@ -80,8 +80,8 @@ class RfRunCreate(BaseModel):
     simulation: Optional[RfSimulationParams] = None
     metadata: Optional[dict[str, Any]] = None
     # 해당 scene_version 의 최신 completed CalibrationRun 보정값을 시뮬에 반영할지 (#88).
-    # true(기본): 보정 적용 / false: raw 시뮬 (보정 전후 비교용).
-    apply_calibration: bool = True
+    # 기본은 raw 시뮬레이션이다. 보정 후 재실행처럼 의도가 명확한 요청만 true 로 보낸다.
+    apply_calibration: bool = False
     # 시뮬 실행 백엔드 선택. sagemaker(기본)=클라우드 async, local=로컬 ai_api 직접 호출.
     backend: RfBackend = "sagemaker"
     # 옛 호출자 호환 (deprecated)

--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -35,6 +35,10 @@ from app.core.geom import wkb_to_geojson
 
 JOB_TYPE_CALIBRATION = "calibration"
 ALLOWED_CALIBRATION_STATUS = {"queued", "running", "completed", "failed"}
+# MVP defaults for the local residual layer. Keep these in one place so the
+# map computation and response metadata cannot drift.
+RESIDUAL_IDW_RADIUS_M = 6.0
+RESIDUAL_IDW_WEIGHT = 0.6
 
 
 # ---------------------------------------------------------------------------
@@ -528,7 +532,7 @@ def _idw_residual_at(
     residual_points: list[tuple[float, float, float]],
     *,
     power: float = 2.0,
-    radius_m: float | None = 6.0,
+    radius_m: float | None = RESIDUAL_IDW_RADIUS_M,
 ) -> float:
     numerator = 0.0
     denominator = 0.0
@@ -562,9 +566,8 @@ def _hybrid_calibrated_value(
     residual_points: list[tuple[float, float, float]],
 ) -> float:
     transfer_value = _apply_rssi_transfer(baseline_dbm, transfer)
-    residual_weight = 0.6
     residual = _idw_residual_at(x, y, residual_points)
-    return transfer_value + residual_weight * residual
+    return transfer_value + RESIDUAL_IDW_WEIGHT * residual
 
 
 def _calibrated_map(
@@ -820,8 +823,8 @@ def evaluate_calibration_run(
                 "intercept_db": round(float(rssi_transfer["intercept"]), 6),
                 "mean_offset_db": round(offset_db, 6),
                 "residual_method": "idw",
-                "residual_weight": 0.6,
-                "residual_radius_m": 6.0,
+                "residual_weight": RESIDUAL_IDW_WEIGHT,
+                "residual_radius_m": RESIDUAL_IDW_RADIUS_M,
                 "residual_point_count": len(residual_points),
                 "purpose": "First matches the simulated RSSI scale to phone measurements, then blends local residuals with IDW.",
             },
@@ -860,8 +863,8 @@ def evaluate_calibration_run(
             "intercept_db": round(float(rssi_transfer["intercept"]), 4),
             "mean_offset_db": round(offset_db, 4),
             "residual_method": "idw",
-            "residual_weight": 0.6,
-            "residual_radius_m": 6.0,
+            "residual_weight": RESIDUAL_IDW_WEIGHT,
+            "residual_radius_m": RESIDUAL_IDW_RADIUS_M,
             "equivalent_tx_power_offset_db": round(offset_db, 4),
         },
         "rf_physical": rf_physical,

--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -267,6 +267,7 @@ class _EvalPoint:
     measured_rssi_dbm: float
     purpose: str
     split: str
+    frequency_mhz: int | None = None
     baseline_pred_dbm: float | None = None
     calibrated_pred_dbm: float | None = None
     invalid_reason: str | None = None
@@ -393,6 +394,7 @@ def _split_points(
                 measured_rssi_dbm=float(p.rssi_dbm),
                 purpose=purpose,
                 split=split,
+                frequency_mhz=p.frequency_mhz,
             )
         )
 
@@ -484,11 +486,146 @@ def _evaluation_points_for_metrics(points: list[_EvalPoint]) -> tuple[list[_Eval
     ]
 
 
-def _calibrated_map(values: list[list[float]], offset_db: float) -> list[list[float]]:
-    return [
-        [float(v) + offset_db if math.isfinite(float(v)) else float(v) for v in row]
-        for row in values
+def _fit_rssi_transfer(points: list[_EvalPoint]) -> dict[str, float]:
+    pairs = [
+        (float(p.baseline_pred_dbm), float(p.measured_rssi_dbm))
+        for p in points
+        if p.baseline_pred_dbm is not None
     ]
+    if not pairs:
+        return {"slope": 1.0, "intercept": 0.0, "mean_offset_db": 0.0}
+
+    xs = [p[0] for p in pairs]
+    ys = [p[1] for p in pairs]
+    mean_x = sum(xs) / len(xs)
+    mean_y = sum(ys) / len(ys)
+    mean_offset = mean_y - mean_x
+    var_x = sum((x - mean_x) ** 2 for x in xs)
+    if len(pairs) < 2 or var_x < 1e-6:
+        return {"slope": 1.0, "intercept": mean_offset, "mean_offset_db": mean_offset}
+
+    cov_xy = sum((x - mean_x) * (y - mean_y) for x, y in pairs)
+    raw_slope = cov_xy / var_x
+    # Indoor phone RSSI often has a much smaller dynamic range than raw RF maps.
+    # Keep the transfer monotonic and avoid amplifying the original contrast.
+    slope = min(1.0, max(0.05, raw_slope))
+    intercept = mean_y - slope * mean_x
+    return {
+        "slope": slope,
+        "intercept": intercept,
+        "mean_offset_db": mean_offset,
+        "raw_slope": raw_slope,
+    }
+
+
+def _apply_rssi_transfer(value_dbm: float, transfer: dict[str, float]) -> float:
+    return float(transfer["slope"]) * value_dbm + float(transfer["intercept"])
+
+
+def _idw_residual_at(
+    x: float,
+    y: float,
+    residual_points: list[tuple[float, float, float]],
+    *,
+    power: float = 2.0,
+    radius_m: float | None = 6.0,
+) -> float:
+    numerator = 0.0
+    denominator = 0.0
+    nearest_dist = math.inf
+    for px, py, residual in residual_points:
+        dist = math.hypot(x - px, y - py)
+        nearest_dist = min(nearest_dist, dist)
+        if dist < 1e-6:
+            return residual
+        if radius_m is not None and dist > radius_m:
+            continue
+        weight = 1.0 / (dist ** power)
+        numerator += weight * residual
+        denominator += weight
+    if denominator <= 0:
+        return 0.0
+    residual = numerator / denominator
+    if radius_m is None:
+        return residual
+    # Fade residual influence near the search-radius edge to avoid painting
+    # unmeasured distant areas too aggressively.
+    fade = max(0.0, min(1.0, 1.0 - nearest_dist / radius_m))
+    return residual * fade
+
+
+def _hybrid_calibrated_value(
+    baseline_dbm: float,
+    x: float,
+    y: float,
+    transfer: dict[str, float],
+    residual_points: list[tuple[float, float, float]],
+) -> float:
+    transfer_value = _apply_rssi_transfer(baseline_dbm, transfer)
+    residual_weight = 0.6
+    residual = _idw_residual_at(x, y, residual_points)
+    return transfer_value + residual_weight * residual
+
+
+def _calibrated_map(
+    radio_map: _RadioMap,
+    transfer: dict[str, float],
+    residual_points: list[tuple[float, float, float]],
+) -> list[list[float]]:
+    values = radio_map.values
+    height = radio_map.height
+    width = radio_map.width
+    return [
+        [
+            _hybrid_calibrated_value(
+                float(v),
+                radio_map.min_x if width == 1 else radio_map.min_x + (radio_map.max_x - radio_map.min_x) * col_idx / (width - 1),
+                radio_map.min_y if height == 1 else radio_map.min_y + (radio_map.max_y - radio_map.min_y) * row_idx / (height - 1),
+                transfer,
+                residual_points,
+            )
+            if math.isfinite(float(v))
+            else float(v)
+            for col_idx, v in enumerate(row)
+        ]
+        for row_idx, row in enumerate(values)
+    ]
+
+
+def _measurement_frequency_summary(points: list[_EvalPoint]) -> dict[str, Any]:
+    freqs = [int(p.frequency_mhz) for p in points if p.frequency_mhz is not None and p.frequency_mhz > 0]
+    if not freqs:
+        return {"available": False, "message": "No measurement frequency_mhz values were uploaded."}
+    bands = {
+        "2.4GHz": sum(1 for f in freqs if 2400 <= f < 2500),
+        "5GHz": sum(1 for f in freqs if 4900 <= f < 5900),
+        "6GHz": sum(1 for f in freqs if 5925 <= f < 7125),
+        "other": sum(1 for f in freqs if not (2400 <= f < 2500 or 4900 <= f < 5900 or 5925 <= f < 7125)),
+    }
+    dominant_band = max(bands, key=lambda k: bands[k])
+    avg_mhz = sum(freqs) / len(freqs)
+    return {
+        "available": True,
+        "point_count": len(freqs),
+        "avg_frequency_mhz": round(avg_mhz, 1),
+        "dominant_band": dominant_band,
+        "bands": bands,
+    }
+
+
+def _rf_physical_summary(rf_run: RfRun) -> dict[str, Any]:
+    request_sim = (rf_run.request_json or {}).get("simulation") or {}
+    radio_map = (rf_run.metrics_json or {}).get("radio_map") or {}
+    physical = radio_map.get("physical") or radio_map.get("config", {}).get("physical") or {}
+    frequency_hz = request_sim.get("frequency_hz")
+    frequency_ghz = physical.get("frequency_ghz")
+    if frequency_ghz is None and frequency_hz is not None:
+        frequency_ghz = float(frequency_hz) / 1e9
+    tx_power_dbm = physical.get("tx_power_dbm", request_sim.get("tx_power_dbm"))
+    return {
+        "frequency_ghz": float(frequency_ghz) if frequency_ghz is not None else None,
+        "tx_power_dbm": float(tx_power_dbm) if tx_power_dbm is not None else None,
+    }
 
 
 def _idw_reference_map(radio_map: _RadioMap, points: list[_EvalPoint]) -> list[list[float]]:
@@ -526,6 +663,8 @@ def _point_payload(p: _EvalPoint) -> dict[str, Any]:
         "measurement_purpose": p.purpose,
         "split": p.split,
     }
+    if p.frequency_mhz is not None:
+        payload["frequency_mhz"] = p.frequency_mhz
     if p.baseline_pred_dbm is not None:
         payload["baseline_pred_dbm"] = p.baseline_pred_dbm
         payload["baseline_error_db"] = abs(p.baseline_pred_dbm - p.measured_rssi_dbm)
@@ -591,10 +730,30 @@ def evaluate_calibration_run(
             "No valid calibration points remain after radio map sampling.",
             400,
         )
-    offset_db = sum(p.measured_rssi_dbm - float(p.baseline_pred_dbm) for p in valid_calibration) / len(valid_calibration)
+    rssi_transfer = _fit_rssi_transfer(valid_calibration)
+    residual_points = [
+        (
+            p.x_m,
+            p.y_m,
+            p.measured_rssi_dbm - _apply_rssi_transfer(float(p.baseline_pred_dbm), rssi_transfer),
+        )
+        for p in valid_calibration
+        if p.baseline_pred_dbm is not None
+    ]
+    offset_db = float(rssi_transfer["mean_offset_db"])
     calibrated_points: list[_EvalPoint] = []
     for p in sampled:
-        calibrated_pred = p.baseline_pred_dbm + offset_db if p.baseline_pred_dbm is not None else None
+        calibrated_pred = (
+            _hybrid_calibrated_value(
+                float(p.baseline_pred_dbm),
+                p.x_m,
+                p.y_m,
+                rssi_transfer,
+                residual_points,
+            )
+            if p.baseline_pred_dbm is not None
+            else None
+        )
         calibrated_points.append(
             _EvalPoint(
                 **{
@@ -646,8 +805,8 @@ def evaluate_calibration_run(
             },
         },
         "calibrated": {
-            "label": "Calibrated Simulation",
-            "values_dbm": _calibrated_map(radio_map.values, offset_db),
+            "label": "Calibrated Simulation (Transfer + Residual IDW)",
+            "values_dbm": _calibrated_map(radio_map, rssi_transfer, residual_points),
             "bounds_m": {
                 "min_x": radio_map.min_x,
                 "min_y": radio_map.min_y,
@@ -655,6 +814,17 @@ def evaluate_calibration_run(
                 "max_y": radio_map.max_y,
             },
             "offset_db": offset_db,
+            "metadata": {
+                "method": "affine_rssi_transfer_plus_residual_idw",
+                "slope": round(float(rssi_transfer["slope"]), 6),
+                "intercept_db": round(float(rssi_transfer["intercept"]), 6),
+                "mean_offset_db": round(offset_db, 6),
+                "residual_method": "idw",
+                "residual_weight": 0.6,
+                "residual_radius_m": 6.0,
+                "residual_point_count": len(residual_points),
+                "purpose": "First matches the simulated RSSI scale to phone measurements, then blends local residuals with IDW.",
+            },
         },
     }
     if measured_reference is not None:
@@ -668,9 +838,34 @@ def evaluate_calibration_run(
         "metric_point_source": metric_point_source,
         "n_invalid_points": len(invalid_points),
     }
+    frequency_summary = _measurement_frequency_summary(calibrated_points)
+    rf_physical = _rf_physical_summary(rr)
+    if frequency_summary.get("available") and rf_physical.get("frequency_ghz") is not None:
+        measured_band = str(frequency_summary.get("dominant_band"))
+        rf_band = "2.4GHz" if 2.3 <= float(rf_physical["frequency_ghz"]) < 2.6 else (
+            "5GHz" if 4.9 <= float(rf_physical["frequency_ghz"]) < 5.9 else (
+                "6GHz" if 5.925 <= float(rf_physical["frequency_ghz"]) < 7.125 else "other"
+            )
+        )
+        if measured_band != "other" and measured_band != rf_band:
+            warnings.append(
+                f"Measured Wi-Fi band is mostly {measured_band}, but RF simulation used {rf_physical['frequency_ghz']:.2f}GHz ({rf_band})."
+            )
     evaluation = {
         "split": split_meta,
-        "calibration": {"method": payload.method, "offset_db": round(offset_db, 4)},
+        "calibration": {
+            "method": "affine_rssi_transfer_plus_residual_idw",
+            "offset_db": round(offset_db, 4),
+            "slope": round(float(rssi_transfer["slope"]), 4),
+            "intercept_db": round(float(rssi_transfer["intercept"]), 4),
+            "mean_offset_db": round(offset_db, 4),
+            "residual_method": "idw",
+            "residual_weight": 0.6,
+            "residual_radius_m": 6.0,
+            "equivalent_tx_power_offset_db": round(offset_db, 4),
+        },
+        "rf_physical": rf_physical,
+        "measurement_frequency": frequency_summary,
         "visualization": {
             "map_type": "three_way_comparison",
             "reference_map_method": payload.visualization.reference_map_method,

--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -360,7 +360,7 @@ def _split_points(
         )
 
     has_explicit_split = strategy == "purpose_or_random" and any(
-        purpose in {"calibration", "validation"} for _, purpose in rows
+        purpose in {"calibration", "validation", "reference"} for _, purpose in rows
     )
     split_by_id: dict[str, str] = {}
     if has_explicit_split:
@@ -398,10 +398,9 @@ def _split_points(
 
     calibration_count = sum(1 for p in result if p.split == "calibration")
     validation_count = sum(1 for p in result if p.split == "validation")
+    reference_count = sum(1 for p in result if p.split == "reference")
     if calibration_count == 0:
         raise AppError(ErrorCode.INVALID_REQUEST_BODY, "No calibration points available.", 400)
-    if validation_count == 0:
-        raise AppError(ErrorCode.INVALID_REQUEST_BODY, "No validation points available.", 400)
 
     return result, {
         "strategy": strategy,
@@ -411,6 +410,7 @@ def _split_points(
         "n_total_points": len(result),
         "n_calibration_points": calibration_count,
         "n_validation_points": validation_count,
+        "n_reference_points": reference_count,
     }
 
 
@@ -438,7 +438,7 @@ def _calc_metrics(points: list[_EvalPoint]) -> dict[str, float]:
     if not baseline_errors or not calibrated_errors:
         raise AppError(
             ErrorCode.INVALID_REQUEST_BODY,
-            "No valid validation points remain after radio map sampling.",
+            "No valid evaluation/reference points remain after radio map sampling.",
             400,
         )
 
@@ -460,6 +460,28 @@ def _calc_metrics(points: list[_EvalPoint]) -> dict[str, float]:
         "rmse_improvement_db": baseline_rmse - calibrated_rmse,
         "mae_improvement_ratio": (baseline_mae - calibrated_mae) / baseline_mae if baseline_mae else 0.0,
     }
+
+
+def _evaluation_points_for_metrics(points: list[_EvalPoint]) -> tuple[list[_EvalPoint], str, list[str]]:
+    """Pick comparison points without forcing a separate validation purpose.
+
+    Priority:
+    1. validation points, for backward compatibility with the old 3-way split.
+    2. reference points, the new presentation-oriented measured reference data.
+    3. calibration points, as a last-resort local demo fallback. This is not a
+       leak-free holdout metric, so a warning is returned with the response.
+    """
+    valid = [p for p in points if p.baseline_pred_dbm is not None]
+    validation = [p for p in valid if p.split == "validation"]
+    if validation:
+        return validation, "validation", []
+    reference = [p for p in valid if p.split == "reference"]
+    if reference:
+        return reference, "reference", []
+    calibration = [p for p in valid if p.split == "calibration"]
+    return calibration, "calibration", [
+        "No reference/evaluation points were available, so metrics were computed on calibration points. Use separate reference measurements for presentation."
+    ]
 
 
 def _calibrated_map(values: list[list[float]], offset_db: float) -> list[list[float]]:
@@ -569,13 +591,6 @@ def evaluate_calibration_run(
             "No valid calibration points remain after radio map sampling.",
             400,
         )
-    if not valid_validation:
-        raise AppError(
-            ErrorCode.INVALID_REQUEST_BODY,
-            "No valid validation points remain after radio map sampling.",
-            400,
-        )
-
     offset_db = sum(p.measured_rssi_dbm - float(p.baseline_pred_dbm) for p in valid_calibration) / len(valid_calibration)
     calibrated_points: list[_EvalPoint] = []
     for p in sampled:
@@ -592,7 +607,8 @@ def evaluate_calibration_run(
     validation_points = [
         p for p in calibrated_points if p.split == "validation" and p.baseline_pred_dbm is not None
     ]
-    metrics = _calc_metrics(validation_points)
+    metric_points, metric_point_source, metric_warnings = _evaluation_points_for_metrics(calibrated_points)
+    metrics = _calc_metrics(metric_points)
     rounded_metrics = {k: round(v, 4) for k, v in metrics.items()}
 
     reference_points = [p for p in calibrated_points if p.split == "reference"]
@@ -602,7 +618,7 @@ def evaluate_calibration_run(
         ]
     reference_points = [p for p in reference_points if p.invalid_reason is None]
     measured_reference: dict[str, Any] | None = None
-    warnings: list[str] = []
+    warnings: list[str] = [*metric_warnings]
     if payload.visualization.include_reference_map:
         if len(reference_points) < 3:
             warnings.append("Measured reference map skipped because fewer than 3 valid reference points are available.")
@@ -648,6 +664,8 @@ def evaluate_calibration_run(
     split_meta = {
         **split_meta,
         "n_reference_points": len(reference_points),
+        "n_metric_points": len(metric_points),
+        "metric_point_source": metric_point_source,
         "n_invalid_points": len(invalid_points),
     }
     evaluation = {
@@ -659,6 +677,7 @@ def evaluate_calibration_run(
             "rssi_min_dbm": payload.visualization.rssi_min_dbm,
             "rssi_max_dbm": payload.visualization.rssi_max_dbm,
             "reference_map_is_visual_only": True,
+            "metric_point_source": metric_point_source,
             "warnings": warnings,
         },
         "metrics": rounded_metrics,
@@ -675,6 +694,7 @@ def evaluate_calibration_run(
         "points": {
             "calibration": [_point_payload(p) for p in calibrated_points if p.split == "calibration"],
             "validation": [_point_payload(p) for p in validation_points],
+            "evaluation": [_point_payload(p) for p in metric_points],
             "reference": [_point_payload(p) for p in reference_points],
             "invalid": [_point_payload(p) for p in invalid_points],
         },

--- a/backend/app/services/rf/calibration_worker/apply.py
+++ b/backend/app/services/rf/calibration_worker/apply.py
@@ -1,16 +1,16 @@
-"""calibration best_params 를 RF 시뮬 입력(scene_json/simulation)에 반영 (#88).
+"""Apply calibration parameters to a Sionna RT RF input.
 
-SageMaker RF 컨테이너는 correction_profile 필드를 안 받으므로, 보정값을
-scene/simulation 값에 미리 녹여서(mutation) 전달한다. 컨테이너 수정 불필요.
+The calibration worker uses a fast surrogate path-loss model to estimate several
+parameters. Not every surrogate parameter is a valid Sionna RT knob. For the
+physical rerun we intentionally apply only parameters that map cleanly to the
+Sionna input:
 
-SageMaker 경로에서 표현 가능한 보정 (4개 중 2개, 고영향):
-  - 재질 attenuation_scale → wall thickness 에 곱함
-      (공용 런타임 수식 effective_thickness = geometric × scale 와 동일 효과)
-  - tx_power_offset_db     → simulation.tx_power_dbm 에 더함
+- material attenuation scale -> effective wall thickness scale
+- tx_power_offset_db -> bounded simulation.tx_power_dbm adjustment
 
-표현 불가 (컨테이너 하드코딩, 저영향 — 추후 컨테이너가 correction_profile 지원하면 추가):
-  - floor_thickness_m
-  - furniture_default_thickness_m
+Surrogate-only parameters such as path_loss_exp, floor_thickness_m, and
+furniture_default_thickness_m are kept in metrics for diagnosis, but are not
+forced into the Sionna scene.
 """
 from __future__ import annotations
 
@@ -21,12 +21,19 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.calibration_run import CalibrationRun
+from app.models.floor import Floor
+from app.models.scene_version import SceneVersion
 
 logger = logging.getLogger(__name__)
 
 
-# calibration material key → scene.json (Sionna) material key.
-# scene_version_export 의 MATERIAL_ALIAS 와 일치해야 함 (drywall→plasterboard 등).
+MIN_SIONNA_TX_POWER_DBM = 10.0
+MAX_SIONNA_TX_POWER_DBM = 23.0
+MIN_SIONNA_WALL_SCALE = 0.7
+MAX_SIONNA_WALL_SCALE = 2.0
+DEFAULT_TX_POWER_DBM = 20.0
+
+
 _CALIB_TO_SIONNA: dict[str, str] = {
     "drywall": "plasterboard",
     "concrete": "concrete",
@@ -37,11 +44,17 @@ _CALIB_TO_SIONNA: dict[str, str] = {
 _SIONNA_TO_CALIB: dict[str, str] = {v: k for k, v in _CALIB_TO_SIONNA.items()}
 
 
-def get_latest_calibration(
-    db: Session, scene_version_id: str
-) -> CalibrationRun | None:
-    """해당 scene_version 의 가장 최근 completed CalibrationRun. 없으면 None."""
-    return db.execute(
+def _clamp(value: float, low: float, high: float) -> float:
+    return min(high, max(low, value))
+
+
+def _has_best_params(run: CalibrationRun | None) -> bool:
+    return bool(run and (run.metrics_json or {}).get("best_params"))
+
+
+def get_latest_calibration(db: Session, scene_version_id: str) -> CalibrationRun | None:
+    """Return latest completed calibration for this scene, then same project/space type."""
+    exact = db.execute(
         select(CalibrationRun)
         .where(
             CalibrationRun.scene_version_id == str(scene_version_id),
@@ -50,6 +63,35 @@ def get_latest_calibration(
         .order_by(CalibrationRun.created_at.desc())
         .limit(1)
     ).scalar_one_or_none()
+    if _has_best_params(exact):
+        return exact
+
+    target = db.execute(
+        select(SceneVersion, Floor)
+        .join(Floor, SceneVersion.floor_id == Floor.id)
+        .where(SceneVersion.id == str(scene_version_id))
+    ).first()
+    if target is None:
+        return None
+    sv, floor = target
+    if not floor.space_type:
+        return None
+
+    candidates = db.execute(
+        select(CalibrationRun)
+        .join(Floor, CalibrationRun.floor_id == Floor.id)
+        .where(
+            CalibrationRun.project_id == sv.project_id,
+            CalibrationRun.status == "completed",
+            Floor.space_type == floor.space_type,
+        )
+        .order_by(CalibrationRun.created_at.desc())
+        .limit(10)
+    ).scalars().all()
+    for candidate in candidates:
+        if _has_best_params(candidate):
+            return candidate
+    return None
 
 
 def apply_to_scene_and_sim(
@@ -57,39 +99,65 @@ def apply_to_scene_and_sim(
     simulation: dict[str, Any],
     best_params: dict[str, Any],
 ) -> dict[str, Any]:
-    """scene_json.walls 두께 + simulation.tx_power_dbm 을 보정값으로 in-place 조정.
+    """Mutate scene_json/simulation with bounded physical calibration values."""
+    raw_scales: dict[str, float] = {
+        str(k): float(v)
+        for k, v in (best_params.get("material_attenuation_scales") or {}).items()
+        if v is not None
+    }
+    tx_offset_raw = float(best_params.get("tx_power_offset_db") or 0.0)
 
-    반환: 적용 요약 dict (감사/디버그용). scene_json / simulation 은 직접 수정됨.
-    """
-    scales: dict[str, float] = best_params.get("material_attenuation_scales") or {}
-    tx_offset = float(best_params.get("tx_power_offset_db") or 0.0)
-
-    # 1) 재질별 attenuation_scale → wall thickness 배수
     walls = scene_json.get("walls") or []
     scaled_count = 0
-    for w in walls:
-        sionna_mat = str(w.get("material") or "").lower()
+    applied_scales: dict[str, float] = {}
+    for wall in walls:
+        sionna_mat = str(wall.get("material") or "").lower()
         calib_key = _SIONNA_TO_CALIB.get(sionna_mat, sionna_mat)
-        scale = scales.get(calib_key)
-        if scale is not None and scale > 0:
-            w["thickness"] = float(w.get("thickness") or 0.12) * float(scale)
-            scaled_count += 1
+        if calib_key not in raw_scales:
+            continue
+        raw_scale = raw_scales[calib_key]
+        scale = _clamp(raw_scale, MIN_SIONNA_WALL_SCALE, MAX_SIONNA_WALL_SCALE)
+        wall["thickness"] = float(wall.get("thickness") or 0.12) * scale
+        applied_scales[calib_key] = scale
+        scaled_count += 1
 
-    # tx_power_offset_db 는 Sionna 에 적용하지 않음.
-    # BO 가 찾은 offset 은 단순 path-loss 수식 모델의 오차를 보정한 값이므로,
-    # 이미 물리적으로 정확한 Sionna 레이트레이싱에 그대로 더하면 신호가 크게 낮아짐.
+    base_tx_power = float(simulation.get("tx_power_dbm") or DEFAULT_TX_POWER_DBM)
+    requested_tx_power = base_tx_power + tx_offset_raw
+    calibrated_tx_power = _clamp(
+        requested_tx_power,
+        MIN_SIONNA_TX_POWER_DBM,
+        MAX_SIONNA_TX_POWER_DBM,
+    )
+    simulation["tx_power_dbm"] = calibrated_tx_power
+
     summary = {
+        "application_mode": "bounded_physical_sionna_rerun",
         "walls_scaled": scaled_count,
-        "tx_power_offset_db_applied": 0.0,
-        "material_scales": scales,
-        "unapplied": {
-            "tx_power_offset_db": tx_offset,
+        "tx_power_dbm_before": round(base_tx_power, 4),
+        "tx_power_offset_db_requested": round(tx_offset_raw, 4),
+        "tx_power_dbm_requested": round(requested_tx_power, 4),
+        "tx_power_offset_db_applied": round(calibrated_tx_power - base_tx_power, 4),
+        "tx_power_dbm_after": round(calibrated_tx_power, 4),
+        "tx_power_dbm_bounds": {
+            "min": MIN_SIONNA_TX_POWER_DBM,
+            "max": MAX_SIONNA_TX_POWER_DBM,
+        },
+        "material_scales_requested": raw_scales,
+        "material_scales_applied": applied_scales,
+        "wall_scale_bounds": {
+            "min": MIN_SIONNA_WALL_SCALE,
+            "max": MAX_SIONNA_WALL_SCALE,
+        },
+        "not_applied_to_sionna": {
+            "path_loss_exp": best_params.get("path_loss_exp"),
             "floor_thickness_m": best_params.get("floor_thickness_m"),
             "furniture_default_thickness_m": best_params.get("furniture_default_thickness_m"),
         },
     }
     logger.info(
-        "calibration applied to RF input: %d walls scaled, tx_offset=%.2f",
-        scaled_count, 0.0,
+        "bounded physical calibration applied: walls=%d tx=%.2f->%.2f dBm",
+        scaled_count,
+        base_tx_power,
+        calibrated_tx_power,
     )
     return summary

--- a/backend/app/services/rf/calibration_worker/runner.py
+++ b/backend/app/services/rf/calibration_worker/runner.py
@@ -83,6 +83,31 @@ def _clamp(value: float, low: float, high: float) -> float:
     return min(high, max(low, value))
 
 
+def _intersect_bounds(
+    requested: tuple[float, float],
+    hard_limits: tuple[float, float],
+) -> tuple[float, float]:
+    """Return requested bounds clipped to hard limits, with a safe fallback.
+
+    Space priors are intentionally data/config driven. If a future prior falls
+    fully outside the physical hard limits, a naive intersection can produce an
+    invalid interval such as (0.7, 0.5). In that case use the nearest valid
+    hard-limit edge as a zero-width interval instead of crashing the optimizer.
+    """
+    req_low, req_high = requested
+    hard_low, hard_high = hard_limits
+    low = max(req_low, hard_low)
+    high = min(req_high, hard_high)
+    if low <= high:
+        return (low, high)
+    if req_high < hard_low:
+        return (hard_low, hard_low)
+    if req_low > hard_high:
+        return (hard_high, hard_high)
+    # Defensive fallback for malformed input where requested low/high are reversed.
+    return (hard_low, hard_high)
+
+
 def _build_bo_bounds(space_type: SpaceType) -> list[tuple[float, float]]:
     """공간 유형 prior 기반 BO bounds — _PARAM_NAMES 순서와 1:1.
 
@@ -92,9 +117,9 @@ def _build_bo_bounds(space_type: SpaceType) -> list[tuple[float, float]]:
     return (
         [prior["path_loss_exp_bounds"]]
         + [
-            (
-                max(prior["material_scale_bounds"][m][0], _PHYSICAL_MATERIAL_SCALE_BOUNDS[0]),
-                min(prior["material_scale_bounds"][m][1], _PHYSICAL_MATERIAL_SCALE_BOUNDS[1]),
+            _intersect_bounds(
+                prior["material_scale_bounds"][m],
+                _PHYSICAL_MATERIAL_SCALE_BOUNDS,
             )
             for m in CALIBRATABLE_MATERIALS
         ]

--- a/backend/app/services/rf/calibration_worker/runner.py
+++ b/backend/app/services/rf/calibration_worker/runner.py
@@ -75,6 +75,12 @@ _PARAM_NAMES: list[str] = (
 # 기본 evaluation budget (env override 가능)
 _BO_N_INITIAL = int(os.getenv("CALIBRATION_BO_N_INITIAL", "12"))
 _BO_N_ITER = int(os.getenv("CALIBRATION_BO_N_ITER", "38"))
+_PHYSICAL_TX_OFFSET_BOUNDS = (-8.0, 3.0)
+_PHYSICAL_MATERIAL_SCALE_BOUNDS = (0.7, 2.0)
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return min(high, max(low, value))
 
 
 def _build_bo_bounds(space_type: SpaceType) -> list[tuple[float, float]]:
@@ -85,9 +91,15 @@ def _build_bo_bounds(space_type: SpaceType) -> list[tuple[float, float]]:
     prior = get_prior(space_type)
     return (
         [prior["path_loss_exp_bounds"]]
-        + [prior["material_scale_bounds"][m] for m in CALIBRATABLE_MATERIALS]
         + [
-            (-10.0, 10.0),   # tx_power_offset_db
+            (
+                max(prior["material_scale_bounds"][m][0], _PHYSICAL_MATERIAL_SCALE_BOUNDS[0]),
+                min(prior["material_scale_bounds"][m][1], _PHYSICAL_MATERIAL_SCALE_BOUNDS[1]),
+            )
+            for m in CALIBRATABLE_MATERIALS
+        ]
+        + [
+            _PHYSICAL_TX_OFFSET_BOUNDS,   # tx_power_offset_db
             (0.02, 0.20),    # floor_thickness_m
             (0.02, 0.30),    # furniture_default_thickness_m
         ]
@@ -372,6 +384,19 @@ async def _run_pipeline(db: Session, cr: CalibrationRun, job: Job) -> None:
             "path_loss_exp_bounds": list(prior["path_loss_exp_bounds"]),
             "description": prior["description"],
         },
+        "sionna_physical_application": {
+            "applied_parameters": [
+                "simulation.tx_power_dbm",
+                "scene_json.walls[].thickness",
+            ],
+            "tx_power_offset_bounds_db": list(_PHYSICAL_TX_OFFSET_BOUNDS),
+            "material_scale_bounds": list(_PHYSICAL_MATERIAL_SCALE_BOUNDS),
+            "surrogate_only_parameters": [
+                "physical.path_loss_exp",
+                "scene_defaults.floor_thickness_m",
+                "scene_defaults.furniture_default_thickness_m",
+            ],
+        },
         "feedback_message": _build_feedback_message(
             space_type=space_type,
             baseline_rmse=baseline_metrics.rmse_dbm,
@@ -478,13 +503,21 @@ def _compose_params(prev: CalibrationParams, delta: CalibrationParams) -> Calibr
         | set(CALIBRATABLE_MATERIALS)
     )
     composed_scales = {
-        m: prev.material_attenuation_scales.get(m, 1.0)
-           * delta.material_attenuation_scales.get(m, 1.0)
+        m: _clamp(
+            prev.material_attenuation_scales.get(m, 1.0)
+            * delta.material_attenuation_scales.get(m, 1.0),
+            _PHYSICAL_MATERIAL_SCALE_BOUNDS[0],
+            _PHYSICAL_MATERIAL_SCALE_BOUNDS[1],
+        )
         for m in materials
     }
     return CalibrationParams(
         path_loss_exp=delta.path_loss_exp,
-        tx_power_offset_db=prev.tx_power_offset_db + delta.tx_power_offset_db,
+        tx_power_offset_db=_clamp(
+            prev.tx_power_offset_db + delta.tx_power_offset_db,
+            _PHYSICAL_TX_OFFSET_BOUNDS[0],
+            _PHYSICAL_TX_OFFSET_BOUNDS[1],
+        ),
         floor_thickness_m=delta.floor_thickness_m,
         furniture_default_thickness_m=delta.furniture_default_thickness_m,
         material_attenuation_scales=composed_scales,
@@ -524,46 +557,27 @@ def _write_parameter_updates(
     rows: list[ParameterUpdate] = []
 
     for m in CALIBRATABLE_MATERIALS:
+        scale = round(params.scale_for(m), 3)
+        if abs(scale - baseline.scale_for(m)) < 0.001:
+            continue
         rows.append(ParameterUpdate(
             calibration_run_id=cr.id,
             target_type="scene_version",
             target_id=cr.scene_version_id,
-            parameter_name=f"materials.{m}.attenuation_scale",
+            parameter_name=f"walls.{m}.effective_thickness_scale",
             old_value_json={"value": baseline.scale_for(m)},
-            new_value_json={"value": round(params.scale_for(m), 3)},
+            new_value_json={"value": scale},
         ))
-    rows.append(ParameterUpdate(
-        calibration_run_id=cr.id,
-        target_type="scene_version",
-        target_id=cr.scene_version_id,
-        parameter_name="physical.path_loss_exp",
-        old_value_json={"value": baseline.path_loss_exp},
-        new_value_json={"value": round(params.path_loss_exp, 3)},
-    ))
-    rows.append(ParameterUpdate(
-        calibration_run_id=cr.id,
-        target_type="scene_version",
-        target_id=cr.scene_version_id,
-        parameter_name="physical.tx_power_offset_db",
-        old_value_json={"value": baseline.tx_power_offset_db},
-        new_value_json={"value": round(params.tx_power_offset_db, 3)},
-    ))
-    rows.append(ParameterUpdate(
-        calibration_run_id=cr.id,
-        target_type="scene_version",
-        target_id=cr.scene_version_id,
-        parameter_name="scene_defaults.floor_thickness_m",
-        old_value_json={"value": baseline.floor_thickness_m},
-        new_value_json={"value": round(params.floor_thickness_m, 4)},
-    ))
-    rows.append(ParameterUpdate(
-        calibration_run_id=cr.id,
-        target_type="scene_version",
-        target_id=cr.scene_version_id,
-        parameter_name="scene_defaults.furniture_default_thickness_m",
-        old_value_json={"value": baseline.furniture_default_thickness_m},
-        new_value_json={"value": round(params.furniture_default_thickness_m, 4)},
-    ))
+    tx_offset = round(params.tx_power_offset_db, 3)
+    if abs(tx_offset - baseline.tx_power_offset_db) >= 0.001:
+        rows.append(ParameterUpdate(
+            calibration_run_id=cr.id,
+            target_type="scene_version",
+            target_id=cr.scene_version_id,
+            parameter_name="physical.tx_power_offset_db",
+            old_value_json={"value": baseline.tx_power_offset_db},
+            new_value_json={"value": tx_offset},
+        ))
     for r in rows:
         db.add(r)
 

--- a/backend/app/services/rf/measurement_service.py
+++ b/backend/app/services/rf/measurement_service.py
@@ -275,9 +275,14 @@ def _bounds_from_floorplan(floorplan: FloorplanInfoDTO) -> FloorBoundsDTO:
 
 
 def create_measurement_link(
-    db: Session, floor_id: str
+    db: Session, floor_id: str, *, recommended_measurement_purpose: str = "calibration"
 ) -> MeasurementLinkCreateResponseDTO:
     _validate_uuid(floor_id, "floor_id")
+    purpose = (
+        recommended_measurement_purpose
+        if recommended_measurement_purpose in {"calibration", "reference", "validation", "unknown"}
+        else "calibration"
+    )
 
     floor = db.query(Floor).filter(Floor.id == floor_id).one_or_none()
     if floor is None:
@@ -299,7 +304,7 @@ def create_measurement_link(
         floor_id=floor.id,
         scene_version_id=scene_version_id,
         asset_id=asset_id,
-        purpose="rssi_measurement",
+        purpose=purpose,
         status="active",
         expires_at=expires_at,
     )
@@ -399,7 +404,9 @@ def get_measurement_link_context(
         bounds=bounds,
         anchor_points=[],
         existing_ap_layouts=[],
-        recommended_measurement_purpose="calibration",
+        recommended_measurement_purpose=link.purpose
+        if link.purpose in {"calibration", "reference", "validation", "unknown"}
+        else "calibration",
     )
 
 

--- a/frontend/src/api/measurement-link.ts
+++ b/frontend/src/api/measurement-link.ts
@@ -4,8 +4,10 @@ import type { MeasurementLinkCreated } from '@/types/measurement-link';
 
 export const measurementLinkApi = {
   // §10.0 POST /floors/{floor_id}/measurement-links — 측정용 QR 토큰 생성
-  create: (floorId: UUID) =>
+  create: (floorId: UUID, recommendedPurpose = 'calibration') =>
     api
-      .post<MeasurementLinkCreated>(`/floors/${floorId}/measurement-links`)
+      .post<MeasurementLinkCreated>(`/floors/${floorId}/measurement-links`, null, {
+        params: { recommended_measurement_purpose: recommendedPurpose },
+      })
       .then((r) => r.data),
 };

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -28,6 +28,7 @@ interface Props {
   spaceType: SpaceType;
   onSpaceTypeChange: (next: SpaceType) => void;
   onCalibrate: () => void;
+  showCalibrateButton?: boolean;
   onAddReferenceMeasurement?: () => void;
   parameterUpdates: ParameterUpdate[];
   evaluation?: CalibrationEvaluationResponse | null;
@@ -47,6 +48,7 @@ export function CalibrationCard({
   spaceType,
   onSpaceTypeChange,
   onCalibrate,
+  showCalibrateButton = true,
   onAddReferenceMeasurement,
   parameterUpdates,
   evaluation,
@@ -108,6 +110,7 @@ export function CalibrationCard({
         onAddReferenceMeasurement={onAddReferenceMeasurement}
       />
 
+      {showCalibrateButton && (
       <button
         type="button"
         onClick={onCalibrate}
@@ -117,6 +120,7 @@ export function CalibrationCard({
         <Sliders className="h-3.5 w-3.5" />
         {succeeded ? '다시 보정 실행' : '보정 실행'}
       </button>
+      )}
       {!canCalibrate && disabledReason && (
         <p className="mt-2 text-[11px] text-muted-foreground">{disabledReason}</p>
       )}
@@ -209,6 +213,7 @@ function CalibrationEvaluationPanel({
     'metric_point_source' in evaluation.evaluation.split
       ? String((evaluation.evaluation.split as Record<string, unknown>).metric_point_source)
       : 'reference';
+  const frequencyText = formatFrequencyCheck(evaluation);
   const fmt = (v: unknown, digits = 1) =>
     typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
   return (
@@ -220,6 +225,11 @@ function CalibrationEvaluationPanel({
         <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
           Metrics use {comparisonLabel} points as the measured comparison data. Reference maps are interpolated measurements, not absolute ground truth.
         </p>
+        {frequencyText && (
+          <p className="mt-1 rounded-md border bg-background px-2 py-1 text-[10px] leading-relaxed text-muted-foreground">
+            {frequencyText}
+          </p>
+        )}
       </div>
 
       <button
@@ -359,6 +369,7 @@ function CalibrationEvaluationDetailModal({
     'metric_point_source' in evaluation.evaluation.split
       ? String((evaluation.evaluation.split as Record<string, unknown>).metric_point_source)
       : 'reference';
+  const frequencyText = formatFrequencyCheck(evaluation);
   const fmt = (v: unknown, digits = 1) =>
     typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
 
@@ -377,6 +388,9 @@ function CalibrationEvaluationDetailModal({
             <p className="text-xs text-muted-foreground">
               Same floorplan, grid, bounds, and RSSI color scale. Metrics use {comparisonLabel} points as measured comparison data.
             </p>
+            {frequencyText && (
+              <p className="mt-1 text-xs text-muted-foreground">{frequencyText}</p>
+            )}
           </div>
           <div className="flex items-center gap-2">
             {onAddReferenceMeasurement && (
@@ -700,6 +714,23 @@ function errorColor(errorDb: number): string {
   if (errorDb <= 3) return '#10b981';
   if (errorDb <= 7) return '#f59e0b';
   return '#ef4444';
+}
+
+function formatFrequencyCheck(evaluation: CalibrationEvaluationResponse): string | null {
+  const measurement = evaluation.evaluation?.['measurement_frequency'];
+  const physical = evaluation.evaluation?.['rf_physical'];
+  if (!measurement || typeof measurement !== 'object') return null;
+  const m = measurement as Record<string, unknown>;
+  if (m.available !== true) return '실측 frequency_mhz가 없어 2.4GHz/5GHz 여부를 확인할 수 없습니다.';
+  const p = physical && typeof physical === 'object' ? (physical as Record<string, unknown>) : {};
+  const measuredBand = String(m.dominant_band ?? 'unknown');
+  const avgMhz = typeof m.avg_frequency_mhz === 'number' ? m.avg_frequency_mhz : null;
+  const rfGhz = typeof p.frequency_ghz === 'number' ? p.frequency_ghz : null;
+  const txPower = typeof p.tx_power_dbm === 'number' ? p.tx_power_dbm : null;
+  const measured = avgMhz != null ? `${measuredBand} (${(avgMhz / 1000).toFixed(2)}GHz avg)` : measuredBand;
+  const simulated = rfGhz != null ? `${rfGhz.toFixed(2)}GHz` : 'unknown GHz';
+  const tx = txPower != null ? `, Tx ${txPower.toFixed(1)}dBm` : '';
+  return `실측 주파수: ${measured} / RF 시뮬레이션: ${simulated}${tx}`;
 }
 
 function rssiColor(value: number, min: number, max: number): string {

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -598,12 +598,22 @@ function MiniRssiMap({
             );
           }),
         )}
-        {calibrationPoints.map((p) => (
-          <circle key={`c-${p.point_id}`} cx={p.x_m} cy={p.y_m} r={w * 0.012} fill="#0f766e" stroke="white" strokeWidth={w * 0.004} />
+        {calibrationPoints.map((p, idx) => (
+          <circle
+            key={`c-${p.point_id}`}
+            cx={p.x_m}
+            cy={p.y_m}
+            r={w * 0.012}
+            fill="#0f766e"
+            stroke="white"
+            strokeWidth={w * 0.004}
+          >
+            <title>{pointTooltip(p, idx, 'calibration')}</title>
+          </circle>
         ))}
         {size === 'large' &&
           errorMode &&
-          validationPoints.map((p) => {
+          validationPoints.map((p, idx) => {
             const err = errorMode === 'baseline' ? p.baseline_error_db : p.calibrated_error_db;
             if (typeof err !== 'number' || !Number.isFinite(err)) return null;
             const radius = w * (0.01 + Math.min(err, 18) / 18 * 0.028);
@@ -617,22 +627,51 @@ function MiniRssiMap({
                 opacity="0.28"
                 stroke={errorColor(err)}
                 strokeWidth={w * 0.003}
-              />
+              >
+                <title>{pointTooltip(p, idx, 'comparison')}</title>
+              </circle>
             );
           })}
-        {validationPoints.map((p) => (
+        {validationPoints.map((p, idx) => (
           <path
             key={`v-${p.point_id}`}
             d={`M ${p.x_m} ${p.y_m - w * 0.014} L ${p.x_m - w * 0.014} ${p.y_m + w * 0.014} L ${p.x_m + w * 0.014} ${p.y_m + w * 0.014} Z`}
             fill="#dc2626"
             stroke="white"
             strokeWidth={w * 0.004}
-          />
+          >
+            <title>{pointTooltip(p, idx, 'comparison')}</title>
+          </path>
         ))}
       </svg>
       {size === 'large' && <RssiScaleBar min={colorScale.min_dbm} max={colorScale.max_dbm} />}
     </div>
   );
+}
+
+function pointTooltip(
+  point: CalibrationEvaluationResponse['points']['validation'][number],
+  index: number,
+  kind: 'calibration' | 'comparison',
+): string {
+  const pointName = `P${String(index + 1).padStart(2, '0')}`;
+  const purpose = kind === 'calibration' ? 'calibration' : 'comparison';
+  const lines = [
+    `${pointName} (${purpose})`,
+    `Measured RSSI: ${formatTooltipNumber(point.rssi_dbm, 'dBm')}`,
+    `Baseline pred: ${formatTooltipNumber(point.baseline_pred_dbm, 'dBm')}`,
+    `Calibrated pred: ${formatTooltipNumber(point.calibrated_pred_dbm, 'dBm')}`,
+    `Before error: ${formatTooltipNumber(point.baseline_error_db, 'dB')}`,
+    `After error: ${formatTooltipNumber(point.calibrated_error_db, 'dB')}`,
+    `Position: ${formatTooltipNumber(point.x_m, 'm')}, ${formatTooltipNumber(point.y_m, 'm')}`,
+  ];
+  return lines.join('\n');
+}
+
+function formatTooltipNumber(value: unknown, unit: string): string {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? `${value.toFixed(1)} ${unit}`
+    : '--';
 }
 
 function RssiScaleBar({ min, max }: { min: number; max: number }) {

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -195,16 +195,23 @@ function CalibrationEvaluationPanel({
     evaluation.maps.measured_reference,
   ].filter((map): map is NonNullable<typeof map> => map != null);
   const m = evaluation.metrics;
+  const comparisonPoints = evaluation.points.evaluation ?? evaluation.points.validation;
+  const comparisonLabel =
+    evaluation.evaluation?.split &&
+    typeof evaluation.evaluation.split === 'object' &&
+    'metric_point_source' in evaluation.evaluation.split
+      ? String((evaluation.evaluation.split as Record<string, unknown>).metric_point_source)
+      : 'reference';
   const fmt = (v: unknown, digits = 1) =>
     typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
   return (
     <section className="mt-3 space-y-3 rounded-lg border bg-muted/30 p-3">
       <div>
         <p className="text-[11px] font-semibold text-foreground">
-          Validation points 기준
+          Reference comparison 기준
         </p>
         <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-          Validation points are held out from the offset calculation. The measured reference map is an interpolated measurement map, not absolute ground truth.
+          Metrics use {comparisonLabel} points as the measured comparison data. Reference maps are interpolated measurements, not absolute ground truth.
         </p>
       </div>
 
@@ -225,7 +232,7 @@ function CalibrationEvaluationPanel({
               map={map}
               colorScale={evaluation.color_scale}
               calibrationPoints={evaluation.points.calibration}
-              validationPoints={evaluation.points.validation}
+              validationPoints={comparisonPoints}
               backgroundImageUrl={backgroundImageUrl}
             />
           ))}
@@ -255,7 +262,7 @@ function CalibrationEvaluationPanel({
 
       <details className="rounded-md border bg-background text-[11px]">
         <summary className="cursor-pointer px-3 py-2 font-medium">
-          Validation point errors ({evaluation.points.validation.length})
+          Reference comparison errors ({comparisonPoints.length})
         </summary>
         <div className="max-h-48 overflow-auto">
           <table className="w-full min-w-[520px] text-left">
@@ -270,7 +277,7 @@ function CalibrationEvaluationPanel({
               </tr>
             </thead>
             <tbody>
-              {evaluation.points.validation.map((p, idx) => (
+              {comparisonPoints.map((p, idx) => (
                 <tr key={p.point_id} className="border-t">
                   <td className="px-2 py-1">P{String(idx + 1).padStart(2, '0')}</td>
                   <td className="px-2 py-1">{fmt(p.rssi_dbm)} dBm</td>
@@ -323,6 +330,13 @@ function CalibrationEvaluationDetailModal({
     evaluation.maps.measured_reference,
   ].filter((map): map is NonNullable<typeof map> => map != null);
   const m = evaluation.metrics;
+  const comparisonPoints = evaluation.points.evaluation ?? evaluation.points.validation;
+  const comparisonLabel =
+    evaluation.evaluation?.split &&
+    typeof evaluation.evaluation.split === 'object' &&
+    'metric_point_source' in evaluation.evaluation.split
+      ? String((evaluation.evaluation.split as Record<string, unknown>).metric_point_source)
+      : 'reference';
   const fmt = (v: unknown, digits = 1) =>
     typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
 
@@ -339,7 +353,7 @@ function CalibrationEvaluationDetailModal({
           <div>
             <h2 className="text-base font-semibold">3-way RSSI map comparison</h2>
             <p className="text-xs text-muted-foreground">
-              Same floorplan, grid, bounds, and RSSI color scale. Validation points are not used for calibration.
+              Same floorplan, grid, bounds, and RSSI color scale. Metrics use {comparisonLabel} points as measured comparison data.
             </p>
           </div>
           <button
@@ -360,7 +374,7 @@ function CalibrationEvaluationDetailModal({
                 map={map}
                 colorScale={evaluation.color_scale}
                 calibrationPoints={evaluation.points.calibration}
-                validationPoints={evaluation.points.validation}
+                validationPoints={comparisonPoints}
                 backgroundImageUrl={backgroundImageUrl}
                 size="large"
               />
@@ -395,14 +409,14 @@ function CalibrationEvaluationDetailModal({
                 </span>
                 <span className="inline-flex items-center gap-1">
                   <span className="h-0 w-0 border-x-[5px] border-b-[9px] border-x-transparent border-b-[#dc2626]" />
-                  validation
+                  comparison
                 </span>
               </div>
             </div>
 
             <div className="rounded-lg border bg-background text-xs">
               <div className="border-b px-4 py-3 font-semibold">
-                Validation point errors ({evaluation.points.validation.length})
+                Reference comparison errors ({comparisonPoints.length})
               </div>
               <div className="max-h-72 overflow-auto">
                 <table className="w-full min-w-[640px] text-left">
@@ -417,7 +431,7 @@ function CalibrationEvaluationDetailModal({
                     </tr>
                   </thead>
                   <tbody>
-                    {evaluation.points.validation.map((p, idx) => (
+                    {comparisonPoints.map((p, idx) => (
                       <tr key={p.point_id} className="border-t">
                         <td className="px-3 py-2">P{String(idx + 1).padStart(2, '0')}</td>
                         <td className="px-3 py-2">{fmt(p.rssi_dbm)} dBm</td>

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -28,6 +28,7 @@ interface Props {
   spaceType: SpaceType;
   onSpaceTypeChange: (next: SpaceType) => void;
   onCalibrate: () => void;
+  onAddReferenceMeasurement?: () => void;
   parameterUpdates: ParameterUpdate[];
   evaluation?: CalibrationEvaluationResponse | null;
   backgroundImageUrl?: string | null;
@@ -46,6 +47,7 @@ export function CalibrationCard({
   spaceType,
   onSpaceTypeChange,
   onCalibrate,
+  onAddReferenceMeasurement,
   parameterUpdates,
   evaluation,
   backgroundImageUrl,
@@ -93,7 +95,7 @@ export function CalibrationCard({
           </span>
         </div>
       ) : succeeded && run ? (
-        <CalibrationResult run={run} parameterUpdates={parameterUpdates} />
+        <CalibrationResult run={run} parameterUpdates={parameterUpdates} evaluation={evaluation} />
       ) : failed ? (
         <p className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[11px] text-destructive">
           보정에 실패했습니다. 측정 데이터가 충분한지 확인해주세요.
@@ -103,6 +105,7 @@ export function CalibrationCard({
       <CalibrationEvaluationPanel
         evaluation={evaluation ?? extractEvaluationResponse(run)}
         backgroundImageUrl={backgroundImageUrl}
+        onAddReferenceMeasurement={onAddReferenceMeasurement}
       />
 
       <button
@@ -124,11 +127,13 @@ export function CalibrationCard({
 function CalibrationResult({
   run,
   parameterUpdates,
+  evaluation,
 }: {
   run: CalibrationRun;
   parameterUpdates: ParameterUpdate[];
+  evaluation?: CalibrationEvaluationResponse | null;
 }) {
-  const metrics = parseCalibrationMetrics(run.error_metrics_json);
+  const metrics = parseCalibrationMetrics(evaluation?.metrics ?? run.error_metrics_json);
   const feedbackMessage = typeof run.error_metrics_json?.['feedback_message'] === 'string'
     ? (run.error_metrics_json['feedback_message'] as string)
     : null;
@@ -137,8 +142,8 @@ function CalibrationResult({
       <div className="rounded-lg border bg-muted/40 p-3">
         <p className="text-[11px] font-semibold text-muted-foreground">보정 결과</p>
         <div className="mt-1.5 grid grid-cols-2 gap-2">
-          <MetricCell label="RMSE" value={metrics.rmse} unit="dBm" />
-          <MetricCell label="MAE" value={metrics.mae} unit="dBm" />
+          <MetricCell label="RMSE" value={metrics.rmse} unit="dB" />
+          <MetricCell label="MAE" value={metrics.mae} unit="dB" />
         </div>
       </div>
       {feedbackMessage && (
@@ -183,9 +188,11 @@ function CalibrationResult({
 function CalibrationEvaluationPanel({
   evaluation,
   backgroundImageUrl,
+  onAddReferenceMeasurement,
 }: {
   evaluation: CalibrationEvaluationResponse | null;
   backgroundImageUrl?: string | null;
+  onAddReferenceMeasurement?: () => void;
 }) {
   const [detailOpen, setDetailOpen] = useState(false);
   if (!evaluation) return null;
@@ -223,6 +230,15 @@ function CalibrationEvaluationPanel({
         <Maximize2 className="h-3 w-3" />
         Detail view
       </button>
+      {onAddReferenceMeasurement && (
+        <button
+          type="button"
+          onClick={onAddReferenceMeasurement}
+          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-2 py-1.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          정답(참조) 데이터 추가 측정
+        </button>
+      )}
 
       <div className="overflow-x-auto">
         <div className="grid min-w-[620px] grid-cols-3 gap-2">
@@ -258,6 +274,9 @@ function CalibrationEvaluationPanel({
           after={fmt(m.calibrated_rmse_db)}
           improvement={`${fmt(m.rmse_improvement_db)} dB`}
         />
+        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
+          MAE는 평균 오차입니다. RMSE는 큰 오차를 더 크게 반영해서, 특정 위치에서 예측이 많이 틀어졌는지 보기 좋습니다.
+        </p>
       </div>
 
       <details className="rounded-md border bg-background text-[11px]">
@@ -297,6 +316,7 @@ function CalibrationEvaluationPanel({
         onClose={() => setDetailOpen(false)}
         evaluation={evaluation}
         backgroundImageUrl={backgroundImageUrl}
+        onAddReferenceMeasurement={onAddReferenceMeasurement}
       />
     </section>
   );
@@ -307,11 +327,13 @@ function CalibrationEvaluationDetailModal({
   onClose,
   evaluation,
   backgroundImageUrl,
+  onAddReferenceMeasurement,
 }: {
   open: boolean;
   onClose: () => void;
   evaluation: CalibrationEvaluationResponse;
   backgroundImageUrl?: string | null;
+  onAddReferenceMeasurement?: () => void;
 }) {
   useEffect(() => {
     if (!open) return;
@@ -356,14 +378,28 @@ function CalibrationEvaluationDetailModal({
               Same floorplan, grid, bounds, and RSSI color scale. Metrics use {comparisonLabel} points as measured comparison data.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border hover:bg-accent"
-            aria-label="Close"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <div className="flex items-center gap-2">
+            {onAddReferenceMeasurement && (
+              <button
+                type="button"
+                onClick={() => {
+                  onAddReferenceMeasurement();
+                  onClose();
+                }}
+                className="rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                정답(참조) 데이터 추가 측정
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border hover:bg-accent"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
         </header>
 
         <div className="min-h-0 flex-1 overflow-auto p-5">
@@ -377,13 +413,17 @@ function CalibrationEvaluationDetailModal({
                 validationPoints={comparisonPoints}
                 backgroundImageUrl={backgroundImageUrl}
                 size="large"
+                errorMode={map.label.toLowerCase().includes('baseline') ? 'baseline' : map.label.toLowerCase().includes('calibrated') ? 'calibrated' : undefined}
               />
             ))}
           </div>
 
           <div className="mt-4 grid gap-4 lg:grid-cols-[24rem_1fr]">
             <div className="rounded-lg border bg-muted/20 p-4 text-sm">
-              <p className="font-semibold">Validation metrics</p>
+              <p className="font-semibold">Comparison metrics</p>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                MAE는 각 측정 지점의 평균 오차입니다. RMSE는 큰 오차를 더 크게 반영해서, 보정 후에도 크게 틀린 구간이 남아 있는지 보여줍니다.
+              </p>
               <div className="mt-3 grid grid-cols-4 gap-2 text-xs font-semibold text-muted-foreground">
                 <span>Metric</span>
                 <span>Before</span>
@@ -414,7 +454,16 @@ function CalibrationEvaluationDetailModal({
               </div>
             </div>
 
-            <div className="rounded-lg border bg-background text-xs">
+            <div className="rounded-lg border bg-background p-4 text-xs">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <p className="font-semibold">Point error chart</p>
+                <p className="text-muted-foreground">Before vs after, dB</p>
+              </div>
+              <ErrorBarChart points={comparisonPoints} />
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-lg border bg-background text-xs">
               <div className="border-b px-4 py-3 font-semibold">
                 Reference comparison errors ({comparisonPoints.length})
               </div>
@@ -444,7 +493,6 @@ function CalibrationEvaluationDetailModal({
                   </tbody>
                 </table>
               </div>
-            </div>
           </div>
         </div>
       </div>
@@ -480,6 +528,7 @@ function MiniRssiMap({
   validationPoints,
   backgroundImageUrl,
   size = 'compact',
+  errorMode,
 }: {
   map: CalibrationEvaluationResponse['maps']['baseline'];
   colorScale: { min_dbm: number; max_dbm: number };
@@ -487,6 +536,7 @@ function MiniRssiMap({
   validationPoints: CalibrationEvaluationResponse['points']['validation'];
   backgroundImageUrl?: string | null;
   size?: 'compact' | 'large';
+  errorMode?: 'baseline' | 'calibrated';
 }) {
   const bounds = map.bounds_m;
   const w = Math.max(bounds.max_x - bounds.min_x, 1);
@@ -537,6 +587,25 @@ function MiniRssiMap({
         {calibrationPoints.map((p) => (
           <circle key={`c-${p.point_id}`} cx={p.x_m} cy={p.y_m} r={w * 0.012} fill="#0f766e" stroke="white" strokeWidth={w * 0.004} />
         ))}
+        {size === 'large' &&
+          errorMode &&
+          validationPoints.map((p) => {
+            const err = errorMode === 'baseline' ? p.baseline_error_db : p.calibrated_error_db;
+            if (typeof err !== 'number' || !Number.isFinite(err)) return null;
+            const radius = w * (0.01 + Math.min(err, 18) / 18 * 0.028);
+            return (
+              <circle
+                key={`err-${errorMode}-${p.point_id}`}
+                cx={p.x_m}
+                cy={p.y_m}
+                r={radius}
+                fill={errorColor(err)}
+                opacity="0.28"
+                stroke={errorColor(err)}
+                strokeWidth={w * 0.003}
+              />
+            );
+          })}
         {validationPoints.map((p) => (
           <path
             key={`v-${p.point_id}`}
@@ -568,6 +637,69 @@ function RssiScaleBar({ min, max }: { min: number; max: number }) {
       </div>
     </div>
   );
+}
+
+function ErrorBarChart({
+  points,
+}: {
+  points: CalibrationEvaluationResponse['points']['validation'];
+}) {
+  const visible = points.slice(0, 24);
+  const maxErr = Math.max(
+    1,
+    ...visible.flatMap((p) => [
+      typeof p.baseline_error_db === 'number' ? p.baseline_error_db : 0,
+      typeof p.calibrated_error_db === 'number' ? p.calibrated_error_db : 0,
+    ]),
+  );
+  if (visible.length === 0) {
+    return <p className="text-muted-foreground">No comparison points available.</p>;
+  }
+  return (
+    <div className="max-h-72 space-y-2 overflow-auto pr-1">
+      {visible.map((p, idx) => {
+        const before = typeof p.baseline_error_db === 'number' ? p.baseline_error_db : 0;
+        const after = typeof p.calibrated_error_db === 'number' ? p.calibrated_error_db : 0;
+        return (
+          <div key={p.point_id} className="grid grid-cols-[2.5rem_1fr_3rem] items-center gap-2">
+            <span className="font-medium text-muted-foreground">P{String(idx + 1).padStart(2, '0')}</span>
+            <div className="space-y-1">
+              <div className="h-2 rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full bg-rose-500"
+                  style={{ width: `${Math.max(2, (before / maxErr) * 100)}%` }}
+                />
+              </div>
+              <div className="h-2 rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full bg-emerald-500"
+                  style={{ width: `${Math.max(2, (after / maxErr) * 100)}%` }}
+                />
+              </div>
+            </div>
+            <span className="text-right tabular-nums">
+              {after.toFixed(1)}
+            </span>
+          </div>
+        );
+      })}
+      {points.length > visible.length && (
+        <p className="pt-1 text-[11px] text-muted-foreground">
+          Showing first {visible.length} of {points.length} points. Full values are in the table below.
+        </p>
+      )}
+      <div className="flex gap-3 pt-1 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1"><span className="h-2 w-4 rounded bg-rose-500" /> before</span>
+        <span className="inline-flex items-center gap-1"><span className="h-2 w-4 rounded bg-emerald-500" /> after</span>
+      </div>
+    </div>
+  );
+}
+
+function errorColor(errorDb: number): string {
+  if (errorDb <= 3) return '#10b981';
+  if (errorDb <= 7) return '#f59e0b';
+  return '#ef4444';
 }
 
 function rssiColor(value: number, min: number, max: number): string {
@@ -627,8 +759,16 @@ function parseCalibrationMetrics(m: Record<string, unknown> | null | undefined):
     return null;
   };
   return {
-    rmse: toNum('rmse_dbm') ?? toNum('rmse') ?? toNum('rmse_after'),
-    mae: toNum('mae_dbm') ?? toNum('mae') ?? toNum('mae_after'),
+    rmse:
+      toNum('calibrated_rmse_db') ??
+      toNum('rmse_dbm') ??
+      toNum('rmse') ??
+      toNum('rmse_after'),
+    mae:
+      toNum('calibrated_mae_db') ??
+      toNum('mae_dbm') ??
+      toNum('mae') ??
+      toNum('mae_after'),
   };
 }
 

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -52,8 +52,10 @@ interface Props {
    * 있으면 'heatmap' / 'both' 모드에서 측정점 radial gradient 대신 이 이미지를 깔아준다.
    */
   estimatedHeatmap?: {
-    url: string;
+    url?: string;
+    valuesDbm?: number[][];
     bounds: { min_x: number; min_y: number; max_x: number; max_y: number };
+    rssiRange?: { min: number; max: number };
   } | null;
   /** dbm color mode 일 때 색 범위 (heatmap rssi_range 와 일치시켜야 통일). 미지정 시 -90~-30. */
   pointColorRange?: { min: number; max: number };
@@ -265,7 +267,30 @@ export function MeasurementCanvas({
         {/* 히트맵: 도형보다 아래에 깔아 도면이 위에 보이도록.
             GP regression dense heatmap 이 있으면 그것을 우선 표시 (전체 도면 커버).
             없으면 측정점 주변 radial gradient 로 fallback. */}
-        {showHeatmap && estimatedHeatmap ? (
+        {showHeatmap && estimatedHeatmap?.valuesDbm ? (
+          <g opacity={0.65} pointerEvents="none">
+            {estimatedHeatmap.valuesDbm.map((row, rowIdx) =>
+              row.map((value, colIdx) => {
+                const rows = estimatedHeatmap.valuesDbm?.length ?? 1;
+                const cols = row.length || 1;
+                const bounds = estimatedHeatmap.bounds;
+                const cellW = (bounds.max_x - bounds.min_x) / cols;
+                const cellH = (bounds.max_y - bounds.min_y) / rows;
+                const range = estimatedHeatmap.rssiRange ?? pointColorRange ?? { min: -90, max: -30 };
+                return (
+                  <rect
+                    key={`calibrated-${rowIdx}-${colIdx}`}
+                    x={bounds.min_x + colIdx * cellW}
+                    y={bounds.min_y + rowIdx * cellH}
+                    width={cellW}
+                    height={cellH}
+                    fill={dbmToInfernoColor(value, range.min, range.max)}
+                  />
+                );
+              }),
+            )}
+          </g>
+        ) : showHeatmap && estimatedHeatmap?.url ? (
           <image
             href={estimatedHeatmap.url}
             xlinkHref={estimatedHeatmap.url}

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import { loadCachedViewBox } from '@/features/editor/viewbox-cache';
 import {
@@ -68,6 +68,13 @@ interface Bounds {
   minY: number;
   maxX: number;
   maxY: number;
+}
+
+interface CanvasTooltip {
+  x: number;
+  y: number;
+  title: string;
+  rows: { label: string; value: string }[];
 }
 
 function emptyBounds(): Bounds {
@@ -169,7 +176,8 @@ export function MeasurementCanvas({
   pointColorMode,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const sceneId = sceneVersion?.id ?? null;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [tooltip, setTooltip] = useState<CanvasTooltip | null>(null);
 
   // 배경 이미지를 editor 와 동일한 좌표계로 배치하기 위해 imageExtent (미터) 계산.
   // image 는 (0,0)~(extent.w, extent.h) 에 그림 → 벽과 정확히 정렬.
@@ -190,7 +198,7 @@ export function MeasurementCanvas({
     const cached = loadCachedViewBox(sceneVersion?.floor_id ?? null);
     if (cached) return cached;
     return computeViewBox(sceneVersion, null);
-  }, [sceneId, sceneVersion?.floor_id, imageExtent]);
+  }, [sceneVersion, imageExtent]);
   const sortedPoints = useMemo(
     () => [...points].sort((a, b) => a.order - b.order),
     [points],
@@ -209,8 +217,70 @@ export function MeasurementCanvas({
   const dbmMin = pointColorRange?.min ?? -90;
   const dbmMax = pointColorRange?.max ?? -30;
 
+  const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const svgPoint = svg.createSVGPoint();
+    svgPoint.x = event.clientX;
+    svgPoint.y = event.clientY;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return;
+    const point = svgPoint.matrixTransform(ctm.inverse());
+    const rect = containerRef.current?.getBoundingClientRect() ?? svg.getBoundingClientRect();
+    const tooltipPos = {
+      x: event.clientX - rect.left + 14,
+      y: event.clientY - rect.top + 14,
+    };
+
+    const hitRadius = Math.max(0.18, Math.min(vb.w, vb.h) * 0.018);
+    let nearest: MeasurementPoint | null = null;
+    let nearestIndex = -1;
+    let nearestDistance = Infinity;
+    for (const [idx, p] of sortedPoints.entries()) {
+      const distance = Math.hypot(point.x - p.x_m, point.y - p.y_m);
+      if (distance < nearestDistance) {
+        nearest = p;
+        nearestIndex = idx;
+        nearestDistance = distance;
+      }
+    }
+
+    if (nearest && nearestDistance <= hitRadius) {
+      const measured = pointRssiByOrder?.get(nearest.id);
+      const estimated = sampleHeatmapAtPoint(estimatedHeatmap, nearest.x_m, nearest.y_m);
+      setTooltip({
+        ...tooltipPos,
+        title: `P${String(nearestIndex + 1).padStart(2, '0')}`,
+        rows: [
+          { label: '실측 RSSI', value: formatDbm(measured) },
+          ...(estimated != null
+            ? [{ label: mode === 'both' ? '통합 보정맵' : '히트맵', value: formatDbm(estimated) }]
+            : []),
+        ],
+      });
+      return;
+    }
+
+    const heatmapValue = showHeatmap
+      ? sampleHeatmapAtPoint(estimatedHeatmap, point.x, point.y)
+      : null;
+    if (heatmapValue != null) {
+      setTooltip({
+        ...tooltipPos,
+        title: mode === 'both' ? '통합 보정맵 RSSI' : '실측 히트맵 RSSI',
+        rows: [
+          { label: '예상 RSSI', value: formatDbm(heatmapValue) },
+        ],
+      });
+      return;
+    }
+
+    setTooltip(null);
+  };
+
   return (
     <div
+      ref={containerRef}
       className={cn(
         'relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl border bg-[#f8fafc] p-6',
         '[background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)]',
@@ -223,6 +293,8 @@ export function MeasurementCanvas({
         preserveAspectRatio="xMidYMid meet"
         overflow="hidden"
         className="h-full w-full select-none overflow-hidden"
+        onPointerMove={handlePointerMove}
+        onPointerLeave={() => setTooltip(null)}
       >
         <defs>
           {/* viewBox(=도면) 영역으로 클립. 측정점/AP/히트맵이 도면 밖 좌표여도
@@ -377,8 +449,64 @@ export function MeasurementCanvas({
         ))}
         </g>
       </svg>
+      {tooltip && (
+        <div
+          className="pointer-events-none absolute z-20 min-w-44 rounded-lg border bg-background/95 px-3 py-2 text-xs shadow-lg backdrop-blur"
+          style={{
+            left: tooltip.x,
+            top: tooltip.y,
+            transform:
+              tooltip.x > 240 && tooltip.y > 120
+                ? 'translate(-100%, -100%)'
+                : tooltip.x > 240
+                ? 'translateX(-100%)'
+                : undefined,
+          }}
+        >
+          <p className="mb-1 font-semibold text-foreground">{tooltip.title}</p>
+          <div className="space-y-0.5">
+            {tooltip.rows.map((row) => (
+              <div key={row.label} className="flex justify-between gap-4 tabular-nums">
+                <span className="text-muted-foreground">{row.label}</span>
+                <span className="font-medium text-foreground">{row.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
+}
+
+function sampleHeatmapAtPoint(
+  heatmap: Props['estimatedHeatmap'],
+  x: number,
+  y: number,
+): number | null {
+  if (!heatmap?.valuesDbm?.length) return null;
+  const { bounds, valuesDbm } = heatmap;
+  if (x < bounds.min_x || x > bounds.max_x || y < bounds.min_y || y > bounds.max_y) {
+    return null;
+  }
+  const rows = valuesDbm.length;
+  const cols = valuesDbm[0]?.length ?? 0;
+  if (rows <= 0 || cols <= 0) return null;
+  const col = Math.min(
+    cols - 1,
+    Math.max(0, Math.floor(((x - bounds.min_x) / (bounds.max_x - bounds.min_x || 1)) * cols)),
+  );
+  const row = Math.min(
+    rows - 1,
+    Math.max(0, Math.floor(((y - bounds.min_y) / (bounds.max_y - bounds.min_y || 1)) * rows)),
+  );
+  const value = valuesDbm[row]?.[col];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function formatDbm(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? `${value.toFixed(1)} dBm`
+    : '--';
 }
 
 // ============================================

--- a/frontend/src/features/mobile/MobileConnectModal.tsx
+++ b/frontend/src/features/mobile/MobileConnectModal.tsx
@@ -8,9 +8,14 @@ import { toast } from '@/stores/toast-store';
 interface Props {
   open: boolean;
   onClose: () => void;
+  recommendedPurpose?: 'calibration' | 'reference' | 'validation' | 'unknown';
 }
 
-export function MobileConnectModal({ open, onClose }: Props) {
+export function MobileConnectModal({
+  open,
+  onClose,
+  recommendedPurpose = 'calibration',
+}: Props) {
   const floorId = useAppStore((s) => s.selectedFloorId);
   const projectId = useAppStore((s) => s.selectedProjectId);
   const createLink = useCreateMeasurementLink();
@@ -21,9 +26,9 @@ export function MobileConnectModal({ open, onClose }: Props) {
     if (!open) return;
     if (!floorId) return;
     if (createLink.isPending || link) return;
-    createLink.mutate(floorId);
+    createLink.mutate({ floorId, recommendedPurpose });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, floorId]);
+  }, [open, floorId, recommendedPurpose]);
 
   // 닫힐 때 상태 초기화 (다음 열릴 때 새 QR 발급)
   useEffect(() => {
@@ -79,10 +84,11 @@ export function MobileConnectModal({ open, onClose }: Props) {
             token={link.token}
             expiresAt={link.expires_at}
             deepLink={link.deep_link}
-            onRefresh={() => createLink.mutate(floorId)}
+            recommendedPurpose={recommendedPurpose}
+            onRefresh={() => createLink.mutate({ floorId, recommendedPurpose })}
           />
         ) : createLink.isError ? (
-          <ErrorState onRetry={() => createLink.mutate(floorId)} />
+          <ErrorState onRetry={() => createLink.mutate({ floorId, recommendedPurpose })} />
         ) : null}
       </div>
     </div>
@@ -130,12 +136,14 @@ function ReadyState({
   token,
   expiresAt,
   deepLink,
+  recommendedPurpose,
   onRefresh,
 }: {
   qrPayload: string;
   token: string;
   expiresAt: string;
   deepLink: string;
+  recommendedPurpose: 'calibration' | 'reference' | 'validation' | 'unknown';
   onRefresh: () => void;
 }) {
   const remaining = useCountdown(expiresAt);
@@ -154,6 +162,10 @@ function ReadyState({
       <p className="text-center text-xs text-muted-foreground">
         모바일 앱으로 아래 QR 코드를 스캔하면 측정이 시작됩니다.
       </p>
+
+      <div className="rounded-lg border bg-muted/20 px-3 py-2 text-center text-xs font-medium">
+        Recommended mode: {recommendedPurpose === 'reference' ? 'Reference comparison' : 'Calibration'}
+      </div>
 
       <div className="flex justify-center rounded-xl border bg-white p-4">
         <QRCodeSVG value={qrPayload} size={200} level="M" includeMargin />

--- a/frontend/src/hooks/use-measurement-link.ts
+++ b/frontend/src/hooks/use-measurement-link.ts
@@ -10,7 +10,13 @@ import type { UUID } from '@/types/common';
  */
 export function useCreateMeasurementLink() {
   return useMutation({
-    mutationFn: (floorId: UUID) => measurementLinkApi.create(floorId),
+    mutationFn: ({
+      floorId,
+      recommendedPurpose = 'calibration',
+    }: {
+      floorId: UUID;
+      recommendedPurpose?: 'calibration' | 'reference' | 'validation' | 'unknown';
+    }) => measurementLinkApi.create(floorId, recommendedPurpose),
     onError: (err) => {
       const e = err as HttpError | null;
       toast.error(

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -49,6 +49,9 @@ import {
   type PlacedApSimple,
 } from '@/features/measurement/MeasurementCanvas';
 
+const EMPTY_MEASUREMENT_SESSIONS: MeasurementSession[] = [];
+const EMPTY_MEASUREMENT_POINTS: ApiPoint[] = [];
+
 export default function MeasurementPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
 
@@ -96,12 +99,12 @@ export default function MeasurementPage() {
 
   // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
   const sessionsQuery = useFloorMeasurementSessions(floorId);
-  const sessions = sessionsQuery.data?.items ?? [];
+  const sessions = sessionsQuery.data?.items ?? EMPTY_MEASUREMENT_SESSIONS;
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const activeSession =
     sessions.find((s) => s.id === selectedSessionId) ?? sessions[0] ?? null;
   const pointsQuery = useMeasurementPoints(activeSession?.id ?? null);
-  const points = pointsQuery.data?.items ?? [];
+  const points = pointsQuery.data?.items ?? EMPTY_MEASUREMENT_POINTS;
 
   const canvasPoints = useMemo(() => apiPointsToCanvas(points), [points]);
   // 캔버스 dbm color mode 에서 점 색 계산용 — id → 실측 RSSI 매핑.
@@ -179,8 +182,9 @@ export default function MeasurementPage() {
   const evaluateCalibration = useEvaluateCalibrationRun();
   const [calibrationEvaluation, setCalibrationEvaluation] =
     useState<CalibrationEvaluationResponse | null>(null);
-  // BO 가 9차원 fit 하므로 최소 8점 (backend 가드와 일치). 그 미만이면 overfit → 다음
-  // 시뮬이 극단적으로 왜곡됨 (벽 무한히 두꺼워짐 등). 사용자가 실수로 누르지 않도록 막음.
+  // Affine RSSI transfer + residual IDW는 적은 측정점으로도 계산은 가능하지만,
+  // 화면에서 바로 신뢰 가능한 보정맵처럼 보이지 않도록 프론트에서는 더 보수적으로 8점부터 허용한다.
+  // 백엔드 평가는 기존 데이터 호환을 위해 최소 5점 guard를 별도로 유지한다.
   const MIN_MEASUREMENTS_FOR_CALIBRATION = 8;
   const hasEnoughMeasurements = points.length >= MIN_MEASUREMENTS_FOR_CALIBRATION;
   const canCalibrate =
@@ -267,9 +271,6 @@ export default function MeasurementPage() {
       {
         onSuccess: (result) => {
           setCalibrationEvaluation(result);
-        },
-        onError: () => {
-          lastAutoCalibrationKey.current = null;
         },
       },
     );

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
@@ -37,11 +37,7 @@ import { useApLayouts } from '@/hooks/use-ap-layouts';
 import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
-import {
-  useEvaluateCalibrationRun,
-  useCalibrationParameterUpdates,
-  useCalibrationRun,
-} from '@/hooks/use-calibration-run';
+import { useEvaluateCalibrationRun } from '@/hooks/use-calibration-run';
 import { CalibrationCard } from '@/features/calibration/CalibrationCard';
 import type { CalibrationEvaluationResponse, SpaceType } from '@/types/calibration-run';
 import { parseGeometry } from '@/features/editor/geometry-utils';
@@ -181,14 +177,8 @@ export default function MeasurementPage() {
   // §11 캘리브레이션 — 현재 측정 세션 + 최근 RF Run + 현재 버전을 입력으로 사용.
   // 측정 페이지에 둠: 진단 카드에서 차이를 발견한 직후 보정 가능.
   const evaluateCalibration = useEvaluateCalibrationRun();
-  const [activeCalibrationId, setActiveCalibrationId] = useState<string | null>(null);
   const [calibrationEvaluation, setCalibrationEvaluation] =
     useState<CalibrationEvaluationResponse | null>(null);
-  const calibrationPoll = useCalibrationRun(activeCalibrationId);
-  const paramUpdatesQuery = useCalibrationParameterUpdates(
-    activeCalibrationId,
-    calibrationPoll.isSucceeded,
-  );
   // BO 가 9차원 fit 하므로 최소 8점 (backend 가드와 일치). 그 미만이면 overfit → 다음
   // 시뮬이 극단적으로 왜곡됨 (벽 무한히 두꺼워짐 등). 사용자가 실수로 누르지 않도록 막음.
   const MIN_MEASUREMENTS_FOR_CALIBRATION = 8;
@@ -198,7 +188,7 @@ export default function MeasurementPage() {
     !!latestRfRunId &&
     !!currentVersion?.id &&
     hasEnoughMeasurements;
-  const evaluationSessionIds = (() => {
+  const evaluationSessionIds = useMemo(() => {
     const ids = new Set<string>();
     for (const session of sessions) {
       if (
@@ -211,7 +201,7 @@ export default function MeasurementPage() {
     }
     if (activeSession?.id) ids.add(activeSession.id);
     return [...ids];
-  })();
+  }, [activeSession, sessions]);
   const calibrationDisabledReason = !hasMeasurement
     ? '먼저 측정을 진행해주세요.'
     : !hasEnoughMeasurements
@@ -228,7 +218,7 @@ export default function MeasurementPage() {
         rf_run_id: latestRfRunId,
         scene_version_id: currentVersion.id,
         measurement_session_ids: evaluationSessionIds.length > 0 ? evaluationSessionIds : [activeSession.id],
-        method: 'global_offset',
+        method: 'affine_rssi_transfer',
         split: { strategy: 'purpose_or_random', holdout_ratio: 0.3, seed: 42 },
         visualization: {
           include_reference_map: true,
@@ -239,12 +229,80 @@ export default function MeasurementPage() {
       },
       {
         onSuccess: (result) => {
-          setActiveCalibrationId(result.calibration_run_id);
           setCalibrationEvaluation(result);
         },
       },
     );
   };
+
+  const lastAutoCalibrationKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (mode !== 'both') return;
+    if (!canCalibrate || !activeSession || !latestRfRunId || !currentVersion) return;
+    const sessionIds = evaluationSessionIds.length > 0 ? evaluationSessionIds : [activeSession.id];
+    const key = [
+      activeSession.floor_id,
+      currentVersion.id,
+      latestRfRunId,
+      sessionIds.join(','),
+      points.length,
+    ].join('|');
+    if (lastAutoCalibrationKey.current === key) return;
+    lastAutoCalibrationKey.current = key;
+    evaluateCalibration.mutate(
+      {
+        floor_id: activeSession.floor_id,
+        rf_run_id: latestRfRunId,
+        scene_version_id: currentVersion.id,
+        measurement_session_ids: sessionIds,
+        method: 'affine_rssi_transfer',
+        split: { strategy: 'purpose_or_random', holdout_ratio: 0.3, seed: 42 },
+        visualization: {
+          include_reference_map: true,
+          reference_map_method: 'idw',
+          rssi_min_dbm: -90,
+          rssi_max_dbm: -30,
+        },
+      },
+      {
+        onSuccess: (result) => {
+          setCalibrationEvaluation(result);
+        },
+        onError: () => {
+          lastAutoCalibrationKey.current = null;
+        },
+      },
+    );
+  }, [
+    mode,
+    canCalibrate,
+    activeSession,
+    latestRfRunId,
+    currentVersion,
+    evaluationSessionIds,
+    points.length,
+    evaluateCalibration,
+  ]);
+
+  const calibratedMainHeatmap = useMemo(() => {
+    const map = calibrationEvaluation?.maps.calibrated;
+    if (!map) return null;
+    return {
+      valuesDbm: map.values_dbm,
+      bounds: map.bounds_m,
+      rssiRange: {
+        min: calibrationEvaluation.color_scale.min_dbm,
+        max: calibrationEvaluation.color_scale.max_dbm,
+      },
+    };
+  }, [calibrationEvaluation]);
+
+  const displayedHeatmap =
+    mode === 'both' && calibratedMainHeatmap ? calibratedMainHeatmap : estimatedHeatmap;
+  const displayedRange =
+    mode === 'both' && calibratedMainHeatmap
+      ? calibratedMainHeatmap.rssiRange
+      : pointColorRange;
 
 
   return (
@@ -279,7 +337,11 @@ export default function MeasurementPage() {
               {/* route 모드 (양호/주의/불량) 만 카드 상단 inline 표시. dbm 모드는 캔버스 하단에 colorbar. */}
               <div className="flex flex-wrap items-center gap-2">
                 {mode === 'route' && <Legend colorMode="quality" range={pointColorRange} />}
-                {mode !== 'route' && activeCoverage?.method && (
+                {mode === 'both' && calibratedMainHeatmap ? (
+                  <span className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/5 px-2 py-1 text-xs font-medium text-primary">
+                    RSSI transfer 보정맵
+                  </span>
+                ) : mode !== 'route' && activeCoverage?.method && (
                   <MethodBadge
                     method={activeCoverage.method}
                     expected={mode === 'both' ? 'residual_kriging' : 'gp_only'}
@@ -292,18 +354,18 @@ export default function MeasurementPage() {
                   backgroundImageUrl={backgroundImageUrl}
                   points={canvasPoints}
                   pointRssiByOrder={pointRssiByOrder}
-                  pointColorRange={pointColorRange}
+                  pointColorRange={displayedRange}
                   aps={canvasAps}
                   mode={mode}
-                  estimatedHeatmap={estimatedHeatmap}
+                  estimatedHeatmap={displayedHeatmap}
                 />
                 {!hasMeasurement && <CanvasEmptyOverlay loading={pointsQuery.isFetching} />}
                 {/* dbm 모드 colorbar — 도면 좌상단. gradient + tick 값 수직 정렬로 "이 색=이 dBm" 직관. */}
-                {mode !== 'route' && pointColorRange && (
+                {mode !== 'route' && displayedRange && (
                   <div className="pointer-events-none absolute left-3 top-3 z-10 w-70">
                     <DbmColorBar
-                      vmin={pointColorRange.min}
-                      vmax={pointColorRange.max}
+                      vmin={displayedRange.min}
+                      vmax={displayedRange.max}
                       label="실측 RSSI"
                     />
                   </div>
@@ -319,19 +381,20 @@ export default function MeasurementPage() {
               measuredAvgDbm={measuredAvgDbm}
             />
             <CalibrationCard
-              run={calibrationPoll.run}
-              isPolling={calibrationPoll.isPolling}
+              run={null}
+              isPolling={false}
               isStarting={evaluateCalibration.isPending}
               canCalibrate={canCalibrate}
               disabledReason={calibrationDisabledReason}
               spaceType={spaceType}
               onSpaceTypeChange={setSpaceTypeOverride}
               onCalibrate={handleCalibrate}
+              showCalibrateButton={false}
               onAddReferenceMeasurement={() => {
                 setMobilePurpose('reference');
                 setMobileOpen(true);
               }}
-              parameterUpdates={paramUpdatesQuery.data ?? []}
+              parameterUpdates={[]}
               evaluation={calibrationEvaluation}
               backgroundImageUrl={backgroundImageUrl}
             />

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -83,10 +83,15 @@ export default function MeasurementPage() {
   // - Source of truth: Floor.space_type (헤더의 도면 셀렉터에서 설정)
   // - 이 페이지에서도 일회성 override 가능 — 사용자가 다른 prior 로 실험하고 싶을 때
   // - floor 가 바뀌면 그 floor 의 값으로 자동 리셋.
-  const [spaceTypeOverride, setSpaceTypeOverride] = useState<SpaceType | null>(null);
-  useEffect(() => {
-    setSpaceTypeOverride(null);  // floor 전환 시 override 해제
-  }, [floorId]);
+  const [spaceTypeOverrideState, setSpaceTypeOverrideState] = useState<{
+    floorId: string | null;
+    value: SpaceType | null;
+  }>({ floorId: null, value: null });
+  const spaceTypeOverride =
+    spaceTypeOverrideState.floorId === floorId ? spaceTypeOverrideState.value : null;
+  const setSpaceTypeOverride = (value: SpaceType | null) => {
+    setSpaceTypeOverrideState({ floorId: floorId ?? null, value });
+  };
   // Floor 의 space_type 을 reactive 하게 읽음 — 헤더에서 변경하면 즉시 반영.
   const projectIdForFloors = useAppStore((s) => s.selectedProjectId);
   const floorsList = useFloors(projectIdForFloors);
@@ -167,6 +172,7 @@ export default function MeasurementPage() {
     [activeCoverage],
   );
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [mobilePurpose, setMobilePurpose] = useState<'calibration' | 'reference'>('calibration');
   const [actionGuideOpen, setActionGuideOpen] = useState(false);
 
   const hasVersion = versions.length > 0;
@@ -192,6 +198,20 @@ export default function MeasurementPage() {
     !!latestRfRunId &&
     !!currentVersion?.id &&
     hasEnoughMeasurements;
+  const evaluationSessionIds = (() => {
+    const ids = new Set<string>();
+    for (const session of sessions) {
+      if (
+        session.measurement_purpose === 'calibration' ||
+        session.measurement_purpose === 'reference' ||
+        session.measurement_purpose === 'validation'
+      ) {
+        ids.add(session.id);
+      }
+    }
+    if (activeSession?.id) ids.add(activeSession.id);
+    return [...ids];
+  })();
   const calibrationDisabledReason = !hasMeasurement
     ? '먼저 측정을 진행해주세요.'
     : !hasEnoughMeasurements
@@ -207,7 +227,7 @@ export default function MeasurementPage() {
         floor_id: activeSession.floor_id,
         rf_run_id: latestRfRunId,
         scene_version_id: currentVersion.id,
-        measurement_session_ids: [activeSession.id],
+        measurement_session_ids: evaluationSessionIds.length > 0 ? evaluationSessionIds : [activeSession.id],
         method: 'global_offset',
         split: { strategy: 'purpose_or_random', holdout_ratio: 0.3, seed: 42 },
         visualization: {
@@ -235,7 +255,10 @@ export default function MeasurementPage() {
         floorId={floorId ?? null}
         projectId={projectIdForFloors}
         onSelectSession={(id) => setSelectedSessionId(id)}
-        onStartMeasurement={() => setMobileOpen(true)}
+        onStartMeasurement={() => {
+          setMobilePurpose('calibration');
+          setMobileOpen(true);
+        }}
       />
 
       {!floorId ? (
@@ -304,6 +327,10 @@ export default function MeasurementPage() {
               spaceType={spaceType}
               onSpaceTypeChange={setSpaceTypeOverride}
               onCalibrate={handleCalibrate}
+              onAddReferenceMeasurement={() => {
+                setMobilePurpose('reference');
+                setMobileOpen(true);
+              }}
               parameterUpdates={paramUpdatesQuery.data ?? []}
               evaluation={calibrationEvaluation}
               backgroundImageUrl={backgroundImageUrl}
@@ -317,7 +344,11 @@ export default function MeasurementPage() {
         </div>
       )}
 
-      <MobileConnectModal open={mobileOpen} onClose={() => setMobileOpen(false)} />
+      <MobileConnectModal
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        recommendedPurpose={mobilePurpose}
+      />
       <ActionGuideModal open={actionGuideOpen} onClose={() => setActionGuideOpen(false)} />
       <HelpFab />
     </div>

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -44,6 +44,12 @@ import type { RfBackend } from '@/types/rf';
 import { cn } from '@/lib/utils';
 
 type SimulationState = 'idle' | 'running' | 'complete';
+type FrequencyBand = '2.4' | '5';
+
+const frequencyHzByBand: Record<FrequencyBand, number> = {
+  '2.4': 2.4e9,
+  '5': 5.0e9,
+};
 
 export default function SimulationPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -65,6 +71,8 @@ export default function SimulationPage() {
   // 시뮬 실행 백엔드 토글 — local(기본, 로컬 ai_api) | sagemaker(클라우드).
   // 로컬에서 분 단위로 결과 보는 게 dev 흐름이라 기본값을 local 로.
   const [backend, setBackend] = useState<RfBackend>('local');
+  const [frequencyBand, setFrequencyBand] = useState<FrequencyBand>('5');
+  const [txPowerDbm, setTxPowerDbm] = useState(20);
 
   // 캔버스 배경으로 보여줄 확정 버전 상세 (rooms/walls/openings/objects 포함).
   const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
@@ -191,7 +199,18 @@ export default function SimulationPage() {
         // 모든 시뮬 파라미터는 backend `app/core/rf_defaults.py` 의 디폴트 사용 —
         // 5GHz / 20dBm / max_depth=3 / samples=100k 등. UI 에서 사용자가 직접 정하는
         // 값이 생기면 여기 채워 보내면 backend 가 우선 적용. 빈 `{}` 는 "new flow" 트리거.
-        simulation: {},
+        simulation: {
+          frequency_hz: frequencyHzByBand[frequencyBand],
+          tx_power_dbm: txPowerDbm,
+        },
+        metadata: {
+          rf_physical_ui: {
+            frequency_band: frequencyBand,
+            frequency_hz: frequencyHzByBand[frequencyBand],
+            tx_power_dbm: txPowerDbm,
+          },
+        },
+        apply_calibration: false,
         backend,
       },
       { onSuccess: (data) => setActiveRunId(data.id) },
@@ -257,6 +276,10 @@ export default function SimulationPage() {
         apsCount={aps.length}
         backend={backend}
         onBackendChange={setBackend}
+        frequencyBand={frequencyBand}
+        onFrequencyBandChange={setFrequencyBand}
+        txPowerDbm={txPowerDbm}
+        onTxPowerDbmChange={setTxPowerDbm}
         floorId={floorId ?? null}
         projectId={selectedProjectId}
         onStart={handleStart}
@@ -456,6 +479,10 @@ function PageHeader({
   apsCount,
   backend,
   onBackendChange,
+  frequencyBand,
+  onFrequencyBandChange,
+  txPowerDbm,
+  onTxPowerDbmChange,
   floorId,
   projectId,
   onStart,
@@ -467,6 +494,10 @@ function PageHeader({
   apsCount: number;
   backend: RfBackend;
   onBackendChange: (b: RfBackend) => void;
+  frequencyBand: FrequencyBand;
+  onFrequencyBandChange: (band: FrequencyBand) => void;
+  txPowerDbm: number;
+  onTxPowerDbmChange: (value: number) => void;
   floorId: string | null;
   projectId: string | null;
   onStart: () => void;
@@ -481,7 +512,7 @@ function PageHeader({
         </p>
       </div>
 
-      <div className="flex shrink-0 items-center gap-3">
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
         {state === 'idle' && (
           <>
             {/* 공간 유형 — Floor.space_type 직접 수정. 변경 시 즉시 저장 (다음 calibration 에 자동 반영).
@@ -490,6 +521,13 @@ function PageHeader({
               floorId={floorId}
               projectId={projectId}
               showLabel={false}
+            />
+            <RfPhysicalControls
+              frequencyBand={frequencyBand}
+              onFrequencyBandChange={onFrequencyBandChange}
+              txPowerDbm={txPowerDbm}
+              onTxPowerDbmChange={onTxPowerDbmChange}
+              disabled={isStarting}
             />
             <BackendToggle value={backend} onChange={onBackendChange} disabled={isStarting} />
           </>
@@ -525,6 +563,71 @@ function PageHeader({
 }
 
 /** SageMaker | Local 백엔드 토글 (idle 일 때만 노출). */
+function RfPhysicalControls({
+  frequencyBand,
+  onFrequencyBandChange,
+  txPowerDbm,
+  onTxPowerDbmChange,
+  disabled,
+}: {
+  frequencyBand: FrequencyBand;
+  onFrequencyBandChange: (band: FrequencyBand) => void;
+  txPowerDbm: number;
+  onTxPowerDbmChange: (value: number) => void;
+  disabled?: boolean;
+}) {
+  const bands: Array<{ key: FrequencyBand; label: string; hint: string }> = [
+    { key: '2.4', label: '2.4GHz', hint: 'Use this when Android measurements are on 2.4GHz Wi-Fi.' },
+    { key: '5', label: '5GHz', hint: 'Use this when Android measurements are on 5GHz Wi-Fi.' },
+  ];
+  const handleTxPowerChange = (value: string) => {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return;
+    onTxPowerDbmChange(Math.min(30, Math.max(0, parsed)));
+  };
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-lg border bg-background p-1 shadow-sm">
+      <div className="inline-flex items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+        {bands.map((band) => {
+          const active = frequencyBand === band.key;
+          return (
+            <button
+              key={band.key}
+              type="button"
+              onClick={() => onFrequencyBandChange(band.key)}
+              disabled={disabled}
+              title={band.hint}
+              className={cn(
+                'rounded px-2 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                active
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {band.label}
+            </button>
+          );
+        })}
+      </div>
+      <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        Tx
+        <input
+          type="number"
+          min={0}
+          max={30}
+          step={1}
+          value={txPowerDbm}
+          onChange={(event) => handleTxPowerChange(event.target.value)}
+          disabled={disabled}
+          className="h-7 w-14 rounded-md border bg-background px-2 text-right text-xs font-medium text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        dBm
+      </label>
+    </div>
+  );
+}
+
 function BackendToggle({
   value,
   onChange,

--- a/frontend/src/types/calibration-run.ts
+++ b/frontend/src/types/calibration-run.ts
@@ -89,6 +89,7 @@ export interface CalibrationEvaluationResponse {
   points: {
     calibration: CalibrationEvaluationPoint[];
     validation: CalibrationEvaluationPoint[];
+    evaluation?: CalibrationEvaluationPoint[];
     reference: CalibrationEvaluationPoint[];
     invalid: CalibrationEvaluationPoint[];
   };

--- a/frontend/src/types/calibration-run.ts
+++ b/frontend/src/types/calibration-run.ts
@@ -39,7 +39,7 @@ export interface CalibrationEvaluationRequest {
   scene_version_id: UUID;
   rf_run_id: UUID;
   measurement_session_ids: UUID[];
-  method?: 'global_offset';
+  method?: 'affine_rssi_transfer' | 'global_offset';
   split?: {
     strategy: 'purpose_or_random' | 'random';
     holdout_ratio: number;


### PR DESCRIPTION
## 개요
- SionnaRT 기반 원본 예측 RSSI와 Android 실측 RSSI를 비교하여, 예측 결과를 실측 스케일에 맞게 보정하고 이를 시각적으로 확인할 수 있는 통합 분석 기능을 추가
- 기존에는 시뮬레이션 결과와 실측 결과를 개별적으로 확인하는 수준이었다면, 이번 변경을 통해 다음 세 가지 맵을 같은 좌표계와 같은 RSSI 색상 스케일에서 비교할 수 있다.

1. Baseline Simulation: 원본 SionnaRT 예측 맵
2. Calibrated Simulation: RSSI transfer + residual IDW 보정 맵
3. Measured Reference Map: 실측 RSSI 기반 보간 참고 맵

이를 통해 사용자는 “시뮬레이션이 실제 측정값과 얼마나 다른지”, “보정 후 오차가 얼마나 줄었는지”, “어느 위치에서 예측 오차가 크게 남는지”를 한 화면에서 확인할 수 있다.

<img width="1914" height="1127" alt="스크린샷 2026-05-30 093202" src="https://github.com/user-attachments/assets/668938a9-37a8-4332-8e9f-f1fa6c832937" />

## 변경 사항
### 1. 실측 RSSI 기반 보정 방식 개선
SionnaRT 원본 예측값과 Android 실측 RSSI 사이의 차이를 보정하기 위해 기존 global offset 중심 방식에서 affine RSSI transfer 기반 방식으로 확장

보정 흐름
```text
실측점 i의 위치: (xi, yi)
S_i = SionnaRT 예측맵에서 (xi, yi)를 샘플링한 값
M_i = Android가 실제로 측정한 RSSI
M_i ≈ aS_i + b 가 되도록 a, b를 찾음

S(x, y) = SionnaRT baseline RSSI 
T(x, y) = aS(x, y) + b 
ri = Mi - T(xi, yi) 
R(x, y) = IDW(ri) 
C(x, y) = T(x, y) + λR(x, y)
```

즉, 먼저 선형 보정으로 전체 RSSI 스케일과 편향을 맞추고, 이후에도 남는 위치별 residual을 IDW 방식으로 부드럽게 보간하여 최종 보정 맵에 반영

현재 residual 반영 강도는 0.6, residual 탐색 반경은 6m로 적용
이를 통해 실측점 주변은 실측 RSSI에 가까워지면서도, 측정하지 않은 영역은 SionnaRT의 물리 기반 공간 패턴을 유지

### 2. Calibration Evaluation 응답 구조 확장
캘리브레이션 결과에 baseline map, calibrated map, measured reference map을 포함하도록 응답 구조를 확장

### 3. Reference measurement 흐름 추가
- 측정 세션을 calibration/reference 목적에 따라 구분할 수 있도록 measurement link 생성 과정에 `recommended_measurement_purpose`를 추가
- 프론트엔드에서는 Reference 비교용 측정을 시작할 수 있도록 모바일 연결 모달에 recommended purpose를 전달하고, 백엔드는 해당 purpose를 measurement link와 context 응답에 반영
- 이를 통해 보정에 사용되는 측정점과, 보정 결과를 검증하거나 비교하기 위한 reference 측정점을 분리해서 사용할 수 있다,

### 4. 측정 페이지에서 자동 통합 분석 실행
- 측정 페이지의 통합 분석 모드에서 충분한 측정점, 최신 RF Run, 현재 scene version이 준비되면 calibration evaluation을 실행하도록 연결
- 이를 통해 사용자가 측정 후 바로 예측/실측 통합 분석 결과를 확인

### 5. 3-way RSSI 비교 UI 개선
- CalibrationCard에 3-way RSSI map comparison 뷰를 추가
- 각 맵은 동일한 floorplan, grid bounds, RSSI color scale을 사용하므로 baseline, calibrated, measured reference 결과를 직관적으로 비교
- 또한 측정 포인트에 tooltip을 추가하여 각 포인트에서 다음 정보를 확인
    - measured RSSI
    - baseline prediction
    - calibrated prediction
    - before error
    - after error
    - floor position
- 오차가 큰 지점은 원형 error marker로 표시하여 보정 전후의 차이를 시각적으로 확인

### 6. RF Run 기본 동작 정리
- RF Run 생성 시 기본값을 raw simulation 중심으로 정리
- apply_calibration의 기본값을 false로 두어, 일반 시뮬레이션은 원본 예측 결과를 생성하고, 보정 후 재실행처럼 의도가 명확한 경우에만 calibration을 적용


## 기대 효과
- SionnaRT 예측값과 Android 실측값의 RSSI 스케일 차이를 줄일 수 있다.
- AP 주변 과대 예측, 전체 RSSI 범위 불일치 문제를 완화할 수 있다.
- 벽 뒤, 코너, 가구 밀집 구역 등 위치별 residual을 반영할 수 있다.
- 측정하지 않은 영역은 물리 기반 SionnaRT 패턴을 유지할 수 있다.
- 발표/시연 시 “실측 + 예측 통합맵”을 설득력 있게 보여줄 수 있다.
- 보정 전후 MAE/RMSE 및 포인트별 오차를 통해 개선 정도를 정량적으로 설명할 수 있다.