### PR TITLE
feat: AP 추천 상위 3개 반환으로 변경 (backend n_recommendations + frontend 타입 동기화)

### DIFF
--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -26,14 +26,22 @@ class ApRecommendationRequest(BaseModel):
     shadow_threshold_dbm: float = Field(default=-80.0)
     # 음영 패널티 점수
     shadow_penalty: float = Field(default=100.0)
+    # 반환할 추천 개수
+    n_recommendations: int = Field(default=3, ge=1, le=10)
+
+
+class ApRecommendationItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: int
+    recommended_x: float
+    recommended_y: float
+    score: float
 
 
 class ApRecommendationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    recommended_x: float
-    recommended_y: float
-    score: float
+    recommendations: list[ApRecommendationItem]
     status: str = "success"
-    # 탐색된 후보 수
     candidates_evaluated: int

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -20,7 +20,7 @@ from app.core.geom import wkb_to_geojson
 from app.models.scene_version import SceneVersion
 from app.models.project import Project
 from app.models.user import User
-from app.schemas.rf.ap_recommendation import ApRecommendationRequest, ApRecommendationResponse
+from app.schemas.rf.ap_recommendation import ApRecommendationItem, ApRecommendationRequest, ApRecommendationResponse
 from app.services.rf.calibration_worker.path_loss import (
     AccessPoint,
     CalibrationParams,
@@ -93,8 +93,8 @@ def recommend_ap_location(
         sv.id, len(candidates), len(eval_points), len(existing_aps),
     )
 
-    # 7) Grid Search
-    best_x, best_y, best_score = _grid_search(
+    # 7) Grid Search — 상위 n_recommendations개 반환
+    top_results = _grid_search_topn(
         candidates=candidates,
         eval_points=eval_points,
         existing_aps=existing_aps,
@@ -102,17 +102,24 @@ def recommend_ap_location(
         params=params,
         shadow_threshold_dbm=request.shadow_threshold_dbm,
         shadow_penalty=request.shadow_penalty,
+        n=request.n_recommendations,
     )
 
     logger.info(
-        "AP 추천 완료: best=(%.2f, %.2f) score=%.1f",
-        best_x, best_y, best_score,
+        "AP 추천 완료: top%d, best=(%.2f, %.2f) score=%.1f",
+        len(top_results), top_results[0][0], top_results[0][1], top_results[0][2],
     )
 
     return ApRecommendationResponse(
-        recommended_x=round(best_x, 3),
-        recommended_y=round(best_y, 3),
-        score=round(best_score, 2),
+        recommendations=[
+            ApRecommendationItem(
+                rank=i + 1,
+                recommended_x=round(x, 3),
+                recommended_y=round(y, 3),
+                score=round(score, 2),
+            )
+            for i, (x, y, score) in enumerate(top_results)
+        ],
         candidates_evaluated=len(candidates),
     )
 
@@ -255,7 +262,7 @@ def _parse_existing_aps(raw: list[dict]) -> list[AccessPoint]:
     return aps
 
 
-def _grid_search(
+def _grid_search_topn(
     *,
     candidates: list[tuple[float, float]],
     eval_points: list[Measurement],
@@ -264,9 +271,10 @@ def _grid_search(
     params: CalibrationParams,
     shadow_threshold_dbm: float,
     shadow_penalty: float,
-) -> tuple[float, float, float]:
-    """모든 후보 좌표에 대해 점수 계산 후 최적 좌표 반환."""
-    best_x, best_y, best_score = candidates[0][0], candidates[0][1], float("-inf")
+    n: int,
+) -> list[tuple[float, float, float]]:
+    """모든 후보 좌표에 대해 점수 계산 후 상위 n개 반환 (x, y, score)."""
+    scored: list[tuple[float, float, float]] = []
 
     for (cx, cy) in candidates:
         test_ap = AccessPoint(name="test", x=cx, y=cy)
@@ -280,8 +288,7 @@ def _grid_search(
             else:
                 score += pred
 
-        if score > best_score:
-            best_score = score
-            best_x, best_y = cx, cy
+        scored.append((cx, cy, score))
 
-    return best_x, best_y, best_score
+    scored.sort(key=lambda t: t[2], reverse=True)
+    return scored[:n]

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -59,19 +59,17 @@ export function buildApRecommendationPayload(params: {
   };
 }
 
-/** 단일 응답 → rank 배열. 추후 복수 추천 API 대응용. */
+/** 응답 → UI 표시용 배열로 normalize. */
 export function normalizeRecommendations(
-  response: ApRecommendationResponse | ApRecommendationResponse[] | null | undefined,
+  response: ApRecommendationResponse | null | undefined,
 ): ApRecommendationResult[] {
   if (!response) return [];
-  const list = Array.isArray(response) ? response : [response];
-  return list.map((item, i) => ({
-    rank: i + 1,
+  return response.recommendations.map((item) => ({
+    rank: item.rank,
     recommended_x: item.recommended_x,
     recommended_y: item.recommended_y,
     score: item.score,
-    status: item.status,
-    candidates_evaluated: item.candidates_evaluated,
+    candidates_evaluated: response.candidates_evaluated,
   }));
 }
 

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -22,21 +22,26 @@ export interface ApRecommendationRequest {
   shadow_penalty?: number;
 }
 
-/** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
-export interface ApRecommendationResponse {
+/** POST /ap-recommendation 응답 내 단일 추천 항목. */
+export interface ApRecommendationItem {
+  rank: number;
   recommended_x: number;
   recommended_y: number;
   score: number;
+}
+
+/** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
+export interface ApRecommendationResponse {
+  recommendations: ApRecommendationItem[];
   status: string;
   candidates_evaluated: number;
 }
 
-/** UI 표시용 — 단일/복수 응답 모두 배열로 normalize. */
+/** UI 표시용. */
 export interface ApRecommendationResult {
   rank: number;
   recommended_x: number;
   recommended_y: number;
   score: number;
-  status: string;
   candidates_evaluated: number;
 }


### PR DESCRIPTION
## Summary

- `POST /ap-recommendation` 응답 구조를 단일 좌표 → 상위 3개 배열로 변경
- `n_recommendations` 파라미터 추가 (기본 3, 최대 10)
- Grid Search 결과를 점수 내림차순 정렬 후 상위 N개 반환
- 프론트엔드 타입 및 `normalizeRecommendations()` 함수 응답 구조에 맞게 동기화

## 변경 파일

- `backend/app/schemas/rf/ap_recommendation.py`
- `backend/app/services/rf/ap_recommendation_service.py`
- `frontend/src/types/ap-recommendation.ts`
- `frontend/src/features/ap-recommendation/recommendation-utils.ts`

## Test plan

- [x] AP 추천 시 3개 결과가 순위(rank 1~3)별로 반환됨
- [x] 프론트엔드에서 3개 추천 위치가 정상 표시됨
- [x] `n_recommendations` 미입력 시 기본값 3으로 동작 확인
- [x] 기존 1개 결과 사용하던 로직 깨지지 않는지 확인

Closes #116