### PR TITLE
feat: AP 배치 추천 화면 전환 및 추천 위치 선택·저장 플로우 구현

### DIFF
--- a/frontend/src/api/ap-recommendation.ts
+++ b/frontend/src/api/ap-recommendation.ts
@@ -1,0 +1,11 @@
+import { api } from './client';
+import type {
+  ApRecommendationRequest,
+  ApRecommendationResponse,
+} from '@/types/ap-recommendation';
+
+export const apRecommendationApi = {
+  /** POST /ap-recommendation — Grid Search 기반 AP 최적 위치 추천. */
+  recommend: (body: ApRecommendationRequest) =>
+    api.post<ApRecommendationResponse>('/ap-recommendation', body).then((r) => r.data),
+};

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -1,0 +1,440 @@
+import { useMemo, useRef, useState } from 'react';
+import { parseGeometry, type Coord } from '@/features/editor/geometry-utils';
+import { loadCachedViewBox } from '@/features/editor/viewbox-cache';
+import {
+  deriveImageExtent,
+  useImageNaturalDimensions,
+} from '@/features/editor/floorplan-image-extent';
+import type { ApRecommendationResult } from '@/types/ap-recommendation';
+import type { DraftOpening, DraftWall, SceneVersion } from '@/types/scene';
+import { cn } from '@/lib/utils';
+import {
+  clampCoord,
+  clampMeterBBox,
+  clampRectToBounds,
+  computeSceneBounds,
+  isValidSelectionBBox,
+  meterBBoxFromRect,
+  normalizeRect,
+  type MeterBBox,
+} from './recommendation-utils';
+
+export interface CanvasExistingAp {
+  id: string;
+  x_m: number;
+  y_m: number;
+  label?: string;
+}
+
+const RECOMMEND_RADIUS_M = 0.28;
+const DRAG_THRESHOLD_M = 0.15;
+/** viewBox 너비 비율 — 도면 스케일과 무관하게 화면에서 읽기 쉬운 라벨 크기 */
+const CANVAS_LABEL_VB_RATIO = 0.018;
+
+function canvasLabelFontM(viewBoxW: number): number {
+  return viewBoxW * CANVAS_LABEL_VB_RATIO;
+}
+
+interface Props {
+  sceneVersion: SceneVersion | null | undefined;
+  backgroundImageUrl?: string | null;
+  existingAps: CanvasExistingAp[];
+  selectionBBox: MeterBBox | null;
+  onSelectionChange: (bbox: MeterBBox | null) => void;
+  recommendations: ApRecommendationResult[];
+  selectedRecommendationRank: number | null;
+  disabled?: boolean;
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function emptyBounds(): Bounds {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+}
+
+function extendBounds(b: Bounds, x: number, y: number) {
+  if (x < b.minX) b.minX = x;
+  if (y < b.minY) b.minY = y;
+  if (x > b.maxX) b.maxX = x;
+  if (y > b.maxY) b.maxY = y;
+}
+
+function computeViewBox(
+  scene: SceneVersion | null | undefined,
+  imageExtent: { w: number; h: number } | null,
+) {
+  const b = emptyBounds();
+  for (const wall of scene?.walls ?? []) {
+    const g = parseGeometry(wall.centerline_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  for (const op of scene?.openings ?? []) {
+    const g = parseGeometry(op.line_geom);
+    if (g?.type === 'LineString') for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+  }
+  if (imageExtent) {
+    extendBounds(b, 0, 0);
+    extendBounds(b, imageExtent.w, imageExtent.h);
+  }
+  if (!isFinite(b.minX)) return { x: 0, y: 0, w: 10, h: 10 };
+  const w = b.maxX - b.minX || 1;
+  const h = b.maxY - b.minY || 1;
+  const padding = Math.max(w, h) * 0.05;
+  return { x: b.minX - padding, y: b.minY - padding, w: w + 2 * padding, h: h + 2 * padding };
+}
+
+export function ApRecommendationCanvas({
+  sceneVersion,
+  backgroundImageUrl,
+  selectionBBox,
+  onSelectionChange,
+  recommendations,
+  selectedRecommendationRank,
+  disabled = false,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [drag, setDrag] = useState<{ start: Coord; current: Coord } | null>(null);
+
+  const imageDims = useImageNaturalDimensions(backgroundImageUrl ?? null);
+  const imageExtent = useMemo(
+    () =>
+      deriveImageExtent(imageDims, {
+        sourceAssetId: sceneVersion?.source_asset_id ?? null,
+        floorId: sceneVersion?.floor_id ?? null,
+      }),
+    [imageDims, sceneVersion?.source_asset_id, sceneVersion?.floor_id],
+  );
+
+  const vb = useMemo(() => {
+    const cached = loadCachedViewBox(sceneVersion?.floor_id ?? null);
+    if (cached) return cached;
+    if (imageExtent) return computeViewBox(sceneVersion, imageExtent);
+    return computeViewBox(sceneVersion, null);
+  }, [sceneVersion?.floor_id, sceneVersion, imageExtent]);
+
+  const sceneBounds = useMemo(
+    () => computeSceneBounds(sceneVersion, imageExtent),
+    [sceneVersion, imageExtent],
+  );
+
+  const clampPoint = (pt: Coord): Coord => clampCoord(pt, sceneBounds);
+
+  const getSvgPoint = (e: React.PointerEvent): Coord | null => {
+    const svg = svgRef.current;
+    if (!svg) return null;
+    const pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return null;
+    const t = pt.matrixTransform(ctm.inverse());
+    return clampPoint([t.x, t.y]);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (disabled) return;
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    svgRef.current?.setPointerCapture(e.pointerId);
+    setDrag({ start: pt, current: pt });
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!drag) return;
+    const pt = getSvgPoint(e);
+    if (!pt) return;
+    setDrag({ start: drag.start, current: pt });
+  };
+
+  const finishDrag = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!drag) return;
+    try {
+      svgRef.current?.releasePointerCapture(e.pointerId);
+    } catch {
+      /* already released */
+    }
+    const rect = clampRectToBounds(normalizeRect(drag.start, drag.current), sceneBounds);
+    setDrag(null);
+    if (rect.w < DRAG_THRESHOLD_M || rect.h < DRAG_THRESHOLD_M) {
+      onSelectionChange(null);
+      return;
+    }
+    const bbox = clampMeterBBox(meterBBoxFromRect(rect), sceneBounds);
+    if (isValidSelectionBBox(bbox)) {
+      onSelectionChange(bbox);
+    }
+  };
+
+  const dragRect = drag
+    ? clampRectToBounds(normalizeRect(drag.start, drag.current), sceneBounds)
+    : null;
+  const clampedSelectionBBox = selectionBBox
+    ? clampMeterBBox(selectionBBox, sceneBounds)
+    : null;
+  const showDragPreview =
+    dragRect && (dragRect.w >= DRAG_THRESHOLD_M || dragRect.h >= DRAG_THRESHOLD_M);
+  const labelFontM = canvasLabelFontM(vb.w);
+  const selectionBadgeH = labelFontM * 1.55;
+  const selectionBadgeW = labelFontM * 8.2;
+
+  return (
+    <div className="relative h-full w-full overflow-hidden bg-[#f8fafc] [background-image:radial-gradient(circle,oklch(0.92_0_0)_1px,transparent_1px)] bg-size-[18px_18px] bg-position-[0_0]">
+      <svg
+        ref={svgRef}
+        viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
+        preserveAspectRatio="xMidYMid meet"
+        overflow="hidden"
+        className={cn(
+          'h-full w-full select-none touch-none',
+          disabled ? 'cursor-not-allowed opacity-60' : 'cursor-crosshair',
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={finishDrag}
+        onPointerCancel={finishDrag}
+      >
+        <defs>
+          <clipPath id="ap-rec-scene-clip">
+            <rect
+              x={sceneBounds.xMin}
+              y={sceneBounds.yMin}
+              width={sceneBounds.xMax - sceneBounds.xMin}
+              height={sceneBounds.yMax - sceneBounds.yMin}
+            />
+          </clipPath>
+        </defs>
+        <g clipPath="url(#ap-rec-scene-clip)">
+          {backgroundImageUrl && (
+            <image
+              href={backgroundImageUrl}
+              xlinkHref={backgroundImageUrl}
+              x={imageExtent ? 0 : vb.x}
+              y={imageExtent ? 0 : vb.y}
+              width={imageExtent ? imageExtent.w : vb.w}
+              height={imageExtent ? imageExtent.h : vb.h}
+              preserveAspectRatio={imageExtent ? 'none' : 'xMidYMid meet'}
+              opacity={0.35}
+              pointerEvents="none"
+              crossOrigin="anonymous"
+            />
+          )}
+
+          {(sceneVersion?.walls ?? []).map((w) => (
+            <WallShape key={w.id} wall={w} />
+          ))}
+          {(sceneVersion?.openings ?? []).map((o) => (
+            <OpeningShape key={o.id} opening={o} />
+          ))}
+
+          {recommendations.map((rec) => (
+            <RecommendationMarker
+              key={rec.rank}
+              rec={rec}
+              selected={selectedRecommendationRank === rec.rank}
+              labelFontM={labelFontM}
+            />
+          ))}
+        </g>
+
+        {/* 선택 영역 — clamp된 좌표, clipPath 밖(배지가 상단에서 잘리지 않도록) */}
+        <g pointerEvents="none">
+          {clampedSelectionBBox && (
+            <g>
+              <rect
+                x={clampedSelectionBBox.x_min}
+                y={clampedSelectionBBox.y_min}
+                width={clampedSelectionBBox.x_max - clampedSelectionBBox.x_min}
+                height={clampedSelectionBBox.y_max - clampedSelectionBBox.y_min}
+                fill="rgb(37 99 235 / 0.22)"
+                stroke="rgb(37 99 235)"
+                strokeWidth="1.5"
+                vectorEffect="non-scaling-stroke"
+              />
+              <rect
+                x={clampedSelectionBBox.x_min}
+                y={clampedSelectionBBox.y_min - selectionBadgeH}
+                width={selectionBadgeW}
+                height={selectionBadgeH}
+                fill="oklch(0.55 0.22 254)"
+              />
+              <text
+                x={clampedSelectionBBox.x_min + labelFontM * 0.45}
+                y={clampedSelectionBBox.y_min - selectionBadgeH * 0.38}
+                fontSize={labelFontM * 0.92}
+                fontWeight="600"
+                fill="white"
+                style={{ userSelect: 'none' }}
+              >
+                우선 개선 영역
+              </text>
+            </g>
+          )}
+
+          {showDragPreview && dragRect && (
+            <rect
+              x={dragRect.x}
+              y={dragRect.y}
+              width={dragRect.w}
+              height={dragRect.h}
+              fill="rgb(37 99 235 / 0.18)"
+              stroke="rgb(37 99 235)"
+              strokeWidth="1.5"
+              strokeDasharray="4 3"
+              vectorEffect="non-scaling-stroke"
+            />
+          )}
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+function WallShape({ wall }: { wall: DraftWall }) {
+  const g = parseGeometry(wall.centerline_geom);
+  if (g?.type !== 'LineString') return null;
+  const start = g.coordinates[0];
+  const end = g.coordinates[g.coordinates.length - 1];
+  if (!start || !end) return null;
+  return (
+    <line
+      x1={start[0]}
+      y1={start[1]}
+      x2={end[0]}
+      y2={end[1]}
+      stroke="oklch(0.25 0 0)"
+      strokeWidth="4"
+      strokeLinecap="round"
+      vectorEffect="non-scaling-stroke"
+      pointerEvents="none"
+    />
+  );
+}
+
+function OpeningShape({ opening }: { opening: DraftOpening }) {
+  const g = parseGeometry(opening.line_geom);
+  if (g?.type !== 'LineString') return null;
+  const start = g.coordinates[0];
+  const end = g.coordinates[g.coordinates.length - 1];
+  if (!start || !end) return null;
+  const isDoor = opening.opening_type === 'door';
+  const color = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  return (
+    <line
+      x1={start[0]}
+      y1={start[1]}
+      x2={end[0]}
+      y2={end[1]}
+      stroke={color}
+      strokeWidth="5"
+      strokeLinecap="butt"
+      vectorEffect="non-scaling-stroke"
+      pointerEvents="none"
+    />
+  );
+}
+
+/* [existing AP 비표시] ExistingApMarker — 다시 켤 때 주석 해제
+function ExistingApMarker({ ap }: { ap: CanvasExistingAp }) {
+  const r = EXISTING_AP_RADIUS_M;
+  const label = ap.label ?? ap.id.toUpperCase();
+  return (
+    <g pointerEvents="none">
+      <circle cx={ap.x_m} cy={ap.y_m} r={r} fill="oklch(0.55 0.22 254)" />
+      <g
+        transform={`translate(${ap.x_m - r * 0.55}, ${ap.y_m - r * 0.55}) scale(${r / 12})`}
+        fill="none"
+        stroke="white"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 20h.01" />
+        <path d="M2 8.82a15 15 0 0 1 20 0" />
+        <path d="M5 12.859a10 10 0 0 1 14 0" />
+        <path d="M8.5 16.429a5 5 0 0 1 7 0" />
+      </g>
+      <rect
+        x={ap.x_m - 0.18}
+        y={ap.y_m + r + 0.04}
+        width={r * 1.8}
+        height={r * 0.75}
+        rx={r * 0.18}
+        fill="white"
+        stroke="oklch(0.85 0.02 240)"
+        strokeWidth="1"
+        vectorEffect="non-scaling-stroke"
+      />
+      <text
+        x={ap.x_m}
+        y={ap.y_m + r + r * 0.38}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={EXISTING_AP_LABEL_FONT_M}
+        fontWeight="600"
+        fill="oklch(0.25 0.04 240)"
+        style={{ userSelect: 'none' }}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+*/
+
+function RecommendationMarker({
+  rec,
+  selected,
+  labelFontM,
+}: {
+  rec: ApRecommendationResult;
+  selected: boolean;
+  labelFontM: number;
+}) {
+  const r = RECOMMEND_RADIUS_M;
+  const fill = selected ? 'oklch(0.62 0.19 145)' : 'oklch(0.72 0.19 145)';
+  return (
+    <g pointerEvents="none">
+      <circle
+        cx={rec.recommended_x}
+        cy={rec.recommended_y}
+        r={r}
+        fill={fill}
+        stroke="white"
+        strokeWidth="2"
+        vectorEffect="non-scaling-stroke"
+      />
+      <text
+        x={rec.recommended_x}
+        y={rec.recommended_y}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={Math.max(r * 0.75, labelFontM * 0.85)}
+        fontWeight="700"
+        fill="white"
+        style={{ userSelect: 'none' }}
+      >
+        {rec.rank}
+      </text>
+      <text
+        x={rec.recommended_x}
+        y={rec.recommended_y + r + labelFontM * 1.05}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={labelFontM}
+        fontWeight="700"
+        fill="oklch(0.28 0.1 145)"
+        stroke="white"
+        strokeWidth={labelFontM * 0.12}
+        paintOrder="stroke fill"
+        style={{ userSelect: 'none' }}
+      >
+        추천 {rec.rank}
+      </text>
+    </g>
+  );
+}

--- a/frontend/src/features/ap-recommendation/ap-canvas-mappers.ts
+++ b/frontend/src/features/ap-recommendation/ap-canvas-mappers.ts
@@ -1,0 +1,44 @@
+import { parseGeometry } from '@/features/editor/geometry-utils';
+import type { ApLayout } from '@/types/ap-layout';
+import type { CanvasExistingAp } from './ApRecommendationCanvas';
+
+/** ApLayout.point_geom → 캔버스 AP 마커. */
+export function apLayoutsToCanvas(layouts: ApLayout[]): CanvasExistingAp[] {
+  const result: CanvasExistingAp[] = [];
+  for (const l of layouts) {
+    const g = parseGeometry(l.point_geom);
+    if (g?.type !== 'Point') continue;
+    const [x, y] = g.coordinates;
+    result.push({ id: l.id, x_m: x, y_m: y, label: l.ap_name });
+  }
+  return result;
+}
+
+/** rf_run.request_json.access_points → 캔버스 AP 마커. */
+export function apsFromRfRunRequest(
+  requestJson: Record<string, unknown> | undefined,
+): CanvasExistingAp[] {
+  if (!requestJson) return [];
+  const raw = (requestJson as { access_points?: unknown }).access_points;
+  if (!Array.isArray(raw)) return [];
+  const out: CanvasExistingAp[] = [];
+  raw.forEach((entry, i) => {
+    if (!entry || typeof entry !== 'object') return;
+    const r = entry as Record<string, unknown>;
+    const x = Number(r['x_m'] ?? r['x']);
+    const y = Number(r['y_m'] ?? r['y']);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    const id = typeof r['id'] === 'string' ? r['id'] : `ap${i + 1}`;
+    out.push({ id, x_m: x, y_m: y, label: id.toUpperCase() });
+  });
+  return out;
+}
+
+/** POST /ap-layouts — 새 AP 이름 (기존 배치·캔버스 AP 수 기준). */
+export function nextApLayoutName(
+  layouts: { ap_name: string }[],
+  canvasAps: { id: string }[],
+): string {
+  const seq = Math.max(layouts.length, canvasAps.length) + 1;
+  return `AP-${String(seq).padStart(2, '0')}`;
+}

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -1,0 +1,190 @@
+import type {
+  ExistingAp,
+  ApRecommendationRequest,
+  ApRecommendationResponse,
+  ApRecommendationResult,
+} from '@/types/ap-recommendation';
+import type { UUID } from '@/types/common';
+import { parseGeometry } from '@/features/editor/geometry-utils';
+
+/** AP 설치 높이 기본값 — SimulationCanvas DEFAULT_AP_Z_M 과 동일. */
+export const AP_DEFAULT_Z_M = 2.5;
+
+/** 미터 단위 선택 영역 (API x_min/x_max/y_min/y_max). */
+export interface MeterBBox {
+  x_min: number;
+  x_max: number;
+  y_min: number;
+  y_max: number;
+}
+
+const MIN_SELECTION_M = 0.2;
+
+/** normalizeRect 결과 → MeterBBox. */
+export function meterBBoxFromRect(rect: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}): MeterBBox {
+  return {
+    x_min: rect.x,
+    x_max: rect.x + rect.w,
+    y_min: rect.y,
+    y_max: rect.y + rect.h,
+  };
+}
+
+export function isValidSelectionBBox(bbox: MeterBBox | null): bbox is MeterBBox {
+  if (!bbox) return false;
+  const w = bbox.x_max - bbox.x_min;
+  const h = bbox.y_max - bbox.y_min;
+  return w >= MIN_SELECTION_M && h >= MIN_SELECTION_M;
+}
+
+/** POST /ap-recommendation 요청 본문 조립 (백엔드 default 필드는 생략). */
+export function buildApRecommendationPayload(params: {
+  sceneVersionId: UUID;
+  bbox: MeterBBox;
+  existingAps: { id: string; x_m: number; y_m: number }[];
+  txPowerDbm?: number;
+}): ApRecommendationRequest {
+  return {
+    scene_version_id: params.sceneVersionId,
+    x_min: params.bbox.x_min,
+    x_max: params.bbox.x_max,
+    y_min: params.bbox.y_min,
+    y_max: params.bbox.y_max,
+    existing_aps: mapToExistingAps(params.existingAps, params.txPowerDbm),
+  };
+}
+
+/** 단일 응답 → rank 배열. 추후 복수 추천 API 대응용. */
+export function normalizeRecommendations(
+  response: ApRecommendationResponse | ApRecommendationResponse[] | null | undefined,
+): ApRecommendationResult[] {
+  if (!response) return [];
+  const list = Array.isArray(response) ? response : [response];
+  return list.map((item, i) => ({
+    rank: i + 1,
+    recommended_x: item.recommended_x,
+    recommended_y: item.recommended_y,
+    score: item.score,
+    status: item.status,
+    candidates_evaluated: item.candidates_evaluated,
+  }));
+}
+
+/** 캔버스 AP → API existing_aps. tx_power_dbm 없으면 필드 생략(백엔드 default 20). */
+export function mapToExistingAps(
+  aps: { id: string; x_m: number; y_m: number }[],
+  txPowerDbm?: number,
+): ExistingAp[] {
+  return aps.map((ap) => {
+    const base: ExistingAp = { id: ap.id, x_m: ap.x_m, y_m: ap.y_m };
+    if (txPowerDbm != null && Number.isFinite(txPowerDbm)) {
+      base.tx_power_dbm = txPowerDbm;
+    }
+    return base;
+  });
+}
+
+/** 두 코너 → (x,y,w,h) 사각형 정규화. */
+export function normalizeRect(
+  a: [number, number],
+  b: [number, number],
+): { x: number; y: number; w: number; h: number } {
+  const x = Math.min(a[0], b[0]);
+  const y = Math.min(a[1], b[1]);
+  const w = Math.abs(a[0] - b[0]);
+  const h = Math.abs(a[1] - b[1]);
+  return { x, y, w, h };
+}
+
+/** 드래그 선택 가능 영역 (미터). 도면 이미지 extent 또는 벽/개구부 tight bounds. */
+export interface SceneBounds {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function clampCoord(
+  point: [number, number],
+  bounds: SceneBounds,
+): [number, number] {
+  return [
+    clamp(point[0], bounds.xMin, bounds.xMax),
+    clamp(point[1], bounds.yMin, bounds.yMax),
+  ];
+}
+
+/** 사각형을 scene bounds 안으로 제한. */
+export function clampRectToBounds(
+  rect: { x: number; y: number; w: number; h: number },
+  bounds: SceneBounds,
+): { x: number; y: number; w: number; h: number } {
+  const x1 = clamp(rect.x, bounds.xMin, bounds.xMax);
+  const y1 = clamp(rect.y, bounds.yMin, bounds.yMax);
+  const x2 = clamp(rect.x + rect.w, bounds.xMin, bounds.xMax);
+  const y2 = clamp(rect.y + rect.h, bounds.yMin, bounds.yMax);
+  return normalizeRect([x1, y1], [x2, y2]);
+}
+
+/** MeterBBox를 scene bounds 안으로 제한. */
+export function clampMeterBBox(bbox: MeterBBox, bounds: SceneBounds): MeterBBox {
+  const x_min = clamp(bbox.x_min, bounds.xMin, bounds.xMax);
+  const x_max = clamp(bbox.x_max, bounds.xMin, bounds.xMax);
+  const y_min = clamp(bbox.y_min, bounds.yMin, bounds.yMax);
+  const y_max = clamp(bbox.y_max, bounds.yMin, bounds.yMax);
+  return {
+    x_min: Math.min(x_min, x_max),
+    x_max: Math.max(x_min, x_max),
+    y_min: Math.min(y_min, y_max),
+    y_max: Math.max(y_min, y_max),
+  };
+}
+
+interface GeometryBoundsInput {
+  walls?: { centerline_geom?: Record<string, unknown> | null }[];
+  openings?: { line_geom?: Record<string, unknown> | null }[];
+}
+
+function extendBoundsFromGeometry(
+  b: { minX: number; minY: number; maxX: number; maxY: number },
+  geom: Record<string, unknown> | null | undefined,
+) {
+  const g = parseGeometry(geom);
+  if (g?.type !== 'LineString') return;
+  for (const [x, y] of g.coordinates) {
+    if (x < b.minX) b.minX = x;
+    if (y < b.minY) b.minY = y;
+    if (x > b.maxX) b.maxX = x;
+    if (y > b.maxY) b.maxY = y;
+  }
+}
+
+/** 도면 이미지 extent 우선, 없으면 벽/개구부 union tight bounds. */
+export function computeSceneBounds(
+  scene: GeometryBoundsInput | null | undefined,
+  imageExtent: { w: number; h: number } | null,
+): SceneBounds {
+  if (imageExtent && imageExtent.w > 0 && imageExtent.h > 0) {
+    return { xMin: 0, yMin: 0, xMax: imageExtent.w, yMax: imageExtent.h };
+  }
+  const b = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+  for (const wall of scene?.walls ?? []) {
+    extendBoundsFromGeometry(b, wall.centerline_geom);
+  }
+  for (const opening of scene?.openings ?? []) {
+    extendBoundsFromGeometry(b, opening.line_geom);
+  }
+  if (!Number.isFinite(b.minX)) {
+    return { xMin: 0, yMin: 0, xMax: 10, yMax: 10 };
+  }
+  return { xMin: b.minX, yMin: b.minY, xMax: b.maxX, yMax: b.maxY };
+}

--- a/frontend/src/features/editor/CanvasToolbar.tsx
+++ b/frontend/src/features/editor/CanvasToolbar.tsx
@@ -29,7 +29,7 @@ const TOP_TOOLS: ToolDef[] = [
 ];
 
 const SHAPE_TOOLS: ToolDef[] = [
-  { id: 'rect', icon: WallIcon, label: '벽/구조물', onClick: 'change' },
+  { id: 'rect', icon: WallIcon, label: '벽', onClick: 'change' },
   // [room 비활성화] '방 만들기' 도구 노출 제거. 다시 켜려면 아래 줄 주석 해제.
   // { id: 'polygon', icon: Hexagon, label: '방 만들기', onClick: 'change' },
   { id: 'door', icon: DoorOpen, label: '문 추가', onClick: 'change' },

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -1625,6 +1625,7 @@ function CreationHint({
     } else {
       text = `시작점을 다시 클릭하면 방이 완성됩니다. (현재 ${creating.points.length}개 점)`;
     }
+  }
   // [object 비활성화] 가구 배치 안내 제거.
   // else if (tool === 'circle') {
   //   text = '캔버스를 클릭해 가구를 배치하세요.';

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -36,6 +36,9 @@ export type MeasurementViewMode = 'route' | 'heatmap' | 'both';
 /** 측정점 색 모드 — heatmap 배경과 시각 통일하려면 'dbm', 신호 품질 한눈에 보려면 'quality'. */
 export type PointColorMode = 'quality' | 'dbm';
 
+const AP_MARKER_RADIUS_M = 0.32;
+const AP_LABEL_FONT_SIZE_M = 0.22;
+
 interface Props {
   sceneVersion: SceneVersion | null | undefined;
   /** 원본 도면 이미지 (배경에 연하게 깔림). 공간편집/시뮬과 동일한 방식. */
@@ -405,9 +408,11 @@ export function MeasurementCanvas({
         {(sceneVersion?.openings ?? []).map((o) => (
           <OpeningShape key={o.id} opening={o} />
         ))}
-        {(sceneVersion?.objects ?? []).map((o) => (
+        {/* [object 비활성화] 실측 캔버스에서 가구/공간성 객체 렌더 제거.
+            다시 켜려면 아래 블록 주석 해제. */}
+        {/* {(sceneVersion?.objects ?? []).map((o) => (
           <ObjectShape key={o.id} object={o} />
-        ))}
+        ))} */}
 
         {/* 측정 경로 라인 — route/both 모드에서만 (heatmap 모드는 점만 표시). */}
         {showLine && sortedPoints.length >= 2 && (
@@ -619,7 +624,7 @@ function objectTypeLabel(t: string | null | undefined): string | null {
 
 function ApMarker({ ap }: { ap: PlacedApSimple }) {
   const fill = 'oklch(0.55 0.22 254)';
-  const r = 0.5;
+  const r = AP_MARKER_RADIUS_M;
   const iconSize = r * 1.1;
   const iconScale = iconSize / 24;
   return (
@@ -641,10 +646,10 @@ function ApMarker({ ap }: { ap: PlacedApSimple }) {
       {ap.label && (
         <text
           x={ap.x_m}
-          y={ap.y_m + r + 0.35}
+          y={ap.y_m + r + r * 0.7}
           textAnchor="middle"
           dominantBaseline="middle"
-          fontSize={0.35}
+          fontSize={AP_LABEL_FONT_SIZE_M}
           fontWeight="600"
           fill="oklch(0.4 0.1 254)"
         >

--- a/frontend/src/features/simulation/DbmColorBar.tsx
+++ b/frontend/src/features/simulation/DbmColorBar.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
 /**
  * RSSI dBm → 색 그라데이션 + tick 라벨 colorbar.
  *
@@ -30,8 +34,6 @@ interface Props {
   tickCount?: number;
   /** 라벨 — 컬러바 위쪽에 작게 표시 (예: "실측 RSSI", "예측 RSSI"). 미지정시 없음. */
   label?: string;
-  /** 데이터가 sim 기반 정확 스케일이 아닌 경우 (예: API 응답 없을때 fallback). 표시되면 "approx." 뱃지. */
-  approximate?: boolean;
   className?: string;
 }
 
@@ -40,9 +42,9 @@ export function DbmColorBar({
   vmax,
   tickCount = 5,
   label,
-  approximate = false,
   className,
 }: Props) {
+  const [expanded, setExpanded] = useState(true);
   // tick 위치 0~100% 균등 분포 + 값 보간.
   const ticks = Array.from({ length: tickCount }, (_, i) => {
     const t = tickCount === 1 ? 0 : i / (tickCount - 1);
@@ -54,57 +56,67 @@ export function DbmColorBar({
 
   return (
     <div
-      className={
-        'pointer-events-none flex flex-col gap-1 rounded-md border bg-card/95 px-3 py-2 shadow-sm backdrop-blur ' +
-        (className ?? '')
-      }
+      className={cn(
+        'pointer-events-auto flex flex-col gap-1 rounded-md border bg-card/95 px-3 py-2 shadow-sm backdrop-blur',
+        className,
+      )}
       role="img"
       aria-label={`RSSI 색 범례: ${vmin.toFixed(0)} ~ ${vmax.toFixed(0)} dBm`}
     >
-      {(label || approximate) && (
-        <div className="flex items-center justify-between text-[10px] font-medium text-muted-foreground">
-          <span>{label ?? ''}</span>
-          {approximate && (
-            <span className="text-[9px] text-muted-foreground/70">approx.</span>
-          )}
-        </div>
-      )}
-      {/* gradient bar */}
-      <div
-        className="h-3 w-full rounded-sm border border-border/60"
-        style={{ backgroundImage: INFERNO_GRADIENT }}
-      />
-      {/* tick marks — gradient 바로 아래 short vertical line + 값 */}
-      <div className="relative h-4 w-full">
-        {ticks.map((t, i) => (
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center justify-between gap-2 text-left text-[10px] font-medium text-muted-foreground"
+        aria-expanded={expanded}
+      >
+        <span>{label ?? 'RSSI 범례'}</span>
+        <span className="inline-flex items-center gap-1">
+          <ChevronDown
+            className={cn('h-3 w-3 transition-transform', expanded && 'rotate-180')}
+            aria-hidden="true"
+          />
+        </span>
+      </button>
+      {expanded && (
+        <>
+          {/* gradient bar */}
           <div
-            key={i}
-            className="absolute top-0 -translate-x-1/2 text-center"
-            style={{ left: `${t.pct}%` }}
-          >
-            <div className="mx-auto h-1 w-px bg-border" />
-            <div className="mt-0.5 font-mono text-[10px] tabular-nums text-foreground/70">
-              {t.value.toFixed(0)}
+            className="h-3 w-full rounded-sm border border-border/60"
+            style={{ backgroundImage: INFERNO_GRADIENT }}
+          />
+          {/* tick marks — gradient 바로 아래 short vertical line + 값 */}
+          <div className="relative h-4 w-full">
+            {ticks.map((t, i) => (
+              <div
+                key={i}
+                className="absolute top-0 -translate-x-1/2 text-center"
+                style={{ left: `${t.pct}%` }}
+              >
+                <div className="mx-auto h-1 w-px bg-border" />
+                <div className="mt-0.5 font-mono text-[10px] tabular-nums text-foreground/70">
+                  {t.value.toFixed(0)}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="text-right text-[9px] text-muted-foreground">dBm</div>
+          <div className="mt-1 border-t pt-1.5">
+            <p className="mb-1 text-[9px] font-medium text-muted-foreground">
+              숫자가 0에 가까울수록 신호가 강합니다.
+            </p>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[9px] leading-tight text-muted-foreground">
+              {DBM_QUALITY_LABELS.map((item) => (
+                <div key={item.dbm} className="flex items-center justify-between gap-2">
+                  <span className="font-mono tabular-nums text-foreground/75">
+                    {item.dbm} dBm
+                  </span>
+                  <span>{item.label}</span>
+                </div>
+              ))}
             </div>
           </div>
-        ))}
-      </div>
-      <div className="text-right text-[9px] text-muted-foreground">dBm</div>
-      <div className="mt-1 border-t pt-1.5">
-        <p className="mb-1 text-[9px] font-medium text-muted-foreground">
-          숫자가 0에 가까울수록 신호가 강합니다.
-        </p>
-        <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[9px] leading-tight text-muted-foreground">
-          {DBM_QUALITY_LABELS.map((item) => (
-            <div key={item.dbm} className="flex items-center justify-between gap-2">
-              <span className="font-mono tabular-nums text-foreground/75">
-                {item.dbm} dBm
-              </span>
-              <span>{item.label}</span>
-            </div>
-          ))}
-        </div>
-      </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -26,6 +26,8 @@ export const DEFAULT_TX_POWER_DBM = 20;
 
 const MAX_APS = 8;
 const DEFAULT_AP_Z_M = 2.5;
+const AP_MARKER_RADIUS_M = 0.26;
+const AP_LABEL_FONT_SIZE_M = 0.19;
 
 interface Props {
   sceneVersion: SceneVersion | null | undefined;
@@ -287,9 +289,11 @@ export function SimulationCanvas({
         {(sceneVersion?.openings ?? []).map((o) => (
           <OpeningShape key={o.id} opening={o} />
         ))}
-        {(sceneVersion?.objects ?? []).map((o) => (
+        {/* [object 비활성화] 시뮬레이션 캔버스에서 가구/공간성 객체 렌더 제거.
+            다시 켜려면 아래 블록 주석 해제. */}
+        {/* {(sceneVersion?.objects ?? []).map((o) => (
           <ObjectShape key={o.id} object={o} />
-        ))}
+        ))} */}
 
         {aps.map((ap) => (
           <ApMarker
@@ -477,9 +481,9 @@ function ApMarker({
   onRemove: () => void;
 }) {
   const fill = 'oklch(0.55 0.22 254)';
-  const r = 0.13;
+  const r = AP_MARKER_RADIUS_M;
   // lucide Wifi 아이콘 (24x24 viewBox) 을 r 안에 들어갈 크기로 스케일.
-  const iconSize = r * 1.3; // 원 지름의 약 65%
+  const iconSize = r * 1.1; // 원 지름의 약 55%
   const iconScale = iconSize / 24;
   return (
     <g className={isDragging ? 'cursor-grabbing' : 'cursor-grab'}>
@@ -510,9 +514,9 @@ function ApMarker({
         <rect
           x={ap.x_m - 0.18}
           y={ap.y_m + r + 0.04}
-          width="0.36"
-          height="0.16"
-          rx="0.04"
+          width={r * 1.8}
+          height={r * 0.75}
+          rx={r * 0.18}
           fill="white"
           stroke="oklch(0.85 0.02 240)"
           strokeWidth="1"
@@ -520,10 +524,10 @@ function ApMarker({
         />
         <text
           x={ap.x_m}
-          y={ap.y_m + r + 0.12}
+          y={ap.y_m + r + r * 0.38}
           textAnchor="middle"
           dominantBaseline="middle"
-          fontSize="0.1"
+          fontSize={AP_LABEL_FONT_SIZE_M}
           fontWeight="600"
           fill="oklch(0.25 0.04 240)"
           style={{ userSelect: 'none' }}
@@ -531,7 +535,7 @@ function ApMarker({
           {ap.id.toUpperCase()}
         </text>
       </g>
-      {/* 삭제 버튼 — 우측 상단 작은 빨간 원 + × 표시 */}
+      {/* 삭제 버튼 — AP 크기에 맞춰 우측 상단에 충분히 크게 표시. */}
       <g
         onPointerDown={(e) => {
           e.stopPropagation();
@@ -542,18 +546,18 @@ function ApMarker({
         <circle
           cx={ap.x_m + r * 0.85}
           cy={ap.y_m - r * 0.85}
-          r="0.055"
+          r={r * 0.34}
           fill="oklch(0.65 0.21 25)"
           stroke="white"
-          strokeWidth="1"
+          strokeWidth="1.5"
           vectorEffect="non-scaling-stroke"
         />
         <text
           x={ap.x_m + r * 0.85}
-          y={ap.y_m - r * 0.85 + 0.003}
+          y={ap.y_m - r * 0.85}
           textAnchor="middle"
           dominantBaseline="middle"
-          fontSize="0.07"
+          fontSize={r * 0.42}
           fontWeight="700"
           fill="white"
           pointerEvents="none"

--- a/frontend/src/hooks/use-ap-recommendation.ts
+++ b/frontend/src/hooks/use-ap-recommendation.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { apRecommendationApi } from '@/api/ap-recommendation';
+import type { HttpError } from '@/api/client';
+import { toast } from '@/stores/toast-store';
+import type { ApRecommendationRequest } from '@/types/ap-recommendation';
+
+/** POST /ap-recommendation — AP 최적 배치 추천. */
+export function useApRecommendation() {
+  return useMutation({
+    mutationFn: (body: ApRecommendationRequest) => apRecommendationApi.recommend(body),
+    onError: (err) => {
+      const e = err as HttpError | null;
+      toast.error(
+        'AP 배치 추천 실패',
+        e?.message ?? '잠시 후 다시 시도해주세요.',
+      );
+    },
+  });
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { NavLink, Outlet } from 'react-router-dom';
 import {
   LayoutGrid,
   Map,
   Radio,
-  Smartphone,
+  Sparkles,
   Activity,
   Settings,
   Wifi,
@@ -22,14 +22,11 @@ const NAV = [
   { to: '/editor', label: '공간 편집', icon: Map },
   { to: '/simulation', label: '시뮬레이션', icon: Radio },
   { to: '/measurement', label: '실측/진단', icon: Activity },
-  { to: '/mobile', label: '모바일 앱', icon: Smartphone },
+  { to: '/mobile', label: 'AP 배치 추천', icon: Sparkles },
 ] as const;
 
 export function AppLayout() {
   const [mobileConnectOpen, setMobileConnectOpen] = useState(false);
-  // /mobile 페이지에선 헤더의 "모바일 앱 연결" 버튼을 숨기고 페이지 내 카드 하단에 배치.
-  const location = useLocation();
-  const isMobileAppPage = location.pathname.startsWith('/mobile');
 
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-background">
@@ -84,16 +81,14 @@ export function AppLayout() {
           </div>
           <div className="flex items-center gap-2">
             <InferenceModeToggle />
-            {!isMobileAppPage && (
-              <button
-                type="button"
-                onClick={() => setMobileConnectOpen(true)}
-                className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
-              >
-                <QrCode className="h-4 w-4" />
-                모바일 앱 연결
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => setMobileConnectOpen(true)}
+              className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
+            >
+              <QrCode className="h-4 w-4" />
+              모바일 앱 연결
+            </button>
             <ProfileMenu />
           </div>
         </header>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,7 +6,7 @@ import {
   Loader2,
   Map,
   Radio,
-  Smartphone,
+  Sparkles,
   type LucideIcon,
 } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
@@ -48,9 +48,9 @@ const TONE: Record<
 const QUICK_ACTIONS = [
   {
     to: '/mobile',
-    icon: Smartphone,
-    label: '현장 모바일 앱 연결',
-    sub: 'QR 스캔으로 기기 연동',
+    icon: Sparkles,
+    label: 'AP 배치 추천',
+    sub: '우선 개선 영역 기반 최적 설치 위치',
     tone: 'blue',
   },
   {

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,166 +1,507 @@
-import { useState } from 'react';
-import { Camera, MapPin, Smartphone } from 'lucide-react';
-import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
+import { useMemo, useState } from 'react';
+import { CheckCircle2, Loader2, Sparkles } from 'lucide-react';
+import type { HttpError } from '@/api/client';
+import { useAppStore } from '@/stores/app-store';
+import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
+import { useFloorRfRuns } from '@/hooks/use-rf-run';
+import { useApLayouts, useCreateApLayout } from '@/hooks/use-ap-layouts';
+import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
+import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
+import { useApRecommendation } from '@/hooks/use-ap-recommendation';
+import { versionToDraftShape } from '@/features/editor/version-as-draft';
+import { DEFAULT_TX_POWER_DBM } from '@/features/simulation/SimulationCanvas';
+import {
+  apLayoutsToCanvas,
+  apsFromRfRunRequest,
+  nextApLayoutName,
+} from '@/features/ap-recommendation/ap-canvas-mappers';
+import { ApRecommendationCanvas } from '@/features/ap-recommendation/ApRecommendationCanvas';
+import {
+  AP_DEFAULT_Z_M,
+  buildApRecommendationPayload,
+  isValidSelectionBBox,
+  normalizeRecommendations,
+  type MeterBBox,
+} from '@/features/ap-recommendation/recommendation-utils';
+import type { ApRecommendationResult } from '@/types/ap-recommendation';
+import { cn } from '@/lib/utils';
 
-const FLOW_STEPS = [
-  '권한 동의 (시작하기 전)',
-  'QR 스캔을 통한 손쉬운 연결',
-  '직관적인 모드 선택',
-  'AR 기반 가구 스캔 UI',
-  '간단한 원클릭 와이파이 실측 수집',
-];
+type PageStatus = 'idle' | 'areaSelected' | 'loading' | 'success' | 'error';
+
+const PROGRESS_STEPS = [
+  { id: 1, label: '우선 개선 영역 선택' },
+  { id: 2, label: '최적 위치 계산' },
+  { id: 3, label: '추천 위치 선택' },
+] as const;
+
+const CARD_BORDER = 'border-[#E5EAF2]';
 
 export default function MobileAppPage() {
-  const [connectOpen, setConnectOpen] = useState(false);
-  return (
-    <div className="h-full overflow-auto bg-muted/20 p-10">
-      <div className="mx-auto flex max-w-6xl items-start justify-center gap-12">
-        <PhoneMockup />
-        <InfoCard onConnectClick={() => setConnectOpen(true)} />
-      </div>
-      <MobileConnectModal open={connectOpen} onClose={() => setConnectOpen(false)} />
-    </div>
-  );
-}
+  const floorId = useAppStore((s) => s.selectedFloorId);
+  const versionsQuery = useFloorVersions(floorId);
+  const currentVersion =
+    versionsQuery.data?.find((v) => v.is_current) ?? versionsQuery.data?.[0] ?? null;
+  const sceneVersionId = currentVersion?.id ?? null;
 
-function PhoneMockup() {
-  return (
-    <div className="relative w-[320px] shrink-0 rounded-[44px] border-[6px] border-foreground bg-background shadow-2xl">
-      {/* 노치 */}
-      <div className="absolute left-1/2 top-2 z-10 h-5 w-28 -translate-x-1/2 rounded-full bg-foreground" />
+  const versionDetailQuery = useSceneVersion(sceneVersionId);
+  const versionDetail = versionDetailQuery.data ?? null;
 
-      <div className="overflow-hidden rounded-[36px]">
-        {/* 상태바 */}
-        <div className="flex items-center justify-between px-6 pt-3 pb-1 text-[11px] font-semibold">
-          <span>12:30</span>
-          <StatusIcons />
+  const versionAsDraft = versionDetail ? versionToDraftShape(versionDetail) : null;
+  const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
+  const fallbackAsset = (floorAssetsQuery.data ?? [])
+    .slice()
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
+  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
+  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const assetUrl = assetUrlQuery.data?.url ?? null;
+  const usableAssetUrl =
+    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
+  const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
+
+  const rfRunsQuery = useFloorRfRuns(floorId, { status: 'succeeded', page_size: 5 });
+  const latestRfRun = useMemo(() => {
+    const items = rfRunsQuery.data?.items ?? [];
+    if (!sceneVersionId) return items[0] ?? null;
+    return (
+      items.find((r) => r.scene_version_id === sceneVersionId) ?? items[0] ?? null
+    );
+  }, [rfRunsQuery.data, sceneVersionId]);
+  const latestRfRunId = latestRfRun?.id ?? null;
+  const apLayoutsQuery = useApLayouts(latestRfRunId);
+
+  const existingAps = useMemo(() => {
+    const layouts = apLayoutsQuery.data ?? [];
+    if (layouts.length > 0) return apLayoutsToCanvas(layouts);
+    return apsFromRfRunRequest(latestRfRun?.request_json as Record<string, unknown> | undefined);
+  }, [apLayoutsQuery.data, latestRfRun?.request_json]);
+
+  const [selectionBBox, setSelectionBBox] = useState<MeterBBox | null>(null);
+  const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
+  const [selectedRank, setSelectedRank] = useState<number | null>(null);
+  const [savedRank, setSavedRank] = useState<number | null>(null);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  const recommendMutation = useApRecommendation();
+  const createLayout = useCreateApLayout();
+
+  const pageStatus: PageStatus = useMemo(() => {
+    if (recommendMutation.isPending) return 'loading';
+    if (recommendMutation.isError) return 'error';
+    if (recommendations.length > 0) return 'success';
+    if (isValidSelectionBBox(selectionBBox)) return 'areaSelected';
+    return 'idle';
+  }, [
+    recommendMutation.isPending,
+    recommendMutation.isError,
+    recommendations.length,
+    selectionBBox,
+  ]);
+
+  const activeStep = useMemo(() => {
+    if (savedRank != null || selectedRank != null) return 3;
+    if (pageStatus === 'success') return 3;
+    if (pageStatus === 'loading') return 2;
+    if (pageStatus === 'areaSelected') return 1;
+    return 1;
+  }, [pageStatus, selectedRank, savedRank]);
+
+  const handleSelectionChange = (bbox: MeterBBox | null) => {
+    setSelectionBBox(bbox);
+    setRecommendations([]);
+    setSelectedRank(null);
+    setSavedRank(null);
+    setPageError(null);
+    recommendMutation.reset();
+  };
+
+  const handleRecommend = () => {
+    if (!sceneVersionId) {
+      setPageError('도면 정보를 불러올 수 없습니다.');
+      return;
+    }
+    if (!isValidSelectionBBox(selectionBBox)) return;
+
+    const payload = buildApRecommendationPayload({
+      sceneVersionId,
+      bbox: selectionBBox,
+      existingAps,
+      txPowerDbm: DEFAULT_TX_POWER_DBM,
+    });
+
+    if (import.meta.env.DEV) {
+      console.debug('[AP Recommendation] request payload:', payload);
+    }
+
+    setPageError(null);
+    setSavedRank(null);
+    recommendMutation.mutate(payload, {
+      onSuccess: (data) => {
+        const normalized = normalizeRecommendations(data);
+        setRecommendations(normalized);
+        if (import.meta.env.DEV) {
+          console.debug('[AP Recommendation] response:', data, 'normalized:', normalized);
+        }
+      },
+      onError: (err) => {
+        const e = err as HttpError | null;
+        setPageError(e?.message ?? '추천 계산에 실패했습니다.');
+      },
+    });
+  };
+
+  const handleSelectRecommendation = (rec: ApRecommendationResult) => {
+    if (!latestRfRunId) {
+      setPageError('AP 배치를 저장하려면 먼저 시뮬레이션을 실행해 주세요.');
+      return;
+    }
+
+    setSelectedRank(rec.rank);
+    setPageError(null);
+
+    const apName = nextApLayoutName(apLayoutsQuery.data ?? [], existingAps);
+
+    createLayout.mutate(
+      {
+        rf_run_id: latestRfRunId,
+        ap_name: apName,
+        point_geom: {
+          type: 'Point',
+          coordinates: [rec.recommended_x, rec.recommended_y],
+        },
+        z_m: AP_DEFAULT_Z_M,
+        power_dbm: DEFAULT_TX_POWER_DBM,
+      },
+      {
+        onSuccess: () => {
+          setSavedRank(rec.rank);
+        },
+        onError: (err) => {
+          const e = err as HttpError | null;
+          setPageError(e?.message ?? 'AP 배치 저장에 실패했습니다.');
+          setSelectedRank(null);
+        },
+      },
+    );
+  };
+
+  const canRecommend =
+    !!sceneVersionId && isValidSelectionBBox(selectionBBox) && !recommendMutation.isPending;
+
+  const sceneLoading =
+    versionsQuery.isLoading ||
+    versionDetailQuery.isLoading ||
+    (floorId != null && !sceneVersionId && !versionsQuery.isError);
+
+  const statusHint = getStatusHint(pageStatus, pageError, savedRank);
+
+  return (
+    <div className="flex h-full flex-col overflow-auto bg-[#F8FAFC]">
+      {/* 본문 헤더 — Figma: 제목 + 설명 + 우측 CTA */}
+      <header className="shrink-0 px-6 pb-4 pt-6 lg:px-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+              AP 배치 추천
+            </h1>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              개선이 필요한 영역을 드래그하면 최적의 AP 설치 위치를 추천합니다.
+            </p>
+          </div>
+          <div className="flex shrink-0 flex-col items-stretch gap-1.5 sm:items-end">
+            <button
+              type="button"
+              onClick={handleRecommend}
+              disabled={!canRecommend}
+              className={cn(
+                'inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold shadow-sm transition-colors',
+                canRecommend
+                  ? 'bg-blue-600 text-white hover:bg-blue-700'
+                  : 'cursor-not-allowed bg-muted text-muted-foreground',
+              )}
+            >
+              {recommendMutation.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  최적 위치 계산 중…
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4" />
+                  최적 배치 추천
+                </>
+              )}
+            </button>
+            {!latestRfRunId && sceneVersionId && (
+              <p className="text-[11px] text-amber-600 sm:text-right">
+                AP 저장은 시뮬레이션 실행 후 가능합니다.
+              </p>
+            )}
+          </div>
         </div>
+      </header>
 
-        {/* 본문 */}
-        <div className="flex h-[610px] flex-col px-6 pb-6 pt-8">
-          <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
-            <Smartphone className="h-6 w-6 text-primary" strokeWidth={1.8} />
+      {/* 본문 — lg: 캔버스(좌) + 추천 패널(우), md↓ 단일 컬럼 */}
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-5 px-6 pb-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-6 lg:px-8">
+        {/* 좌측: 캔버스 + 진행 단계 */}
+        <div className="flex min-h-0 flex-col gap-4">
+          <div
+            className={cn(
+              'relative flex min-h-[min(52vh,32rem)] flex-1 flex-col overflow-hidden rounded-2xl bg-white shadow-sm',
+              CARD_BORDER,
+              'border',
+            )}
+          >
+            {!floorId ? (
+              <EmptyState message="층을 선택해 주세요." />
+            ) : sceneLoading ? (
+              <div className="flex h-full min-h-[320px] items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                도면 불러오는 중…
+              </div>
+            ) : !sceneVersionId ? (
+              <EmptyState message="도면 정보를 불러올 수 없습니다." />
+            ) : (
+              <ApRecommendationCanvas
+                sceneVersion={versionDetail}
+                backgroundImageUrl={backgroundImageUrl}
+                existingAps={existingAps}
+                selectionBBox={selectionBBox}
+                onSelectionChange={handleSelectionChange}
+                recommendations={recommendations}
+                selectedRecommendationRank={selectedRank}
+                disabled={recommendMutation.isPending || createLayout.isPending}
+              />
+            )}
+
+            {sceneVersionId && statusHint && pageStatus !== 'loading' && (
+              <div className="pointer-events-none absolute bottom-4 left-4 right-4">
+                <p className="rounded-lg border border-[#E5EAF2] bg-white/95 px-4 py-2.5 text-center text-xs text-muted-foreground shadow-sm backdrop-blur">
+                  {statusHint}
+                </p>
+              </div>
+            )}
           </div>
 
-          <h2 className="text-[22px] font-bold leading-snug">
-            시작하기 전에
-            <br />
-            권한이 필요해요
-          </h2>
-
-          <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">
-            현장에서 원활하게 데이터를 수집하고 대시보드와 연결하기 위해 아래
-            권한을 허용해 주세요.
-          </p>
-
-          <ul className="mt-7 space-y-5">
-            <PermissionRow
-              icon={<Camera className="h-4 w-4" strokeWidth={1.8} />}
-              title="카메라"
-              description="웹 대시보드의 QR 코드를 스캔하고, 공간의 가구를 자동으로 인식합니다."
-            />
-            <PermissionRow
-              icon={<MapPin className="h-4 w-4" strokeWidth={1.8} />}
-              title="위치 및 주변 기기"
-              description="실제 걸어다니며 와이파이 신호 강도와 품질을 정확하게 측정합니다."
-            />
-          </ul>
-
-          <div className="flex-1" />
-
-          <button
-            type="button"
-            className="w-full rounded-xl bg-primary py-3.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+          {/* 진행 단계 카드 — 캔버스 아래 */}
+          <div
+            className={cn(
+              'shrink-0 rounded-2xl bg-white px-6 py-5 shadow-sm',
+              CARD_BORDER,
+              'border',
+            )}
           >
-            동의하고 시작하기
-          </button>
-
-          {/* iOS 하단 핸들 */}
-          <div className="mx-auto mt-3 h-1 w-28 rounded-full bg-foreground/80" />
+            <ProgressStepper activeStep={activeStep} pageStatus={pageStatus} />
+          </div>
         </div>
+
+        {/* 우측: 추천 결과 패널 (모바일에서는 하단 카드) */}
+        <aside
+          className={cn(
+            'flex min-h-[280px] flex-col overflow-hidden rounded-2xl bg-white shadow-sm lg:min-h-0 lg:self-stretch',
+            CARD_BORDER,
+            'border',
+          )}
+        >
+          <div className="border-b border-[#E5EAF2] px-5 py-4">
+            <h2 className="text-base font-bold text-foreground">최적 배치 추천</h2>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            {recommendations.length === 0 ? (
+              <div className="flex h-full min-h-[200px] flex-col items-center justify-center gap-2 px-4 text-center">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                  <Sparkles className="h-5 w-5 text-muted-foreground" />
+                </div>
+                <p className="text-sm font-medium text-foreground/80">
+                  {pageStatus === 'loading'
+                    ? '최적 위치를 계산하고 있습니다…'
+                    : '추천 결과가 여기에 표시됩니다'}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  도면에서 우선 개선 영역을 드래그한 뒤 「최적 배치 추천」을 눌러주세요.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {recommendations.map((rec) => (
+                  <RecommendationCard
+                    key={rec.rank}
+                    rec={rec}
+                    selected={selectedRank === rec.rank}
+                    saved={savedRank === rec.rank}
+                    saving={createLayout.isPending && selectedRank === rec.rank}
+                    saveDisabled={!latestRfRunId || createLayout.isPending}
+                    onSelect={() => handleSelectRecommendation(rec)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </aside>
       </div>
     </div>
   );
 }
 
-function PermissionRow({
-  icon,
-  title,
-  description,
+function getStatusHint(
+  pageStatus: PageStatus,
+  pageError: string | null,
+  savedRank: number | null,
+): string | null {
+  switch (pageStatus) {
+    case 'idle':
+      return '도면 위에서 우선 개선할 영역을 드래그하여 선택하세요.';
+    case 'areaSelected':
+      return '영역이 선택되었습니다. 우측 상단 「최적 배치 추천」 버튼을 눌러주세요.';
+    case 'success':
+      return savedRank != null
+        ? '추천 위치가 AP 배치로 저장되었습니다.'
+        : '추천 위치를 확인하고 우측 패널에서 선택하세요.';
+    case 'error':
+      return pageError ?? '추천 계산에 실패했습니다. 다시 시도해 주세요.';
+    default:
+      return null;
+  }
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex h-full min-h-[320px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
+      {message}
+    </div>
+  );
+}
+
+function RecommendationCard({
+  rec,
+  selected,
+  saved,
+  saving,
+  saveDisabled,
+  onSelect,
 }: {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
+  rec: ApRecommendationResult;
+  selected: boolean;
+  saved: boolean;
+  saving: boolean;
+  saveDisabled: boolean;
+  onSelect: () => void;
 }) {
   return (
-    <li className="flex items-start gap-3">
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        {icon}
+    <article
+      className={cn(
+        'rounded-xl border bg-white p-4 transition-colors',
+        saved || selected ? 'border-emerald-300 shadow-sm' : 'border-[#E5EAF2]',
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-sm font-bold text-white">
+          {rec.rank}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-bold text-foreground">{rec.rank}순위 추천</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            위치 X {rec.recommended_x.toFixed(0)}m / Y {rec.recommended_y.toFixed(0)}m
+          </p>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            우선 개선 영역 커버리지 가장 높음
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            후보 점수{' '}
+            <span className="font-semibold text-foreground">{rec.score.toFixed(1)}</span>
+          </p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            탐색 후보 수 {rec.candidates_evaluated}
+          </p>
+        </div>
       </div>
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <p className="text-[13px] font-semibold">{title}</p>
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
-          {description}
-        </p>
-      </div>
-    </li>
-  );
-}
-
-function InfoCard({ onConnectClick }: { onConnectClick: () => void }) {
-  return (
-    <div className="flex w-[360px] shrink-0 flex-col gap-3">
-      <section className="rounded-2xl border bg-background p-6 shadow-sm">
-        <header className="flex items-center gap-2">
-          <Smartphone className="h-5 w-5 text-foreground" strokeWidth={1.8} />
-          <h3 className="text-base font-bold">모바일 앱 프로토타입</h3>
-        </header>
-
-        <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">
-          비전문가인 소상공인이 현장에서 간편하게 와이파이 품질을 측정하고
-          가구를 스캔할 수 있도록 돕는 Android 컴패니언 앱 디자인입니다.
-        </p>
-
-        <h4 className="mt-6 text-sm font-semibold">주요 화면 플로우</h4>
-        <ul className="mt-3 space-y-2 text-[13px] text-foreground/80">
-          {FLOW_STEPS.map((step) => (
-            <li key={step} className="flex items-start gap-2">
-              <span className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/60" />
-              <span>{step}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
-
       <button
         type="button"
-        onClick={onConnectClick}
-        className="inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+        onClick={onSelect}
+        disabled={saveDisabled && !saved}
+        className={cn(
+          'mt-4 w-full rounded-lg border py-2.5 text-sm font-medium transition-colors',
+          saved
+            ? 'border-emerald-500 bg-emerald-500 text-white'
+            : 'border-[#E5EAF2] bg-[#F8FAFC] text-foreground hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-50',
+        )}
       >
-        <Smartphone className="h-4 w-4" />
-        모바일 앱 연결
+        {saving ? (
+          <span className="inline-flex items-center justify-center gap-1.5">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            저장 중…
+          </span>
+        ) : saved ? (
+          <span className="inline-flex items-center justify-center gap-1.5">
+            <CheckCircle2 className="h-4 w-4" />
+            저장됨
+          </span>
+        ) : (
+          '이 위치 선택'
+        )}
       </button>
-    </div>
+    </article>
   );
 }
 
-function StatusIcons() {
+function ProgressStepper({
+  activeStep,
+  pageStatus,
+}: {
+  activeStep: number;
+  pageStatus: PageStatus;
+}) {
   return (
-    <div className="flex items-center gap-1">
-      <svg width="14" height="10" viewBox="0 0 14 10" fill="currentColor">
-        <path d="M7 0a7 7 0 0 1 5 2.1l-1 1A5.6 5.6 0 0 0 7 1.4 5.6 5.6 0 0 0 3 3.1l-1-1A7 7 0 0 1 7 0Zm0 2.8a4.2 4.2 0 0 1 3 1.3l-1 1A2.8 2.8 0 0 0 7 4.2 2.8 2.8 0 0 0 5 5.1l-1-1A4.2 4.2 0 0 1 7 2.8Zm0 2.8a1.4 1.4 0 0 1 1 .4L7 7l-1-1a1.4 1.4 0 0 1 1-.4Z" />
-      </svg>
-      <svg width="14" height="10" viewBox="0 0 18 12" fill="currentColor">
-        <rect x="0" y="6" width="3" height="6" rx="1" />
-        <rect x="5" y="3" width="3" height="9" rx="1" />
-        <rect x="10" y="0" width="3" height="12" rx="1" />
-        <rect x="15" y="6" width="3" height="6" rx="1" opacity="0.4" />
-      </svg>
-      <svg width="22" height="11" viewBox="0 0 24 12" fill="none">
-        <rect x="0.5" y="0.5" width="20" height="11" rx="3" stroke="currentColor" />
-        <rect x="2" y="2" width="17" height="8" rx="1.5" fill="currentColor" />
-        <rect x="21" y="3.5" width="1.5" height="5" rx="0.75" fill="currentColor" />
-      </svg>
-    </div>
+    <ol className="flex items-start">
+      {PROGRESS_STEPS.map((step, index) => {
+        const done =
+          step.id < activeStep ||
+          (step.id === 1 && pageStatus !== 'idle') ||
+          (step.id === 2 && (pageStatus === 'success' || pageStatus === 'loading')) ||
+          (step.id === 3 && activeStep >= 3);
+        const current = step.id === activeStep && pageStatus !== 'error';
+        const isLast = index === PROGRESS_STEPS.length - 1;
+
+        return (
+          <li key={step.id} className="flex min-w-0 flex-1 items-start">
+            <div className="flex min-w-0 flex-1 flex-col items-center gap-2">
+              <div
+                className={cn(
+                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold',
+                  done && !current && 'bg-emerald-500 text-white',
+                  current && 'bg-blue-600 text-white',
+                  !done && !current && 'bg-muted text-muted-foreground',
+                )}
+              >
+                {done && !current ? (
+                  <CheckCircle2 className="h-4 w-4" />
+                ) : (
+                  step.id
+                )}
+              </div>
+              <span
+                className={cn(
+                  'max-w-28 text-center text-xs leading-tight',
+                  current ? 'font-semibold text-foreground' : 'text-muted-foreground',
+                )}
+              >
+                {step.label}
+              </span>
+            </div>
+            {!isLast && (
+              <div
+                className={cn(
+                  'mt-4 h-0.5 min-w-4 flex-1',
+                  step.id < activeStep ? 'bg-emerald-400' : 'bg-[#E5EAF2]',
+                )}
+                aria-hidden="true"
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
   );
 }

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -356,7 +356,6 @@ export default function SimulationPage() {
                       vmin={heatmapColorScale?.vminDbm ?? -85}
                       vmax={heatmapColorScale?.vmaxDbm ?? -30}
                       label="예측 RSSI (시뮬)"
-                      approximate={!heatmapColorScale}
                     />
                   </div>
                 )}

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -1,0 +1,42 @@
+import type { UUID } from './common';
+
+/** POST /ap-recommendation — existing_aps 항목. */
+export interface ExistingAp {
+  id: string;
+  x_m: number;
+  y_m: number;
+  tx_power_dbm?: number;
+}
+
+/** POST /ap-recommendation 요청 본문 (backend ApRecommendationRequest). */
+export interface ApRecommendationRequest {
+  scene_version_id: UUID;
+  x_min: number;
+  x_max: number;
+  y_min: number;
+  y_max: number;
+  step_m?: number;
+  existing_aps?: ExistingAp[];
+  calibration_run_id?: UUID | null;
+  shadow_threshold_dbm?: number;
+  shadow_penalty?: number;
+}
+
+/** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
+export interface ApRecommendationResponse {
+  recommended_x: number;
+  recommended_y: number;
+  score: number;
+  status: string;
+  candidates_evaluated: number;
+}
+
+/** UI 표시용 — 단일/복수 응답 모두 배열로 normalize. */
+export interface ApRecommendationResult {
+  rank: number;
+  recommended_x: number;
+  recommended_y: number;
+  score: number;
+  status: string;
+  candidates_evaluated: number;
+}


### PR DESCRIPTION
## Summary
* `/mobile` 페이지를 **AP 배치 추천** 화면으로 전환
* 도면 위에서 우선 개선 영역을 드래그해 선택하고, `POST /ap-recommendation`으로 최적 AP 위치를 받아 표시하도록 구현
* 추천 결과 확인 후 **「이 위치 선택」** 버튼을 통해 `POST /ap-layouts`에 추천 AP 위치를 저장할 수 있도록 연동함. 단, 저장은 RF Run이 존재하는 층/버전 기준으로 동작
* `ApRecommendationCanvas`를 추가해 도면·벽·개구부 오버레이, 드래그 선택, 추천 마커, 진행 단계 UI를 구현
* 선택 영역은 **도면(scene) bounds 안으로 clamp**하여 grid/여백 밖으로 나가 잘리거나 API에 범위 밖 좌표가 전송되지 않도록 처리
* 기존 AP 마커는 캔버스에서 숨기고, `existing_aps`는 API payload용으로만 유지
* 문·창문 색상은 공간 편집/시뮬레이션/실측 화면과 동일하게 맞춤

## API 연동

* `POST /ap-recommendation`

  * `scene_version_id`, `x_min/x_max/y_min/y_max`, `existing_aps`를 전달해 추천 AP 위치를 요청함.
* `POST /ap-layouts`

  * 추천 좌표를 AP 레이아웃으로 저장
  * 저장 시 `rf_run_id`가 필요
