### PR TITLE
style: 시뮬·실측·AP 추천 UI 통일 및 시뮬 이력/히트맵 UX 개선

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,10 @@
 VITE_API_BASE_URL=http://43.201.65.165:8000
 
+# Local RF 시뮬 heatmap — ai_api 주소 (Vite dev 프록시 대상). 기본 localhost:9000
+# VITE_AI_API_BASE_URL=http://localhost:9000
+# ai_api internal 라우트용 (필요 시 vite.config 프록시 헤더에 추가)
+# INTERNAL_API_KEY=your-key
+
 # Dev-only: skip auth guard so you can browse all pages without logging in.
 # Set to "true" in .env.local during development. Ignored in production builds.
 # VITE_BYPASS_AUTH=true

--- a/frontend/src/components/Toaster.tsx
+++ b/frontend/src/components/Toaster.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react';
 import { CheckCircle2, Info, X, XCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useToastStore, type Toast, type ToastKind } from '@/stores/toast-store';
+
+const EXIT_MS = 220;
 
 const KIND_STYLES: Record<ToastKind, { icon: typeof CheckCircle2; iconClass: string; ring: string }> = {
   success: {
@@ -25,7 +28,7 @@ export function Toaster() {
   const dismiss = useToastStore((s) => s.dismiss);
 
   return (
-    <div className="pointer-events-none fixed bottom-6 right-6 z-50 flex w-full max-w-sm flex-col gap-2">
+    <div className="pointer-events-none fixed bottom-6 right-6 z-50 flex w-full max-w-sm flex-col gap-2.5">
       {toasts.map((t) => (
         <ToastItem key={t.id} toast={t} onDismiss={() => dismiss(t.id)} />
       ))}
@@ -34,14 +37,23 @@ export function Toaster() {
 }
 
 function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  const [exiting, setExiting] = useState(false);
   const style = KIND_STYLES[toast.kind];
   const Icon = style.icon;
+
+  const handleDismiss = () => {
+    if (exiting) return;
+    setExiting(true);
+    window.setTimeout(onDismiss, EXIT_MS);
+  };
+
   return (
     <div
       role="status"
       className={cn(
         'pointer-events-auto flex items-start gap-3 rounded-xl border bg-background p-3.5 shadow-lg ring-1',
         style.ring,
+        exiting ? 'animate-toast-out' : 'animate-toast-in',
       )}
     >
       <Icon className={cn('mt-0.5 h-5 w-5 shrink-0', style.iconClass)} />
@@ -55,7 +67,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
       </div>
       <button
         type="button"
-        onClick={onDismiss}
+        onClick={handleDismiss}
         aria-label="닫기"
         className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
       >

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -8,6 +8,7 @@ import {
 import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import type { DraftOpening, DraftWall, SceneVersion } from '@/types/scene';
 import { cn } from '@/lib/utils';
+import { CANVAS_BLUE, CANVAS_WINDOW } from '@/lib/canvas-scene-colors';
 import {
   clampCoord,
   clampMeterBBox,
@@ -32,17 +33,26 @@ const DRAG_THRESHOLD_M = 0.15;
 const CANVAS_LABEL_VB_RATIO = 0.018;
 
 const SELECTION_BADGE_LABEL = '우선 개선 영역';
+/** 우선 개선 영역 — bright lemon yellow (문·창문·primary blue 와 구분) */
+const SELECTION_FILL = 'rgba(254, 240, 138, 0.35)';
+const SELECTION_FILL_PREVIEW = 'rgba(254, 240, 138, 0.28)';
+const SELECTION_STROKE = '#FACC15';
+const SELECTION_LABEL_BG = '#FACC15';
+const SELECTION_LABEL_TEXT = '#111827';
+/** 선택 rect 모서리 — 도면 미터 좌표 기준 */
+const SELECTION_CORNER_R = 0.14;
 
 function selectionBadgeMetrics(labelFontM: number) {
   const font = labelFontM * 0.92;
-  const padX = labelFontM * 0.28;
+  const padX = labelFontM * 0.24;
   let textWidth = 0;
   for (const ch of SELECTION_BADGE_LABEL) {
     textWidth += ch === ' ' ? font * 0.28 : font * 0.88;
   }
   const width = padX * 2 + textWidth;
-  const height = labelFontM * 1.55;
-  return { font, padX, width, height };
+  const height = labelFontM * 1.45;
+  const cornerR = labelFontM * 0.22;
+  return { font, padX, width, height, cornerR };
 }
 
 function canvasLabelFontM(viewBoxW: number): number {
@@ -265,8 +275,10 @@ export function ApRecommendationCanvas({
                 y={clampedSelectionBBox.y_min}
                 width={clampedSelectionBBox.x_max - clampedSelectionBBox.x_min}
                 height={clampedSelectionBBox.y_max - clampedSelectionBBox.y_min}
-                fill="rgb(37 99 235 / 0.22)"
-                stroke="rgb(37 99 235)"
+                rx={SELECTION_CORNER_R}
+                ry={SELECTION_CORNER_R}
+                fill={SELECTION_FILL}
+                stroke={SELECTION_STROKE}
                 strokeWidth="1.5"
                 vectorEffect="non-scaling-stroke"
               />
@@ -275,14 +287,16 @@ export function ApRecommendationCanvas({
                 y={selectionBadgeY}
                 width={selectionBadge.width}
                 height={selectionBadge.height}
-                fill="oklch(0.55 0.22 254)"
+                rx={selectionBadge.cornerR}
+                ry={selectionBadge.cornerR}
+                fill={SELECTION_LABEL_BG}
               />
               <text
                 x={clampedSelectionBBox.x_min + selectionBadge.padX}
                 y={selectionBadgeY + selectionBadge.height * 0.62}
                 fontSize={selectionBadge.font}
-                fontWeight="600"
-                fill="white"
+                fontWeight="500"
+                fill={SELECTION_LABEL_TEXT}
                 style={{ userSelect: 'none' }}
               >
                 우선 개선 영역
@@ -296,8 +310,10 @@ export function ApRecommendationCanvas({
               y={dragRect.y}
               width={dragRect.w}
               height={dragRect.h}
-              fill="rgb(37 99 235 / 0.18)"
-              stroke="rgb(37 99 235)"
+              rx={SELECTION_CORNER_R}
+              ry={SELECTION_CORNER_R}
+              fill={SELECTION_FILL_PREVIEW}
+              stroke={SELECTION_STROKE}
               strokeWidth="1.5"
               strokeDasharray="4 3"
               vectorEffect="non-scaling-stroke"
@@ -349,7 +365,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
   const end = g.coordinates[g.coordinates.length - 1];
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const color = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW;
   return (
     <line
       x1={start[0]}
@@ -371,7 +387,7 @@ function ExistingApMarker({ ap }: { ap: CanvasExistingAp }) {
   const label = ap.label ?? ap.id.toUpperCase();
   return (
     <g pointerEvents="none">
-      <circle cx={ap.x_m} cy={ap.y_m} r={r} fill="oklch(0.55 0.22 254)" />
+      <circle cx={ap.x_m} cy={ap.y_m} r={r} fill={CANVAS_BLUE} />
       <g
         transform={`translate(${ap.x_m - r * 0.55}, ${ap.y_m - r * 0.55}) scale(${r / 12})`}
         fill="none"
@@ -423,7 +439,7 @@ function RecommendationMarker({
   labelFontM: number;
 }) {
   const r = RECOMMEND_RADIUS_M;
-  const fill = selected ? 'oklch(0.62 0.19 145)' : 'oklch(0.72 0.19 145)';
+  const fill = selected ? '#059669' : '#10b981';
   return (
     <g pointerEvents="none">
       <circle
@@ -432,7 +448,7 @@ function RecommendationMarker({
         r={r}
         fill={fill}
         stroke="white"
-        strokeWidth="2"
+        strokeWidth="1.5"
         vectorEffect="non-scaling-stroke"
       />
       <text
@@ -441,7 +457,7 @@ function RecommendationMarker({
         textAnchor="middle"
         dominantBaseline="middle"
         fontSize={Math.max(r * 0.55, labelFontM * 0.65)}
-        fontWeight="700"
+        fontWeight="600"
         fill="white"
         style={{ userSelect: 'none' }}
       >
@@ -453,10 +469,10 @@ function RecommendationMarker({
         textAnchor="middle"
         dominantBaseline="middle"
         fontSize={labelFontM}
-        fontWeight="700"
-        fill="oklch(0.28 0.1 145)"
+        fontWeight="600"
+        fill={fill}
         stroke="white"
-        strokeWidth={labelFontM * 0.12}
+        strokeWidth={labelFontM * 0.1}
         paintOrder="stroke fill"
         style={{ userSelect: 'none' }}
       >

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -31,6 +31,20 @@ const DRAG_THRESHOLD_M = 0.15;
 /** viewBox 너비 비율 — 도면 스케일과 무관하게 화면에서 읽기 쉬운 라벨 크기 */
 const CANVAS_LABEL_VB_RATIO = 0.018;
 
+const SELECTION_BADGE_LABEL = '우선 개선 영역';
+
+function selectionBadgeMetrics(labelFontM: number) {
+  const font = labelFontM * 0.92;
+  const padX = labelFontM * 0.28;
+  let textWidth = 0;
+  for (const ch of SELECTION_BADGE_LABEL) {
+    textWidth += ch === ' ' ? font * 0.28 : font * 0.88;
+  }
+  const width = padX * 2 + textWidth;
+  const height = labelFontM * 1.55;
+  return { font, padX, width, height };
+}
+
 function canvasLabelFontM(viewBoxW: number): number {
   return viewBoxW * CANVAS_LABEL_VB_RATIO;
 }
@@ -44,6 +58,8 @@ interface Props {
   recommendations: ApRecommendationResult[];
   selectedRecommendationRank: number | null;
   disabled?: boolean;
+  /** true면 새 우선 개선 영역 드래그 불가 (추천 완료·계산 중) */
+  dragDisabled?: boolean;
 }
 
 interface Bounds {
@@ -96,7 +112,9 @@ export function ApRecommendationCanvas({
   recommendations,
   selectedRecommendationRank,
   disabled = false,
+  dragDisabled = false,
 }: Props) {
+  const interactionBlocked = disabled || dragDisabled;
   const svgRef = useRef<SVGSVGElement>(null);
   const [drag, setDrag] = useState<{ start: Coord; current: Coord } | null>(null);
 
@@ -137,7 +155,7 @@ export function ApRecommendationCanvas({
   };
 
   const handlePointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
-    if (disabled) return;
+    if (interactionBlocked) return;
     const pt = getSvgPoint(e);
     if (!pt) return;
     svgRef.current?.setPointerCapture(e.pointerId);
@@ -145,6 +163,7 @@ export function ApRecommendationCanvas({
   };
 
   const handlePointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (interactionBlocked) return;
     if (!drag) return;
     const pt = getSvgPoint(e);
     if (!pt) return;
@@ -152,6 +171,7 @@ export function ApRecommendationCanvas({
   };
 
   const finishDrag = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (interactionBlocked) return;
     if (!drag) return;
     try {
       svgRef.current?.releasePointerCapture(e.pointerId);
@@ -179,10 +199,9 @@ export function ApRecommendationCanvas({
   const showDragPreview =
     dragRect && (dragRect.w >= DRAG_THRESHOLD_M || dragRect.h >= DRAG_THRESHOLD_M);
   const labelFontM = canvasLabelFontM(vb.w);
-  const selectionBadgeH = labelFontM * 1.55;
-  const selectionBadgeW = labelFontM * 8.2;
+  const selectionBadge = selectionBadgeMetrics(labelFontM);
   const selectionBadgeY = clampedSelectionBBox
-    ? Math.max(sceneBounds.yMin, clampedSelectionBBox.y_min - selectionBadgeH)
+    ? Math.max(sceneBounds.yMin, clampedSelectionBBox.y_min - selectionBadge.height)
     : 0;
 
   return (
@@ -194,7 +213,9 @@ export function ApRecommendationCanvas({
         overflow="hidden"
         className={cn(
           'h-full w-full select-none touch-none',
-          disabled ? 'cursor-not-allowed opacity-60' : 'cursor-crosshair',
+          disabled && 'cursor-not-allowed opacity-60',
+          !disabled && dragDisabled && 'cursor-default',
+          !disabled && !dragDisabled && 'cursor-crosshair',
         )}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
@@ -233,15 +254,6 @@ export function ApRecommendationCanvas({
           {(sceneVersion?.openings ?? []).map((o) => (
             <OpeningShape key={o.id} opening={o} />
           ))}
-
-          {recommendations.map((rec) => (
-            <RecommendationMarker
-              key={rec.rank}
-              rec={rec}
-              selected={selectedRecommendationRank === rec.rank}
-              labelFontM={labelFontM}
-            />
-          ))}
         </g>
 
         {/* 선택 영역 — clamp된 좌표, clipPath 밖(배지가 상단에서 잘리지 않도록) */}
@@ -261,14 +273,14 @@ export function ApRecommendationCanvas({
               <rect
                 x={clampedSelectionBBox.x_min}
                 y={selectionBadgeY}
-                width={selectionBadgeW}
-                height={selectionBadgeH}
+                width={selectionBadge.width}
+                height={selectionBadge.height}
                 fill="oklch(0.55 0.22 254)"
               />
               <text
-                x={clampedSelectionBBox.x_min + labelFontM * 0.45}
-                y={selectionBadgeY + selectionBadgeH * 0.62}
-                fontSize={labelFontM * 0.92}
+                x={clampedSelectionBBox.x_min + selectionBadge.padX}
+                y={selectionBadgeY + selectionBadge.height * 0.62}
+                fontSize={selectionBadge.font}
                 fontWeight="600"
                 fill="white"
                 style={{ userSelect: 'none' }}
@@ -291,6 +303,18 @@ export function ApRecommendationCanvas({
               vectorEffect="non-scaling-stroke"
             />
           )}
+        </g>
+
+        {/* 추천 AP 마커 — 선택 영역 위에 표시 */}
+        <g pointerEvents="none">
+          {recommendations.map((rec) => (
+            <RecommendationMarker
+              key={rec.rank}
+              rec={rec}
+              selected={selectedRecommendationRank === rec.rank}
+              labelFontM={labelFontM}
+            />
+          ))}
         </g>
       </svg>
     </div>
@@ -416,12 +440,12 @@ function RecommendationMarker({
         y={rec.recommended_y}
         textAnchor="middle"
         dominantBaseline="middle"
-        fontSize={Math.max(r * 0.75, labelFontM * 0.85)}
+        fontSize={Math.max(r * 0.55, labelFontM * 0.65)}
         fontWeight="700"
         fill="white"
         style={{ userSelect: 'none' }}
       >
-        {rec.rank}
+        AP
       </text>
       <text
         x={rec.recommended_x}
@@ -436,7 +460,7 @@ function RecommendationMarker({
         paintOrder="stroke fill"
         style={{ userSelect: 'none' }}
       >
-        추천 {rec.rank}
+        추천 위치
       </text>
     </g>
   );

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -181,6 +181,9 @@ export function ApRecommendationCanvas({
   const labelFontM = canvasLabelFontM(vb.w);
   const selectionBadgeH = labelFontM * 1.55;
   const selectionBadgeW = labelFontM * 8.2;
+  const selectionBadgeY = clampedSelectionBBox
+    ? Math.max(sceneBounds.yMin, clampedSelectionBBox.y_min - selectionBadgeH)
+    : 0;
 
   return (
     <div className="relative h-full w-full overflow-hidden bg-[#f8fafc] [background-image:radial-gradient(circle,oklch(0.92_0_0)_1px,transparent_1px)] bg-size-[18px_18px] bg-position-[0_0]">
@@ -257,14 +260,14 @@ export function ApRecommendationCanvas({
               />
               <rect
                 x={clampedSelectionBBox.x_min}
-                y={clampedSelectionBBox.y_min - selectionBadgeH}
+                y={selectionBadgeY}
                 width={selectionBadgeW}
                 height={selectionBadgeH}
                 fill="oklch(0.55 0.22 254)"
               />
               <text
                 x={clampedSelectionBBox.x_min + labelFontM * 0.45}
-                y={clampedSelectionBBox.y_min - selectionBadgeH * 0.38}
+                y={selectionBadgeY + selectionBadgeH * 0.62}
                 fontSize={labelFontM * 0.92}
                 fontWeight="600"
                 fill="white"

--- a/frontend/src/features/ap-recommendation/ap-canvas-mappers.ts
+++ b/frontend/src/features/ap-recommendation/ap-canvas-mappers.ts
@@ -1,4 +1,5 @@
 import { parseGeometry } from '@/features/editor/geometry-utils';
+import { nextApSequentialName } from '@/lib/ap-layout-naming';
 import type { ApLayout } from '@/types/ap-layout';
 import type { CanvasExistingAp } from './ApRecommendationCanvas';
 
@@ -34,11 +35,14 @@ export function apsFromRfRunRequest(
   return out;
 }
 
-/** POST /ap-layouts — 새 AP 이름 (기존 배치·캔버스 AP 수 기준). */
+/** POST /ap-layouts — 새 AP 이름 (기존 이름 접미사 최댓값 + 1). */
 export function nextApLayoutName(
   layouts: { ap_name: string }[],
-  canvasAps: { id: string }[],
+  canvasAps: { id: string; label?: string }[],
 ): string {
-  const seq = Math.max(layouts.length, canvasAps.length) + 1;
-  return `AP-${String(seq).padStart(2, '0')}`;
+  const names = [
+    ...layouts.map((l) => l.ap_name),
+    ...canvasAps.flatMap((a) => [a.label, a.id].filter((v): v is string => !!v)),
+  ];
+  return nextApSequentialName(names);
 }

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -1,5 +1,17 @@
 import { useEffect, useState } from 'react';
-import { Loader2, Maximize2, Sliders, X } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ClipboardList,
+  Loader2,
+  Maximize2,
+  Sliders,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type {
   CalibrationEvaluationResponse,
   CalibrationRun,
@@ -17,6 +29,15 @@ const SPACE_TYPE_OPTIONS: { value: SpaceType; label: string }[] = [
   { value: 'residential', label: '원룸/주거' },
 ];
 
+/** UI 전용 — 보정 실행 전 선행 조건 (API/로직 변경 없음). */
+export type CalibrationGate =
+  | 'no_measurement'
+  | 'insufficient_points'
+  | 'no_simulation'
+  | 'ready';
+
+type CalibrationUiStatus = 'needs_data' | 'ready' | 'running' | 'complete' | 'failed';
+
 interface Props {
   run: CalibrationRun | null;
   isPolling: boolean;
@@ -24,11 +45,17 @@ interface Props {
   canCalibrate: boolean;
   /** 비활성 시 사용자에게 보여줄 사유 (측정 부족 / 시뮬 부족 등). */
   disabledReason?: string | null;
-  /** 사용자가 선택한 공간 유형 — calibration 의 soft prior 로 backend 에 전달. */
+  /** 선행 조건 — 안내 박스 문구 분기용. */
+  calibrationGate?: CalibrationGate;
+  /** false 면 select 대신 현재 값만 표시 (상단 FloorSpaceTypeSelector 와 중복 방지). */
+  showSpaceTypeField?: boolean;
+  /** 사용자가 선택한 공간 유형 — Floor.space_type 과 동기화 권장. */
   spaceType: SpaceType;
-  onSpaceTypeChange: (next: SpaceType) => void;
+  onSpaceTypeChange?: (next: SpaceType) => void;
   onCalibrate: () => void;
   showCalibrateButton?: boolean;
+  /** false 면 "실측/진단으로 이동" 링크 숨김 (이미 해당 페이지일 때). */
+  showMeasurementLink?: boolean;
   onAddReferenceMeasurement?: () => void;
   parameterUpdates: ParameterUpdate[];
   evaluation?: CalibrationEvaluationResponse | null;
@@ -36,8 +63,7 @@ interface Props {
 }
 
 /**
- * 시뮬레이션 보정 카드 — 측정 vs 시뮬 비교로 시뮬 파라미터(벽 흡수율 등) 자동 보정.
- * 시뮬레이션 페이지의 우측 사이드바에 노출. 보정 결과는 다음 시뮬 실행 시 자동 반영.
+ * 시뮬레이션 보정 카드 — 실측과 시뮬 비교로 예측 정확도를 높이는 보정 UI.
  */
 export function CalibrationCard({
   run,
@@ -45,10 +71,13 @@ export function CalibrationCard({
   isStarting,
   canCalibrate,
   disabledReason,
+  calibrationGate,
   spaceType,
   onSpaceTypeChange,
   onCalibrate,
   showCalibrateButton = true,
+  showSpaceTypeField = true,
+  showMeasurementLink = true,
   onAddReferenceMeasurement,
   parameterUpdates,
   evaluation,
@@ -57,52 +86,102 @@ export function CalibrationCard({
   const succeeded = run?.status === 'succeeded';
   const failed = run?.status === 'failed';
   const showProgress = isStarting || isPolling;
+  const isComplete = succeeded || !!evaluation;
+
+  const uiStatus: CalibrationUiStatus = showProgress
+    ? 'running'
+    : failed
+      ? 'failed'
+      : isComplete
+        ? 'complete'
+        : canCalibrate
+          ? 'ready'
+          : 'needs_data';
+
+  const gate: CalibrationGate =
+    calibrationGate ??
+    (canCalibrate
+      ? 'ready'
+      : disabledReason?.includes('시뮬레이션')
+        ? 'no_simulation'
+        : disabledReason?.includes('측정점')
+          ? 'insufficient_points'
+          : 'no_measurement');
 
   return (
-    <div className="rounded-2xl border bg-background p-5 shadow-sm">
-      <header className="mb-3 flex items-center gap-2">
-        <Sliders className="h-4 w-4 text-primary" />
-        <h3 className="text-sm font-bold">시뮬레이션 보정</h3>
-      </header>
-      <p className="text-[11px] leading-relaxed text-muted-foreground">
-        실측과 시뮬레이션 결과를 비교해서 벽 흡수율 등 시뮬 파라미터를 자동 보정합니다.
-        보정 후 시뮬레이션을 다시 실행하면 더 정확한 예측을 얻을 수 있습니다.
-      </p>
-
-      {/* 공간 유형 select — calibration BO 의 soft prior. 잘못 골라도 BO 가 어느 정도 보정. */}
-      <label className="mt-3 block">
-        <span className="text-[11px] font-medium text-muted-foreground">공간 유형</span>
-        <select
-          value={spaceType}
-          onChange={(e) => onSpaceTypeChange(e.target.value as SpaceType)}
-          disabled={showProgress}
-          className="mt-1 block w-full rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
-        >
-          {SPACE_TYPE_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-        <span className="mt-1 block text-[10px] leading-relaxed text-muted-foreground">
-          공간 유형은 보정의 초기 가정만 좁혀줍니다. 실제 결과는 측정 RSSI 기반으로 결정됩니다.
-        </span>
-      </label>
-
-      {showProgress ? (
-        <div className="mt-3 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2.5 text-xs">
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
-          <span className="font-medium">
-            {isStarting ? '보정 요청 중…' : '보정 진행 중…'}
+    <div className="rounded-xl border border-slate-200/80 bg-white p-4 shadow-sm">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Sliders className="h-4 w-4" />
           </span>
+          <h3 className="text-sm font-semibold leading-tight text-foreground">시뮬레이션 보정</h3>
         </div>
-      ) : succeeded && run ? (
-        <CalibrationResult run={run} parameterUpdates={parameterUpdates} evaluation={evaluation} />
-      ) : failed ? (
-        <p className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[11px] text-destructive">
-          보정에 실패했습니다. 측정 데이터가 충분한지 확인해주세요.
+        <CalibrationStatusBadge status={uiStatus} />
+      </header>
+
+      <div className="mt-3 space-y-1">
+        <p className="text-xs leading-snug text-foreground/90">
+          실측값을 기준으로 시뮬레이션 오차를 줄입니다.
         </p>
-      ) : null}
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          {uiStatus === 'needs_data'
+            ? '측정 데이터를 먼저 수집하면 보정값을 계산할 수 있습니다.'
+            : '보정 후 시뮬레이션을 다시 실행하면 더 정확한 예측을 확인할 수 있습니다.'}
+        </p>
+      </div>
+
+      {showSpaceTypeField ? (
+        <SpaceTypeField
+          spaceType={spaceType}
+          onSpaceTypeChange={onSpaceTypeChange ?? (() => {})}
+          disabled={showProgress}
+        />
+      ) : (
+        <SpaceTypeReadonly spaceType={spaceType} />
+      )}
+
+      {uiStatus === 'needs_data' && (
+        <CalibrationGateNotice
+          gate={gate}
+          disabledReason={disabledReason}
+          showMeasurementLink={showMeasurementLink}
+        />
+      )}
+
+      {uiStatus === 'running' && (
+        <div className="mt-3 flex items-center gap-2.5 rounded-xl border border-primary/15 bg-primary/5 px-3 py-2.5">
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+          <div>
+            <p className="text-xs font-medium text-foreground">
+              {isStarting ? '보정을 시작하는 중…' : '보정 중…'}
+            </p>
+            <p className="text-[11px] text-muted-foreground">잠시만 기다려주세요.</p>
+          </div>
+        </div>
+      )}
+
+      {uiStatus === 'complete' && run && (
+        <CalibrationResult run={run} parameterUpdates={parameterUpdates} evaluation={evaluation} />
+      )}
+
+      {uiStatus === 'failed' && (
+        <div className="mt-3 flex gap-2.5 rounded-xl border border-destructive/20 bg-destructive/5 px-3 py-2.5">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          <p className="text-[11px] leading-relaxed text-destructive">
+            보정에 실패했습니다. 측정 데이터가 충분한지 확인해주세요.
+          </p>
+        </div>
+      )}
+
+      {uiStatus === 'complete' && !run && evaluation && (
+        <div className="mt-3 flex gap-2.5 rounded-xl border border-emerald-200/80 bg-emerald-50/80 px-3 py-2.5">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+          <p className="text-[11px] leading-relaxed text-emerald-900">
+            보정된 값으로 시뮬레이션을 다시 실행해보세요.
+          </p>
+        </div>
+      )}
 
       <CalibrationEvaluationPanel
         evaluation={evaluation ?? extractEvaluationResponse(run)}
@@ -111,19 +190,208 @@ export function CalibrationCard({
       />
 
       {showCalibrateButton && (
-      <button
-        type="button"
-        onClick={onCalibrate}
-        disabled={!canCalibrate || showProgress}
-        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        <div className="mt-3 space-y-2">
+          {uiStatus === 'complete' && (
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              보정 결과는 다음 시뮬레이션 실행에 반영됩니다.
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={onCalibrate}
+            disabled={!canCalibrate || showProgress}
+            className={cn(
+              'inline-flex w-full items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-semibold transition-colors',
+              uiStatus === 'complete'
+                ? 'border border-slate-200 bg-white text-foreground hover:bg-slate-50 disabled:opacity-60'
+                : 'bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50',
+            )}
+          >
+            {showProgress ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                보정 중…
+              </>
+            ) : uiStatus === 'complete' ? (
+              <>
+                <Sparkles className="h-3.5 w-3.5" />
+                다시 보정하기
+              </>
+            ) : (
+              <>
+                <Sliders className="h-3.5 w-3.5" />
+                보정 실행하기
+              </>
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CalibrationStatusBadge({ status }: { status: CalibrationUiStatus }) {
+  const config: Record<
+    CalibrationUiStatus,
+    { label: string; className: string }
+  > = {
+    needs_data: {
+      label: '측정 필요',
+      className: 'border-sky-300 bg-sky-100 text-sky-700',
+    },
+    ready: {
+      label: '보정 가능',
+      className: 'border-primary/20 bg-primary/5 text-primary',
+    },
+    running: {
+      label: '보정 중',
+      className: 'border-primary/20 bg-primary/5 text-primary',
+    },
+    complete: {
+      label: '보정 완료',
+      className: 'border-emerald-200/80 bg-emerald-50 text-emerald-800',
+    },
+    failed: {
+      label: '보정 실패',
+      className: 'border-destructive/20 bg-destructive/5 text-destructive',
+    },
+  };
+  const { label, className } = config[status];
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded-full border px-2 py-1 text-[10px] font-semibold leading-snug',
+        className,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function SpaceTypeReadonly({ spaceType }: { spaceType: SpaceType }) {
+  const label =
+    SPACE_TYPE_OPTIONS.find((o) => o.value === spaceType)?.label ?? '미지정';
+  return (
+    <div className="mt-3">
+      <span className="text-[11px] font-medium text-foreground/80">공간 유형</span>
+      <div
+        className={cn(
+          'mt-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2',
+          'text-xs font-medium text-foreground shadow-sm',
+        )}
       >
-        <Sliders className="h-3.5 w-3.5" />
-        {succeeded ? '다시 보정 실행' : '보정 실행'}
-      </button>
-      )}
-      {!canCalibrate && disabledReason && (
-        <p className="mt-2 text-[11px] text-muted-foreground">{disabledReason}</p>
-      )}
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function SpaceTypeField({
+  spaceType,
+  onSpaceTypeChange,
+  disabled,
+}: {
+  spaceType: SpaceType;
+  onSpaceTypeChange: (next: SpaceType) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="mt-3">
+      <label className="block">
+        <span className="text-[11px] font-medium text-foreground/80">공간 유형</span>
+        <span className="mt-0.5 block text-[10px] text-muted-foreground">
+          초기 보정값을 정하는 기준입니다.
+        </span>
+        <div className="relative mt-1.5">
+          <select
+            value={spaceType}
+            onChange={(e) => onSpaceTypeChange(e.target.value as SpaceType)}
+            disabled={disabled}
+            className={cn(
+              'h-9 w-full appearance-none rounded-xl border border-slate-200 bg-white',
+              'px-3 pr-9 text-xs font-medium text-foreground shadow-sm',
+              'focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+            )}
+          >
+            {SPACE_TYPE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+        </div>
+      </label>
+    </div>
+  );
+}
+
+function CalibrationGateNotice({
+  gate,
+  disabledReason,
+  showMeasurementLink,
+}: {
+  gate: CalibrationGate;
+  disabledReason?: string | null;
+  showMeasurementLink: boolean;
+}) {
+  if (gate === 'no_simulation') {
+    return (
+      <div className="mt-3 flex gap-2.5 rounded-xl border border-slate-200/80 bg-slate-50 px-3 py-2.5">
+        <ClipboardList className="mt-0.5 h-4 w-4 shrink-0 text-slate-500" />
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-medium text-foreground">시뮬레이션 결과가 필요합니다</p>
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            시뮬레이션 페이지에서 한 번 실행한 뒤, 다시 보정을 시도해주세요.
+          </p>
+          <Link
+            to="/simulation"
+            className="inline-flex items-center text-[11px] font-semibold text-primary hover:underline"
+          >
+            시뮬레이션으로 이동
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (gate === 'insufficient_points') {
+    return (
+      <div className="mt-3 flex gap-2.5 rounded-xl border border-slate-200/80 bg-slate-50 px-3 py-2.5">
+        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-500" />
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-medium text-foreground">측정점이 더 필요합니다</p>
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {disabledReason ??
+              '도면 전반에 골고루 측정하면 더 안정적인 보정값을 얻을 수 있습니다.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 flex gap-2.5 rounded-xl border border-slate-200/80 bg-slate-50 px-3 py-2.5">
+      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-500" />
+      <div className="min-w-0 space-y-1">
+        <p className="text-xs font-medium text-foreground">측정 데이터가 필요합니다</p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          실측/진단에서 측정을 완료하면 보정을 실행할 수 있습니다.
+        </p>
+        {showMeasurementLink && (
+          <Link
+            to="/measurement"
+            className="inline-flex items-center text-[11px] font-semibold text-primary hover:underline"
+          >
+            실측/진단으로 이동
+          </Link>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -26,6 +26,17 @@ import {
   saveCachedScaleRatio,
   useImageNaturalDimensions,
 } from './floorplan-image-extent';
+import {
+  CANVAS_BLUE,
+  CANVAS_BLUE_FAINT,
+  CANVAS_BLUE_TINT,
+  CANVAS_BLUE_TINT_STRONG,
+  CANVAS_OBJECT_FILL,
+  CANVAS_OBJECT_LABEL,
+  CANVAS_OBJECT_STROKE,
+  CANVAS_WALL,
+  CANVAS_WINDOW,
+} from '@/lib/canvas-scene-colors';
 import type { EditorTool } from '@/stores/editor-store';
 
 interface Bounds {
@@ -214,6 +225,11 @@ type CreatingState =
 
 /** 폴리곤 닫기 임계값 (미터). 시작점 근처 클릭으로 인식. */
 const POLYGON_CLOSE_THRESHOLD_M = 0.4;
+
+/** 벽·문·창 실선/미리보기 점선 공통 stroke (OpeningShape·WallShape 와 동일). */
+const STROKE_WALL = CANVAS_WALL;
+const STROKE_DOOR = CANVAS_BLUE;
+const STROKE_WINDOW = CANVAS_WINDOW;
 
 /** 끝점 스냅 반경 (미터). 이 안에 기존 끝점이 있으면 딱 붙음. */
 const SNAP_RADIUS_M = 0.25;
@@ -1344,7 +1360,7 @@ export function DraftSceneCanvas({
                   width={b.w}
                   height={b.h}
                   fill="none"
-                  stroke="oklch(0.55 0.22 264)"
+                  stroke={CANVAS_BLUE}
                   strokeWidth="1.5"
                   strokeDasharray="0.18 0.12"
                   vectorEffect="non-scaling-stroke"
@@ -1376,7 +1392,7 @@ export function DraftSceneCanvas({
               y1={creating.firstPoint[1]}
               x2={cursorPos[0]}
               y2={cursorPos[1]}
-              stroke="oklch(0.55 0.22 264)"
+              stroke={STROKE_WALL}
               strokeWidth="4"
               strokeDasharray="6 4"
               strokeLinecap="butt"
@@ -1386,7 +1402,7 @@ export function DraftSceneCanvas({
               cx={creating.firstPoint[0]}
               cy={creating.firstPoint[1]}
               r="0.07"
-              fill="oklch(0.55 0.22 264)"
+              fill={STROKE_WALL}
             />
           </g>
         )}
@@ -1399,7 +1415,7 @@ export function DraftSceneCanvas({
               y1={creating.firstPoint[1]}
               x2={cursorPos[0]}
               y2={cursorPos[1]}
-              stroke="oklch(0.55 0.22 264)"
+              stroke={tool === 'window' ? STROKE_WINDOW : STROKE_DOOR}
               strokeWidth="5"
               strokeDasharray="4 3"
               vectorEffect="non-scaling-stroke"
@@ -1408,7 +1424,7 @@ export function DraftSceneCanvas({
               cx={creating.firstPoint[0]}
               cy={creating.firstPoint[1]}
               r="0.07"
-              fill="oklch(0.55 0.22 264)"
+              fill={tool === 'window' ? STROKE_WINDOW : STROKE_DOOR}
             />
           </g>
         )}
@@ -1425,8 +1441,8 @@ export function DraftSceneCanvas({
               {canClose && pts.length >= 3 && (
                 <polygon
                   points={polyPoints}
-                  fill="oklch(0.92 0.05 264 / 0.3)"
-                  stroke="oklch(0.55 0.22 264)"
+                  fill={CANVAS_BLUE_TINT_STRONG}
+                  stroke={CANVAS_BLUE}
                   strokeWidth="3"
                   strokeDasharray="6 4"
                   vectorEffect="non-scaling-stroke"
@@ -1437,7 +1453,7 @@ export function DraftSceneCanvas({
                 <polyline
                   points={polyPoints}
                   fill="none"
-                  stroke="oklch(0.55 0.22 264)"
+                  stroke={CANVAS_BLUE}
                   strokeWidth="3"
                   strokeDasharray="6 4"
                   strokeLinecap="round"
@@ -1452,7 +1468,7 @@ export function DraftSceneCanvas({
                   y1={pts[pts.length - 1][1]}
                   x2={cursorPos[0]}
                   y2={cursorPos[1]}
-                  stroke="oklch(0.55 0.22 264)"
+                  stroke={CANVAS_BLUE}
                   strokeWidth="2"
                   strokeDasharray="3 3"
                   strokeLinecap="round"
@@ -1470,8 +1486,8 @@ export function DraftSceneCanvas({
                     cx={p[0]}
                     cy={p[1]}
                     r={isFirstHighlighted ? 0.13 : isFirst ? 0.09 : 0.06}
-                    fill={isFirstHighlighted ? 'oklch(0.55 0.22 264)' : 'white'}
-                    stroke="oklch(0.55 0.22 264)"
+                    fill={isFirstHighlighted ? CANVAS_BLUE : 'white'}
+                    stroke={CANVAS_BLUE}
                     strokeWidth={isFirstHighlighted ? 2 : 2}
                     vectorEffect="non-scaling-stroke"
                   />
@@ -1488,7 +1504,7 @@ export function DraftSceneCanvas({
             cy={cursorPos[1]}
             r="0.18"
             fill="oklch(0.9 0.04 256)"
-            stroke="oklch(0.55 0.22 264)"
+            stroke={CANVAS_BLUE}
             strokeWidth="2"
             strokeDasharray="3 2"
             vectorEffect="non-scaling-stroke"
@@ -1508,8 +1524,8 @@ export function DraftSceneCanvas({
                 y={r.y}
                 width={r.w}
                 height={r.h}
-                fill="oklch(0.62 0.18 264 / 0.08)"
-                stroke="oklch(0.62 0.18 264)"
+                fill={CANVAS_BLUE_FAINT}
+                stroke={CANVAS_BLUE}
                 strokeWidth="1.5"
                 strokeDasharray="4 3"
                 vectorEffect="non-scaling-stroke"
@@ -1814,8 +1830,8 @@ function RoomShape({
     <g>
       <polygon
         points={points}
-        fill={selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.01 256)'}
-        stroke={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.86 0 0)'}
+        fill={selected ? CANVAS_BLUE_TINT : 'oklch(0.95 0.01 256)'}
+        stroke={selected ? CANVAS_BLUE : 'oklch(0.86 0 0)'}
         strokeWidth={selected ? 3 : 1.5}
         vectorEffect="non-scaling-stroke"
         className="cursor-pointer"
@@ -1910,7 +1926,7 @@ function WallShape({
         y1={start[1]}
         x2={end[0]}
         y2={end[1]}
-        stroke={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.25 0 0)'}
+        stroke={selected ? STROKE_DOOR : STROKE_WALL}
         strokeWidth={selected ? 6 : 4}
         strokeLinecap="butt"
         vectorEffect="non-scaling-stroke"
@@ -1940,7 +1956,7 @@ function OpeningShape({
   const [start, end] = coords;
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const baseColor = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  const baseColor = isDoor ? STROKE_DOOR : STROKE_WINDOW;
   const label = isDoor ? '문' : '창문';
   // 라벨은 선의 중점에서 수직 방향으로 살짝 떨어뜨려 배치.
   const midX = (start[0] + end[0]) / 2;
@@ -2030,9 +2046,9 @@ function ObjectShape({
     w = Math.max(0.2, w * Math.abs(sx));
     h = Math.max(0.2, h * Math.abs(sy));
   }
-  const fill = selected ? 'oklch(0.92 0.05 264)' : 'oklch(0.95 0.03 240)';
-  const stroke = selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.74 0.08 240)';
-  const labelFill = 'oklch(0.4 0.04 240)';
+  const fill = selected ? CANVAS_BLUE_TINT : CANVAS_OBJECT_FILL;
+  const stroke = selected ? CANVAS_BLUE : CANVAS_OBJECT_STROKE;
+  const labelFill = CANVAS_OBJECT_LABEL;
   // 공간성 객체는 선택 여부와 무관하게 항상 점선 (공간 vs 가구 구분 일관).
   const strokeDasharray = spaceLike ? '0.18 0.12' : undefined;
 
@@ -2149,7 +2165,7 @@ function ResizeCorner({
         cy={y}
         r={size}
         fill="white"
-        stroke="oklch(0.55 0.22 264)"
+        stroke={CANVAS_BLUE}
         strokeWidth="1.5"
         vectorEffect="non-scaling-stroke"
       />
@@ -2208,7 +2224,7 @@ function GroupResizeHandle({
         width={inner}
         height={inner}
         fill="white"
-        stroke="oklch(0.55 0.22 264)"
+        stroke={CANVAS_BLUE}
         strokeWidth="2"
         vectorEffect="non-scaling-stroke"
       />
@@ -2235,7 +2251,7 @@ function VertexHandle({
         cy={y}
         r={size}
         fill="white"
-        stroke="oklch(0.55 0.22 264)"
+        stroke={CANVAS_BLUE}
         strokeWidth="1.5"
         vectorEffect="non-scaling-stroke"
       />

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -294,7 +294,11 @@ function snapToWall(
     if (axed[0] !== raw[0] || axed[1] !== raw[1]) {
       const wallStop = nearestWallProjection(axed, draft, SNAP_RADIUS_M, excludeWallId);
       if (wallStop && isOnSameAxis(axisFrom, axed, wallStop)) {
-        return { point: wallStop, snapped: true, kind: 'axis' };
+        const horizontal = Math.abs(axed[1] - axisFrom[1]) < AXIS_SNAP_TOLERANCE_M;
+        const correctedPoint: Coord = horizontal
+          ? [wallStop[0], axisFrom[1]]
+          : [axisFrom[0], wallStop[1]];
+        return { point: correctedPoint, snapped: true, kind: 'axis' };
       }
       return { point: axed, snapped: true, kind: 'axis' };
     }

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, ChevronDown, Ruler, RotateCcw, ScanLine, Sparkles, Trash2 } from 'lucide-react';
+import { Check, ChevronDown, Ruler, RotateCcw, Sparkles, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   materialLabel,
@@ -96,7 +96,9 @@ export function PropertiesPanel({
         <EmptyBody />
       )}
 
+      {/* [미구현] 모바일 AR 가구 스캔 — 백엔드/모바일 연동 없음. 구현 시 MobileScanCard 복구.
       <MobileScanCard />
+      */}
     </aside>
   );
 }
@@ -687,24 +689,6 @@ function EmptyBody() {
       </p>
       <p className="mt-1 text-[11px] text-muted-foreground/80">
         캔버스의 도형을 클릭하면 속성이 표시됩니다.
-      </p>
-    </div>
-  );
-}
-
-function MobileScanCard() {
-  return (
-    <div className="mt-auto rounded-xl bg-primary p-4 text-primary-foreground shadow-sm">
-      <div className="flex items-center gap-2">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/15">
-          <ScanLine className="h-4 w-4" />
-        </div>
-        <span className="text-sm font-semibold">모바일 가구 스캔</span>
-      </div>
-      <p className="mt-3 text-xs leading-relaxed text-primary-foreground/90">
-        카메라로 공간을 비추기만 하세요.
-        <br />
-        가구 크기와 위치를 자동으로 측정합니다.
       </p>
     </div>
   );

--- a/frontend/src/features/floor/FloorSpaceTypeSelector.tsx
+++ b/frontend/src/features/floor/FloorSpaceTypeSelector.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { Building2 } from 'lucide-react';
 import { useFloors, useUpdateFloor } from '@/hooks/use-floors';
 import type { SpaceType } from '@/types/calibration-run';
+import { cn } from '@/lib/utils';
 
 const SPACE_TYPE_OPTIONS: { value: SpaceType; label: string }[] = [
   { value: 'unknown', label: '미지정' },
@@ -26,6 +27,8 @@ interface Props {
   projectId: string | null;
   /** 추가 클래스 (배치 보조). */
   className?: string;
+  /** select 요소 전용 클래스. */
+  selectClassName?: string;
   /** 라벨 표시 여부 — compact 모드면 false. */
   showLabel?: boolean;
 }
@@ -34,6 +37,7 @@ export function FloorSpaceTypeSelector({
   floorId,
   projectId,
   className,
+  selectClassName,
   showLabel = true,
 }: Props) {
   const floorsQuery = useFloors(projectId);
@@ -66,7 +70,10 @@ export function FloorSpaceTypeSelector({
         onChange={(e) => handleChange(e.target.value as SpaceType)}
         disabled={disabled}
         title="이 도면(층) 의 공간 유형 — calibration 보정의 초기 가정에 사용. 변경시 즉시 저장."
-        className="rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+        className={cn(
+          selectClassName ??
+            'rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50',
+        )}
       >
         {SPACE_TYPE_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -12,6 +12,13 @@ import type {
   SceneVersion,
 } from '@/types/scene';
 import { cn } from '@/lib/utils';
+import {
+  CANVAS_BLUE,
+  CANVAS_OBJECT_FILL,
+  CANVAS_OBJECT_LABEL,
+  CANVAS_OBJECT_STROKE,
+  CANVAS_WINDOW,
+} from '@/lib/canvas-scene-colors';
 
 export type MeasurementPointQuality = 'good' | 'warning' | 'poor';
 
@@ -419,7 +426,7 @@ export function MeasurementCanvas({
           <polyline
             points={sortedPoints.map((p) => `${p.x_m},${p.y_m}`).join(' ')}
             fill="none"
-            stroke="oklch(0.6 0.18 255)"
+            stroke={CANVAS_BLUE}
             strokeWidth="2"
             strokeDasharray="6 4"
             vectorEffect="non-scaling-stroke"
@@ -551,7 +558,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
   const end = g.coordinates[g.coordinates.length - 1];
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const color = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW;
   return (
     <line
       x1={start[0]}
@@ -585,8 +592,8 @@ function ObjectShape({ object }: { object: DraftObject }) {
         width={w}
         height={h}
         rx="0.15"
-        fill="oklch(0.95 0.03 240)"
-        stroke="oklch(0.74 0.08 240)"
+        fill={CANVAS_OBJECT_FILL}
+        stroke={CANVAS_OBJECT_STROKE}
         strokeWidth="1.5"
         vectorEffect="non-scaling-stroke"
       />
@@ -598,7 +605,7 @@ function ObjectShape({ object }: { object: DraftObject }) {
           dominantBaseline="middle"
           fontSize={Math.min(w, h) * 0.22}
           fontWeight="500"
-          fill="oklch(0.4 0.04 240)"
+          fill={CANVAS_OBJECT_LABEL}
         >
           {label}
         </text>
@@ -623,7 +630,7 @@ function objectTypeLabel(t: string | null | undefined): string | null {
 }
 
 function ApMarker({ ap }: { ap: PlacedApSimple }) {
-  const fill = 'oklch(0.55 0.22 254)';
+  const fill = CANVAS_BLUE;
   const r = AP_MARKER_RADIUS_M;
   const iconSize = r * 1.1;
   const iconScale = iconSize / 24;
@@ -651,7 +658,7 @@ function ApMarker({ ap }: { ap: PlacedApSimple }) {
           dominantBaseline="middle"
           fontSize={AP_LABEL_FONT_SIZE_M}
           fontWeight="600"
-          fill="oklch(0.4 0.1 254)"
+          fill={fill}
         >
           {ap.label}
         </text>

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -13,6 +13,14 @@ import type {
   SceneVersion,
 } from '@/types/scene';
 import { cn } from '@/lib/utils';
+import {
+  CANVAS_AP_LABEL_BORDER,
+  CANVAS_BLUE,
+  CANVAS_OBJECT_FILL,
+  CANVAS_OBJECT_LABEL,
+  CANVAS_OBJECT_STROKE,
+  CANVAS_WINDOW,
+} from '@/lib/canvas-scene-colors';
 
 export interface PlacedAp {
   id: string;          // 'ap1', 'ap2', ... — 사용자/SageMaker 식별자
@@ -109,6 +117,21 @@ function computeViewBox(
   return { x: b.minX - padding, y: b.minY - padding, w: w + 2 * padding, h: h + 2 * padding };
 }
 
+/** viewBox 와 히트맵 bounds 의 union — clipPath 밖으로 히트맵이 잘리지 않게. */
+function unionViewBoxWithHeatmapBounds(
+  vb: { x: number; y: number; w: number; h: number },
+  bounds: { minX: number; minY: number; maxX: number; maxY: number },
+): { x: number; y: number; w: number; h: number } {
+  const minX = Math.min(vb.x, bounds.minX);
+  const minY = Math.min(vb.y, bounds.minY);
+  const maxX = Math.max(vb.x + vb.w, bounds.maxX);
+  const maxY = Math.max(vb.y + vb.h, bounds.maxY);
+  const w = maxX - minX || 1;
+  const h = maxY - minY || 1;
+  const padding = Math.max(w, h) * 0.05;
+  return { x: minX - padding, y: minY - padding, w: w + 2 * padding, h: h + 2 * padding };
+}
+
 /**
  * 시뮬레이션 페이지 캔버스 — 확정 버전 도형(rooms/walls/openings/objects)을 read-only 로
  * 보여주고, 그 위에 사용자가 AP 를 자유롭게 배치/드래그/삭제. 최대 8개.
@@ -144,14 +167,31 @@ export function SimulationCanvas({
     [imageDims, sceneVersion?.source_asset_id, sceneVersion?.floor_id],
   );
 
-  // viewBox: editor/measurement 와 같은 floor 캐시를 우선 사용해 페이지 간 도면 크기를 고정.
-  // 캐시가 없을 때만 image+shape union 으로 계산.
+  // viewBox: AP 배치(idle) 는 editor 캐시 우선. 결과(히트맵) 보기는 과거 run 의 bounds 가
+  // 현재 편집 캐시와 어긋나 clip 되는 경우가 있어 scene+image(+heatmap) union 으로 계산.
   const vb = useMemo(() => {
+    if (readOnly && heatmapUrl) {
+      const base = imageExtent
+        ? computeViewBox(sceneVersion, imageExtent)
+        : computeViewBox(sceneVersion, null);
+      if (heatmapBounds) {
+        return unionViewBoxWithHeatmapBounds(base, heatmapBounds);
+      }
+      return base;
+    }
     const cached = loadCachedViewBox(sceneVersion?.floor_id ?? null);
     if (cached) return cached;
     if (imageExtent) return computeViewBox(sceneVersion, imageExtent);
     return computeViewBox(sceneVersion, null);
-  }, [sceneId, sceneVersion?.floor_id, imageExtent]);
+  }, [
+    sceneId,
+    sceneVersion,
+    sceneVersion?.floor_id,
+    imageExtent,
+    readOnly,
+    heatmapUrl,
+    heatmapBounds,
+  ]);
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOffset, setDragOffset] = useState<Coord>([0, 0]);
 
@@ -220,7 +260,7 @@ export function SimulationCanvas({
     : 'cursor-default';
 
   return (
-    <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[#f8fafc] p-6 [background-image:radial-gradient(circle,_oklch(0.92_0_0)_1px,_transparent_1px)] [background-position:0_0] [background-size:18px_18px]">
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-slate-50/80 p-4 [background-image:radial-gradient(circle,_rgb(148_163_184_/_0.12)_1px,_transparent_1px)] [background-position:0_0] [background-size:20px_20px]">
       <svg
         ref={svgRef}
         viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
@@ -272,7 +312,7 @@ export function SimulationCanvas({
             width={heatmapBounds ? heatmapBounds.maxX - heatmapBounds.minX : vb.w}
             height={heatmapBounds ? heatmapBounds.maxY - heatmapBounds.minY : vb.h}
             preserveAspectRatio={heatmapBounds ? 'none' : 'xMidYMid meet'}
-            opacity={0.6}
+            opacity={0.72}
             pointerEvents="none"
             onError={() => {
               console.warn('[SimulationCanvas] 히트맵 이미지 로드 실패:', heatmapUrl);
@@ -383,7 +423,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
   const end = g.coordinates[g.coordinates.length - 1];
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const color = isDoor ? 'oklch(0.55 0.22 264)' : 'oklch(0.7 0.18 200)';
+  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW;
   const label = isDoor ? '문' : '창문';
   const midX = (start[0] + end[0]) / 2;
   const midY = (start[1] + end[1]) / 2;
@@ -441,8 +481,8 @@ function ObjectShape({ object }: { object: DraftObject }) {
         width={w}
         height={h}
         rx="0.15"
-        fill="oklch(0.95 0.03 240)"
-        stroke="oklch(0.74 0.08 240)"
+        fill={CANVAS_OBJECT_FILL}
+        stroke={CANVAS_OBJECT_STROKE}
         strokeWidth="1.5"
         strokeDasharray={strokeDasharray}
         vectorEffect="non-scaling-stroke"
@@ -455,7 +495,7 @@ function ObjectShape({ object }: { object: DraftObject }) {
           dominantBaseline="middle"
           fontSize={computeLabelFontSize(label, w, h)}
           fontWeight="500"
-          fill="oklch(0.4 0.04 240)"
+          fill={CANVAS_OBJECT_LABEL}
           style={{ userSelect: 'none' }}
         >
           {label}
@@ -480,7 +520,7 @@ function ApMarker({
   onPointerDown: (e: React.PointerEvent) => void;
   onRemove: () => void;
 }) {
-  const fill = 'oklch(0.55 0.22 254)';
+  const fill = CANVAS_BLUE;
   const r = AP_MARKER_RADIUS_M;
   // lucide Wifi 아이콘 (24x24 viewBox) 을 r 안에 들어갈 크기로 스케일.
   const iconSize = r * 1.1; // 원 지름의 약 55%
@@ -518,7 +558,7 @@ function ApMarker({
           height={r * 0.75}
           rx={r * 0.18}
           fill="white"
-          stroke="oklch(0.85 0.02 240)"
+          stroke={CANVAS_AP_LABEL_BORDER}
           strokeWidth="1"
           vectorEffect="non-scaling-stroke"
         />
@@ -529,7 +569,7 @@ function ApMarker({
           dominantBaseline="middle"
           fontSize={AP_LABEL_FONT_SIZE_M}
           fontWeight="600"
-          fill="oklch(0.25 0.04 240)"
+          fill={fill}
           style={{ userSelect: 'none' }}
         >
           {ap.id.toUpperCase()}

--- a/frontend/src/features/simulation/SimulationHistory.tsx
+++ b/frontend/src/features/simulation/SimulationHistory.tsx
@@ -1,11 +1,11 @@
-import { ArrowLeftRight, Clock } from 'lucide-react';
+import { useState } from 'react';
+import { ArrowLeftRight, ChevronDown, History } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface SimulationHistoryItem {
   id: string;
-  label: string;
-  timeLabel: string;
-  /** 메트릭이 RfMap 에 있어서 history list 에선 비어있을 수 있음. null → "—" 표시. */
+  /** RF Run.created_at (ISO) — 카드 제목·실행 시점 표시용. */
+  createdAt: string;
   avgRssiDbm: number | null;
   coveragePercent: number | null;
   active?: boolean;
@@ -13,75 +13,248 @@ export interface SimulationHistoryItem {
 
 interface Props {
   items: SimulationHistoryItem[];
+  isLoading?: boolean;
   showCompareButton?: boolean;
   onSelect?: (id: string) => void;
-  emptyMessage?: string;
 }
 
-export function SimulationHistory({ items, showCompareButton, onSelect, emptyMessage }: Props) {
+type CoverageStatus = {
+  label: string;
+  badgeClass: string;
+};
+
+export function SimulationHistory({ items, isLoading, showCompareButton, onSelect }: Props) {
+  const [expanded, setExpanded] = useState(true);
+  const bestId = findBestResultId(items);
+
   return (
-    <section className="rounded-2xl border bg-background p-5 shadow-sm">
-      <header className="mb-4 flex items-center gap-2">
-        <Clock className="h-4 w-4 text-foreground/70" strokeWidth={2} />
-        <h3 className="text-sm font-bold">시뮬레이션 기록</h3>
-      </header>
-
-      {items.length === 0 ? (
-        <p className="py-2 text-xs text-muted-foreground">
-          {emptyMessage ?? '아직 시뮬레이션 기록이 없습니다.'}
-        </p>
-      ) : (
-        <ul className="space-y-3">
-          {items.map((item) => (
-            <li key={item.id}>
-              <button
-                type="button"
-                onClick={() => onSelect?.(item.id)}
-                disabled={!onSelect}
-                className={cn(
-                  'w-full rounded-lg border p-3 text-left transition-colors hover:border-primary/40 disabled:cursor-default',
-                  item.active && 'border-primary/40 bg-primary/5',
-                )}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <span className="text-sm font-semibold">{item.label}</span>
-                  <span className="shrink-0 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {item.timeLabel}
-                  </span>
-                </div>
-                <div className="mt-2 flex items-center gap-3 text-[12px] text-muted-foreground">
-                  <span>
-                    평균:{' '}
-                    <span className="font-semibold text-foreground">
-                      {item.avgRssiDbm == null ? '—' : `${formatNum(item.avgRssiDbm)}dBm`}
-                    </span>
-                  </span>
-                  <span>
-                    커버리지:{' '}
-                    <span className="font-semibold text-foreground">
-                      {item.coveragePercent == null ? '—' : `${formatNum(item.coveragePercent)}%`}
-                    </span>
-                  </span>
-                </div>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {showCompareButton && (
+    <section className="rounded-lg border border-slate-200 bg-white p-3">
+      <header className={cn(expanded && 'mb-2.5')}>
         <button
           type="button"
-          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-primary/40 bg-background py-2.5 text-sm font-semibold text-primary hover:bg-primary/5"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="flex w-full items-start justify-between gap-2 text-left"
         >
-          <ArrowLeftRight className="h-4 w-4" />두 시뮬레이션 결과 비교하기
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <History className="h-3.5 w-3.5 shrink-0 text-slate-400" strokeWidth={2} />
+              <h3 className="text-sm font-semibold text-slate-900">시뮬레이션 기록</h3>
+              {!isLoading && items.length > 0 && (
+                <span className="text-[10px] text-slate-400">({items.length})</span>
+              )}
+            </div>
+            {expanded && (
+              <p className="mt-0.5 pl-5 text-[11px] leading-relaxed text-slate-500">
+                최근 실행 결과를 비교해볼 수 있습니다.
+              </p>
+            )}
+          </div>
+          <ChevronDown
+            className={cn(
+              'mt-0.5 h-4 w-4 shrink-0 text-slate-400 transition-transform',
+              expanded && 'rotate-180',
+            )}
+            aria-hidden
+          />
+        </button>
+      </header>
+
+      {expanded &&
+        (isLoading ? (
+          <ul className="space-y-1.5" aria-busy="true" aria-label="기록 불러오는 중">
+            {Array.from({ length: 3 }, (_, i) => (
+              <li key={i}>
+                <HistoryCardSkeleton />
+              </li>
+            ))}
+          </ul>
+        ) : items.length === 0 ? (
+          <EmptyHistoryState />
+        ) : (
+          <ul className="space-y-1.5">
+            {items.map((item) => (
+              <li key={item.id}>
+                <HistoryCard
+                  item={item}
+                  isBest={item.id === bestId}
+                  onSelect={onSelect}
+                />
+              </li>
+            ))}
+          </ul>
+        ))}
+
+      {expanded && showCompareButton && (
+        <button
+          type="button"
+          className="mt-2.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-slate-200 bg-white py-1.5 text-xs font-medium text-blue-600 transition-colors hover:bg-slate-50"
+        >
+          <ArrowLeftRight className="h-3.5 w-3.5" />
+          두 시뮬레이션 결과 비교하기
         </button>
       )}
     </section>
   );
 }
 
-/** 소수 셋째자리에서 반올림 → 둘째자리까지 표시. 정수면 trailing 0 안 붙음. */
-function formatNum(n: number): string {
-  return Number(n.toFixed(2)).toString();
+function HistoryCard({
+  item,
+  isBest,
+  onSelect,
+}: {
+  item: SimulationHistoryItem;
+  isBest: boolean;
+  onSelect?: (id: string) => void;
+}) {
+  const status = getCoverageStatus(item.coveragePercent);
+  const title = formatExecutionLabel(item.createdAt);
+  const shortId = item.id.slice(0, 6);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(item.id)}
+      disabled={!onSelect}
+      className={cn(
+        'relative w-full rounded-md border border-slate-200 bg-white p-2.5 text-left transition-colors disabled:cursor-default',
+        isBest && 'border-l-4 border-l-blue-500 pl-2',
+        item.active && 'border-blue-300 bg-blue-50/60',
+        !item.active && 'hover:border-slate-300',
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-xs font-medium text-slate-800">{title}</span>
+        {isBest ? (
+          <span className="shrink-0 rounded border border-blue-100 bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
+            최고
+          </span>
+        ) : (
+          status && (
+            <span
+              className={cn(
+                'shrink-0 rounded border px-1.5 py-0.5 text-xs',
+                status.badgeClass,
+              )}
+            >
+              {status.label}
+            </span>
+          )
+        )}
+      </div>
+
+      <div className="mt-2 space-y-1">
+        <p className="text-[11px] text-slate-500">
+          평균 신호 세기
+          <span className="ml-2 font-medium tabular-nums text-slate-700">
+            {item.avgRssiDbm == null ? '—' : formatRssi(item.avgRssiDbm)}
+          </span>
+        </p>
+        <p className="flex items-center justify-between gap-2 text-[11px] text-slate-500">
+          <span>
+            안정 커버리지
+            <span className="ml-2 font-medium tabular-nums text-slate-700">
+              {item.coveragePercent == null ? '—' : formatCoverage(item.coveragePercent)}
+            </span>
+          </span>
+          <span className="shrink-0 tabular-nums text-[10px] text-slate-400/80">#{shortId}</span>
+        </p>
+      </div>
+    </button>
+  );
+}
+
+function EmptyHistoryState() {
+  return (
+    <div className="rounded-md border border-dashed border-slate-200 px-3 py-5 text-center">
+      <p className="text-xs font-medium text-slate-700">아직 실행된 시뮬레이션이 없습니다.</p>
+      <p className="mt-1 text-[10px] leading-relaxed text-slate-500">
+        AP를 배치한 뒤 시뮬레이션을 실행하면 결과가 여기에 표시됩니다.
+      </p>
+    </div>
+  );
+}
+
+function HistoryCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-md border border-slate-200 bg-white p-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="h-3.5 w-24 rounded bg-slate-100" />
+        <div className="h-5 w-10 rounded bg-slate-100" />
+      </div>
+      <div className="mt-2 space-y-1">
+        <div className="h-2.5 w-36 rounded bg-slate-100" />
+        <div className="flex items-center justify-between gap-2">
+          <div className="h-2.5 w-32 rounded bg-slate-100" />
+          <div className="h-2.5 w-10 rounded bg-slate-100" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 커버리지 ≥70% 양호 · ≥40% 일부 개선 필요 · 그 미만 개선 필요 */
+function getCoverageStatus(coverage: number | null): CoverageStatus | null {
+  if (coverage == null) return null;
+  if (coverage >= 70) {
+    return {
+      label: '양호',
+      badgeClass: 'border-slate-100 bg-slate-50 text-slate-600',
+    };
+  }
+  if (coverage >= 40) {
+    return {
+      label: '일부 개선 필요',
+      badgeClass: 'border-amber-100/80 bg-amber-50 text-amber-600',
+    };
+  }
+  return {
+    label: '개선 필요',
+    badgeClass: 'border-slate-100 bg-slate-50 text-slate-500',
+  };
+}
+
+/** 커버리지 최대 → 동률이면 평균 신호 세기(dBm)가 더 높은(덜 음수) 항목. */
+function findBestResultId(items: SimulationHistoryItem[]): string | null {
+  const ranked = items.filter((item) => item.coveragePercent != null);
+  if (ranked.length === 0) return null;
+
+  let best = ranked[0];
+  for (let i = 1; i < ranked.length; i += 1) {
+    const candidate = ranked[i];
+    const cmp = compareResults(candidate, best);
+    if (cmp > 0) best = candidate;
+  }
+  return best.id;
+}
+
+function compareResults(a: SimulationHistoryItem, b: SimulationHistoryItem): number {
+  const ac = a.coveragePercent ?? -Infinity;
+  const bc = b.coveragePercent ?? -Infinity;
+  if (ac !== bc) return ac - bc;
+
+  const ar = a.avgRssiDbm;
+  const br = b.avgRssiDbm;
+  if (ar == null && br == null) return 0;
+  if (ar == null) return -1;
+  if (br == null) return 1;
+  return ar - br;
+}
+
+function formatExecutionLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '실행 기록';
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${month}월 ${day}일 ${hh}:${mm} 실행`;
+}
+
+function formatRssi(n: number): string {
+  return `${n.toFixed(1)} dBm`;
+}
+
+function formatCoverage(n: number): string {
+  return `${n.toFixed(1)}%`;
 }

--- a/frontend/src/features/simulation/SimulationResultCard.tsx
+++ b/frontend/src/features/simulation/SimulationResultCard.tsx
@@ -14,7 +14,6 @@ export function SimulationResultCard({
   coveragePercent,
   staleReason,
 }: Props) {
-  // mock: rssi -100~-30 범위를 0~100 으로 매핑
   const rssiFillPct =
     avgRssiDbm == null
       ? 0
@@ -22,14 +21,14 @@ export function SimulationResultCard({
   const coverageFillPct = coveragePercent ?? 0;
 
   return (
-    <section className="rounded-2xl border bg-background p-5 shadow-sm">
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
       <header className="mb-4 flex items-center gap-2">
-        <BarChart3 className="h-4 w-4 text-primary" strokeWidth={2} />
-        <h3 className="text-sm font-bold">새로운 배치 예측 결과</h3>
+        <BarChart3 className="h-3.5 w-3.5 text-slate-400" strokeWidth={2} />
+        <h3 className="text-sm font-semibold text-slate-900">새로운 배치 예측 결과</h3>
       </header>
 
       <Metric
-        label="평균 신호 강도"
+        label="평균 신호 세기"
         valueText={avgRssiDbm == null ? '—' : formatNum(avgRssiDbm)}
         unit={avgRssiDbm == null ? '' : 'dBm'}
         fillPct={rssiFillPct}
@@ -38,7 +37,7 @@ export function SimulationResultCard({
 
       <div className="mt-5">
         <Metric
-          label="면적 커버리지 (양호)"
+          label="안정 커버리지"
           valueText={coveragePercent == null ? '—' : formatNum(coveragePercent)}
           unit={coveragePercent == null ? '' : '%'}
           fillPct={coverageFillPct}
@@ -47,17 +46,14 @@ export function SimulationResultCard({
       </div>
 
       {staleReason && (
-        <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground">
-          {staleReason}
-        </p>
+        <p className="mt-3 text-[11px] leading-relaxed text-slate-500">{staleReason}</p>
       )}
     </section>
   );
 }
 
-/** 소수 셋째자리에서 반올림 → 둘째자리까지 표시. 정수면 "100" 같이 trailing 0 안 붙음. */
 function formatNum(n: number): string {
-  return Number(n.toFixed(2)).toString();
+  return Number(n.toFixed(1)).toString();
 }
 
 function Metric({
@@ -75,11 +71,13 @@ function Metric({
 }) {
   return (
     <div>
-      <div className="flex items-baseline justify-between">
-        <span className="text-[13px] font-medium text-foreground/80">{label}</span>
-        <span className="text-2xl font-bold tabular-nums">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="shrink-0 text-[13px] text-slate-500">{label}</span>
+        <span className="shrink-0 text-2xl font-medium tabular-nums text-slate-700">
           {valueText}
-          <span className="ml-1 text-xs font-medium text-muted-foreground">{unit}</span>
+          {unit && (
+            <span className="ml-1 text-xs font-normal text-slate-400">{unit}</span>
+          )}
         </span>
       </div>
       <div className="mt-1.5 h-2 w-full overflow-hidden rounded-full bg-muted">

--- a/frontend/src/hooks/use-ap-recommendation-session.ts
+++ b/frontend/src/hooks/use-ap-recommendation-session.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  EMPTY_AP_RECOMMENDATION_SESSION,
+  useApRecommendationStore,
+  type ApRecommendationSession,
+} from '@/stores/ap-recommendation-store';
+import type { MeterBBox } from '@/features/ap-recommendation/recommendation-utils';
+import type { ApRecommendationResult } from '@/types/ap-recommendation';
+import type { UUID } from '@/types/common';
+
+function isPersistedSession(
+  session: ApRecommendationSession | undefined,
+  sceneVersionId: UUID | null,
+): session is ApRecommendationSession {
+  if (!session || session.savedRank == null) return false;
+  if (
+    sceneVersionId &&
+    session.sceneVersionId &&
+    session.sceneVersionId !== sceneVersionId
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * AP 배치 추천 UI 세션.
+ * - 페이지 내 편집: useState (추천만 받고 저장 안 한 상태는 유지하지 않음)
+ * - 「이 위치 선택」 저장 성공 후에만 localStorage persist
+ */
+export function useApRecommendationSession(
+  floorId: UUID | null,
+  sceneVersionId: UUID | null,
+) {
+  const patchFloor = useApRecommendationStore((s) => s.patchFloor);
+  const clearFloor = useApRecommendationStore((s) => s.clearFloor);
+
+  const [selectionBBox, setSelectionBBox] = useState<MeterBBox | null>(null);
+  const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
+  const [selectedRank, setSelectedRank] = useState<number | null>(null);
+  const [savedRank, setSavedRank] = useState<number | null>(null);
+
+  useEffect(() => {
+    const stored = floorId
+      ? useApRecommendationStore.getState().byFloor[floorId]
+      : undefined;
+
+    if (isPersistedSession(stored, sceneVersionId)) {
+      setSelectionBBox(stored.selectionBBox);
+      setRecommendations(stored.recommendations);
+      setSelectedRank(stored.selectedRank);
+      setSavedRank(stored.savedRank);
+      return;
+    }
+
+    setSelectionBBox(EMPTY_AP_RECOMMENDATION_SESSION.selectionBBox);
+    setRecommendations(EMPTY_AP_RECOMMENDATION_SESSION.recommendations);
+    setSelectedRank(EMPTY_AP_RECOMMENDATION_SESSION.selectedRank);
+    setSavedRank(EMPTY_AP_RECOMMENDATION_SESSION.savedRank);
+  }, [floorId, sceneVersionId]);
+
+  const persistSavedSession = useCallback(
+    (session: ApRecommendationSession) => {
+      if (!floorId || session.savedRank == null) return;
+      patchFloor(floorId, session);
+    },
+    [floorId, patchFloor],
+  );
+
+  const resetSession = useCallback(() => {
+    if (floorId) clearFloor(floorId);
+    setSelectionBBox(null);
+    setRecommendations([]);
+    setSelectedRank(null);
+    setSavedRank(null);
+  }, [floorId, clearFloor]);
+
+  return {
+    selectionBBox,
+    recommendations,
+    selectedRank,
+    savedRank,
+    setSelectionBBox,
+    setRecommendations,
+    setSelectedRank,
+    setSavedRank,
+    persistSavedSession,
+    resetSession,
+  };
+}

--- a/frontend/src/hooks/use-rf-map-image-url.ts
+++ b/frontend/src/hooks/use-rf-map-image-url.ts
@@ -1,0 +1,7 @@
+import { useMemo } from 'react';
+import { resolveHeatmapImageUrl } from '@/lib/ai-api-image-proxy';
+
+/** RF heatmap 표시 URL — dev 에서 ai_api localhost 는 Vite 프록시 경로로 변환. */
+export function useRfMapImageUrl(sourceUrl: string | null | undefined): string | null {
+  return useMemo(() => resolveHeatmapImageUrl(sourceUrl ?? null), [sourceUrl]);
+}

--- a/frontend/src/hooks/use-rf-run.ts
+++ b/frontend/src/hooks/use-rf-run.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { rfJobApi, rfRunApi, type ListRfRunsParams } from '@/api/rf-run';
 import type { HttpError } from '@/api/client';
@@ -8,6 +8,9 @@ import type { RfJob, RfRun, RfRunCreate } from '@/types/rf';
 import { isJobFailed, isJobSucceeded, isJobTerminal } from '@/types/job';
 
 const POLL_INTERVAL_MS = 3_000;
+
+/** run id 별 완료/실패 토스트 1회만 (Strict Mode·리마운트 중복 방지). */
+const notifiedRfRunIds = new Set<string>();
 
 /** POST /rf-runs — 시뮬레이션 큐 등록. */
 export function useCreateRfRun() {
@@ -31,8 +34,6 @@ export function useCreateRfRun() {
  * succeeded/failed 시 자동 중지 + 토스트 (중복 발화 방지).
  */
 export function useRfRun(rfRunId: UUID | null) {
-  const settledRef = useRef<string | null>(null);
-
   const query = useQuery({
     queryKey: ['rf-run', rfRunId] as const,
     queryFn: () => rfRunApi.get(rfRunId as UUID),
@@ -48,20 +49,16 @@ export function useRfRun(rfRunId: UUID | null) {
   useEffect(() => {
     const data = query.data;
     if (!data || !rfRunId) return;
-    if (settledRef.current === rfRunId) return;
+    if (notifiedRfRunIds.has(rfRunId)) return;
     if (isJobSucceeded(data.status)) {
-      settledRef.current = rfRunId;
+      notifiedRfRunIds.add(rfRunId);
       toast.success('RF 시뮬레이션 완료', '결과를 확인해주세요.');
     } else if (isJobFailed(data.status)) {
-      settledRef.current = rfRunId;
+      notifiedRfRunIds.add(rfRunId);
       const err = (data.metrics_json?.['error_message'] as string | undefined) ?? undefined;
       toast.error('RF 시뮬레이션 실패', err ?? '잠시 후 다시 시도해주세요.');
     }
   }, [query.data, rfRunId]);
-
-  useEffect(() => {
-    settledRef.current = null;
-  }, [rfRunId]);
 
   const rfRun: RfRun | null = query.data ?? null;
   const status = rfRun?.status;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,7 +11,7 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.55 0.22 264);
+  --primary: oklch(0.623 0.214 259.815);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
@@ -26,7 +26,7 @@
   --ring: oklch(0.708 0 0);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.55 0.22 264);
+  --sidebar-primary: oklch(0.623 0.214 259.815);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
@@ -41,7 +41,7 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.65 0.22 264);
+  --primary: oklch(0.68 0.19 259.815);
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
@@ -56,7 +56,7 @@
   --ring: oklch(0.556 0 0);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.65 0.22 264);
+  --sidebar-primary: oklch(0.68 0.19 259.815);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
@@ -96,6 +96,54 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --animate-bubble-rise: bubble-rise 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  --animate-panel-rise: panel-rise 0.95s cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-toast-in: toast-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-toast-out: toast-out 0.22s cubic-bezier(0.4, 0, 1, 1) both;
+
+  @keyframes bubble-rise {
+    from {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes panel-rise {
+    from {
+      opacity: 0;
+      transform: translateY(40px) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes toast-in {
+    from {
+      opacity: 0;
+      transform: translateX(20px) translateY(8px) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) translateY(0) scale(1);
+    }
+  }
+
+  @keyframes toast-out {
+    from {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translateX(16px) scale(0.96);
+    }
+  }
 }
 
 @layer base {

--- a/frontend/src/lib/ai-api-image-proxy.ts
+++ b/frontend/src/lib/ai-api-image-proxy.ts
@@ -1,0 +1,32 @@
+/** Vite dev server 가 `/__ai_api__` → ai_api 로 프록시할 때 쓰는 prefix. */
+export const AI_API_DEV_PROXY_PREFIX = '/__ai_api__';
+
+/** local ai_api heatmap URL — 브라우저가 직접 localhost:9000 에 접속하면 실패. */
+export function isAiApiHeatmapUrl(url: string): boolean {
+  if (!/^https?:\/\//i.test(url)) return false;
+  if (url.includes('/internal/sionna/images/')) return true;
+  return /localhost:9000|127\.0\.0\.1:9000/i.test(url);
+}
+
+/** `http://localhost:9000/internal/...` → `/__ai_api__/internal/...` (dev 전용). */
+export function toAiApiDevProxyUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${AI_API_DEV_PROXY_PREFIX}${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * RF heatmap `<image href>` 용 URL.
+ * - S3 presigned 등: 그대로
+ * - dev + ai_api localhost: Vite 프록시 경로로 변환
+ */
+export function resolveHeatmapImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (import.meta.env.DEV && isAiApiHeatmapUrl(url)) {
+    return toAiApiDevProxyUrl(url);
+  }
+  return url;
+}

--- a/frontend/src/lib/ap-layout-naming.ts
+++ b/frontend/src/lib/ap-layout-naming.ts
@@ -1,0 +1,11 @@
+const AP_NAME_SUFFIX = /^AP-(\d+)$/i;
+
+/** 기존 AP 이름에서 숫자 접미사 최댓값 + 1 → `AP-01` 형식. */
+export function nextApSequentialName(existingNames: string[]): string {
+  let max = 0;
+  for (const raw of existingNames) {
+    const m = AP_NAME_SUFFIX.exec(raw.trim());
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return `AP-${String(max + 1).padStart(2, '0')}`;
+}

--- a/frontend/src/lib/canvas-scene-colors.ts
+++ b/frontend/src/lib/canvas-scene-colors.ts
@@ -1,0 +1,19 @@
+/** Tailwind blue-500 (#3B82F6) — 도면 문·AP·선택·경로 등 공통 accent */
+export const CANVAS_BLUE = 'oklch(0.623 0.214 259.815)';
+
+export const CANVAS_BLUE_TINT = 'oklch(0.92 0.05 260)';
+export const CANVAS_BLUE_TINT_STRONG = 'oklch(0.92 0.05 260 / 0.3)';
+export const CANVAS_BLUE_FAINT = 'oklch(0.623 0.214 259.815 / 0.08)';
+
+/** 가구·공간 객체 */
+export const CANVAS_OBJECT_FILL = 'oklch(0.96 0.03 260)';
+export const CANVAS_OBJECT_STROKE = 'oklch(0.75 0.12 260)';
+export const CANVAS_OBJECT_LABEL = 'oklch(0.45 0.08 260)';
+
+export const CANVAS_AP_LABEL_BORDER = 'oklch(0.85 0.06 260)';
+
+/** 창문 — Tailwind teal-500 (#14B8A6), blue-500 과 톤 맞춘 세련된 민트 */
+export const CANVAS_WINDOW = 'oklch(0.704 0.14 182.503)';
+
+/** 벽 */
+export const CANVAS_WALL = 'oklch(0.25 0 0)';

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   ChevronRight,
   Clock,
+  Loader2,
   MapPin,
   Smartphone,
   TrendingUp,
@@ -38,7 +39,7 @@ import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import { useEvaluateCalibrationRun } from '@/hooks/use-calibration-run';
-import { CalibrationCard } from '@/features/calibration/CalibrationCard';
+import { CalibrationCard, type CalibrationGate } from '@/features/calibration/CalibrationCard';
 import type { CalibrationEvaluationResponse, SpaceType } from '@/types/calibration-run';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import {
@@ -78,24 +79,11 @@ export default function MeasurementPage() {
     assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
   const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
 
-  // calibration soft prior 용 공간 유형.
-  // - Source of truth: Floor.space_type (헤더의 도면 셀렉터에서 설정)
-  // - 이 페이지에서도 일회성 override 가능 — 사용자가 다른 prior 로 실험하고 싶을 때
-  // - floor 가 바뀌면 그 floor 의 값으로 자동 리셋.
-  const [spaceTypeOverrideState, setSpaceTypeOverrideState] = useState<{
-    floorId: string | null;
-    value: SpaceType | null;
-  }>({ floorId: null, value: null });
-  const spaceTypeOverride =
-    spaceTypeOverrideState.floorId === floorId ? spaceTypeOverrideState.value : null;
-  const setSpaceTypeOverride = (value: SpaceType | null) => {
-    setSpaceTypeOverrideState({ floorId: floorId ?? null, value });
-  };
-  // Floor 의 space_type 을 reactive 하게 읽음 — 헤더에서 변경하면 즉시 반영.
+  // calibration soft prior — Floor.space_type 이 source of truth (헤더 FloorSpaceTypeSelector).
   const projectIdForFloors = useAppStore((s) => s.selectedProjectId);
   const floorsList = useFloors(projectIdForFloors);
   const currentFloor = floorsList.data?.find((f) => f.id === floorId) ?? null;
-  const spaceType: SpaceType = spaceTypeOverride ?? currentFloor?.space_type ?? 'unknown';
+  const spaceType: SpaceType = currentFloor?.space_type ?? 'unknown';
 
   // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
   const sessionsQuery = useFloorMeasurementSessions(floorId);
@@ -206,14 +194,20 @@ export default function MeasurementPage() {
     if (activeSession?.id) ids.add(activeSession.id);
     return [...ids];
   }, [activeSession, sessions]);
-  const calibrationDisabledReason = !hasMeasurement
-    ? '먼저 측정을 진행해주세요.'
+  const calibrationGate: CalibrationGate = !hasMeasurement
+    ? 'no_measurement'
     : !hasEnoughMeasurements
-    ? `보정 신뢰성 확보를 위해 측정점이 ${MIN_MEASUREMENTS_FOR_CALIBRATION}개 이상 필요합니다 ` +
-      `(현재 ${points.length}개). 도면 전반 골고루 더 측정해주세요.`
-    : !latestRfRunId
-    ? '비교할 시뮬레이션 결과가 없습니다. 시뮬레이션 페이지에서 실행해주세요.'
-    : null;
+      ? 'insufficient_points'
+      : !latestRfRunId
+        ? 'no_simulation'
+        : 'ready';
+  const calibrationDisabledReason = !hasMeasurement
+    ? null
+    : !hasEnoughMeasurements
+      ? `보정을 위해 측정점 ${MIN_MEASUREMENTS_FOR_CALIBRATION}개 이상이 필요합니다 (현재 ${points.length}개). 도면 곳곳을 더 측정해주세요.`
+      : !latestRfRunId
+        ? null
+        : null;
   const handleCalibrate = () => {
     if (!canCalibrate || !activeSession || !latestRfRunId || !currentVersion) return;
     evaluateCalibration.mutate(
@@ -387,10 +381,12 @@ export default function MeasurementPage() {
               isStarting={evaluateCalibration.isPending}
               canCalibrate={canCalibrate}
               disabledReason={calibrationDisabledReason}
+              calibrationGate={calibrationGate}
               spaceType={spaceType}
-              onSpaceTypeChange={setSpaceTypeOverride}
+              showSpaceTypeField={false}
               onCalibrate={handleCalibrate}
-              showCalibrateButton={false}
+              showCalibrateButton
+              showMeasurementLink={false}
               onAddReferenceMeasurement={() => {
                 setMobilePurpose('reference');
                 setMobileOpen(true);
@@ -589,7 +585,7 @@ function PageHeader({
         <button
           type="button"
           onClick={onStartMeasurement}
-          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-sm shadow-blue-500/20 hover:bg-blue-600"
         >
           <Smartphone className="h-4 w-4" />
           새로운 측정 시작
@@ -761,15 +757,56 @@ function LegendDot({ color, label }: { color: string; label: string }) {
 
 function CanvasEmptyOverlay({ loading }: { loading: boolean }) {
   return (
-    <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-      <div className="pointer-events-auto max-w-sm rounded-xl border bg-background/95 px-5 py-4 text-center shadow-sm backdrop-blur">
-        <p className="text-sm font-semibold">
-          {loading ? '측정 데이터 불러오는 중...' : '측정 데이터가 없습니다'}
-        </p>
-        <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-          상단의 "새로운 측정 시작" 또는 헤더의 "모바일 앱 연결" 로 측정을 진행하면
-          여기에 결과가 표시됩니다.
-        </p>
+    <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-6 pb-20">
+      <div
+        className={cn(
+          'pointer-events-auto w-full max-w-md -translate-y-6 animate-panel-rise',
+          'rounded-2xl border border-sky-200/90 bg-sky-50/95 px-6 py-5 shadow-md backdrop-blur-sm',
+        )}
+      >
+        <div className="flex items-start gap-4">
+          <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-sky-100 text-sky-600">
+            {loading ? (
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+            ) : (
+              <MapPin className="h-5 w-5" aria-hidden />
+            )}
+          </span>
+          <div className="min-w-0 space-y-4 text-left">
+            <div className="space-y-2">
+              <p className="text-base font-semibold leading-relaxed text-sky-950">
+                {loading ? '측정 데이터를 불러오는 중' : '아직 측정 데이터가 없어요'}
+              </p>
+              <p className="text-xs leading-relaxed text-sky-900/75">
+                {loading
+                  ? '잠시만 기다려주세요.'
+                  : '모바일로 도면 위를 걸으며 측정하면 결과가 이곳에 표시됩니다.'}
+              </p>
+            </div>
+            {!loading && (
+              <ol className="space-y-2.5 text-xs leading-relaxed text-sky-900/80">
+                <li className="flex items-center gap-2.5">
+                  <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white text-[10px] font-bold text-sky-700 ring-1 ring-sky-200">
+                    1
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <Smartphone className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+                    헤더에서 모바일 앱 연결
+                  </span>
+                </li>
+                <li className="flex items-center gap-2.5">
+                  <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white text-[10px] font-bold text-sky-700 ring-1 ring-sky-200">
+                    2
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <Activity className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+                    상단에서 새로운 측정 시작
+                  </span>
+                </li>
+              </ol>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { CheckCircle2, Loader2, Sparkles } from 'lucide-react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2, ChevronDown, Loader2, RotateCcw, Sparkles } from 'lucide-react';
 import type { HttpError } from '@/api/client';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
@@ -35,7 +35,7 @@ const PROGRESS_STEPS = [
   { id: 3, label: '추천 위치 선택' },
 ] as const;
 
-const CARD_BORDER = 'border-[#E5EAF2]';
+const CARD_BORDER = 'border-slate-200';
 
 export default function MobileAppPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -242,39 +242,68 @@ export default function MobileAppPage() {
     (floorId != null && !sceneVersionId && !versionsQuery.isError);
 
   const statusHint = getStatusHint(pageStatus, pageError, savedRank);
+  const hintStepId = useMemo(
+    () => getHintStepId(pageStatus, activeStep),
+    [pageStatus, activeStep],
+  );
+
+  const canvasAreaRef = useRef<HTMLDivElement>(null);
+  const stepIconRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [bubbleLeftPx, setBubbleLeftPx] = useState<number | null>(null);
+
+  const registerStepIconRef = useCallback((index: number, el: HTMLDivElement | null) => {
+    stepIconRefs.current[index] = el;
+  }, []);
+
+  useLayoutEffect(() => {
+    const syncBubblePosition = () => {
+      const canvas = canvasAreaRef.current;
+      const icon = stepIconRefs.current[hintStepId - 1];
+      if (!canvas || !icon) {
+        setBubbleLeftPx(null);
+        return;
+      }
+      const canvasRect = canvas.getBoundingClientRect();
+      const iconRect = icon.getBoundingClientRect();
+      setBubbleLeftPx(iconRect.left + iconRect.width / 2 - canvasRect.left);
+    };
+
+    syncBubblePosition();
+    window.addEventListener('resize', syncBubblePosition);
+    return () => window.removeEventListener('resize', syncBubblePosition);
+  }, [hintStepId, statusHint, sceneVersionId, pageStatus]);
 
   return (
-    <div className="flex h-full flex-col overflow-auto bg-[#F8FAFC]">
-      {/* 본문 헤더 — Figma: 제목 + 설명 + 우측 CTA */}
-      <header className="shrink-0 px-6 pb-4 pt-6 lg:px-8">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+    <div className="flex h-full flex-col overflow-auto bg-background">
+      <header className="shrink-0 px-6 pb-3 pt-5 lg:px-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
-            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+            <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
               AP 배치 추천
             </h1>
-            <p className="mt-1.5 text-sm text-muted-foreground">
+            <p className="mt-1 text-sm text-slate-500">
               개선이 필요한 영역을 드래그하면 최적의 AP 설치 위치를 추천합니다.
             </p>
           </div>
-          <div className="flex shrink-0 flex-col items-stretch gap-1.5 sm:items-end">
+          <div className="flex shrink-0 flex-col items-stretch gap-1 sm:items-end">
             <button
               type="button"
               onClick={handleHeaderAction}
               disabled={headerButtonDisabled}
               className={cn(
-                'inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold shadow-sm transition-colors',
-                isRecommendPending && 'cursor-not-allowed bg-muted text-muted-foreground',
+                'inline-flex h-9 items-center justify-center gap-1.5 rounded-md px-4 text-sm font-medium transition-colors',
+                isRecommendPending && 'cursor-not-allowed bg-slate-100 text-slate-400',
                 !isRecommendPending &&
                   hasRecommendation &&
-                  'border border-blue-200 bg-white text-blue-600 hover:bg-blue-50',
+                  'border border-slate-200 bg-white text-slate-700 hover:bg-slate-50',
                 !isRecommendPending &&
                   !hasRecommendation &&
                   canRecommend &&
-                  'bg-blue-600 text-white hover:bg-blue-700',
+                  'bg-blue-500 text-white shadow-sm shadow-blue-500/20 hover:bg-blue-600',
                 !isRecommendPending &&
                   !hasRecommendation &&
                   !canRecommend &&
-                  'cursor-not-allowed bg-muted text-muted-foreground',
+                  'cursor-not-allowed bg-slate-100 text-slate-400',
               )}
             >
               {isRecommendPending ? (
@@ -283,7 +312,10 @@ export default function MobileAppPage() {
                   최적 위치 계산 중…
                 </>
               ) : hasRecommendation ? (
-                '다시 생성하기'
+                <>
+                  <RotateCcw className="h-4 w-4" />
+                  다시 생성하기
+                </>
               ) : (
                 <>
                   <Sparkles className="h-4 w-4" />
@@ -300,15 +332,13 @@ export default function MobileAppPage() {
         </div>
       </header>
 
-      {/* 본문 — lg: 캔버스(좌) + 추천 패널(우), md↓ 단일 컬럼 */}
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-5 px-6 pb-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-6 lg:px-8">
-        {/* 좌측: 캔버스 + 진행 단계 */}
-        <div className="flex min-h-0 flex-col gap-4">
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 px-6 pb-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:gap-5 lg:px-8">
+        <div className="flex min-h-0 flex-col gap-3">
           <div
+            ref={canvasAreaRef}
             className={cn(
-              'relative flex min-h-[min(52vh,32rem)] flex-1 flex-col overflow-hidden rounded-2xl bg-white shadow-sm',
+              'relative flex min-h-[min(52vh,32rem)] flex-1 flex-col overflow-hidden rounded-xl border bg-white shadow-sm',
               CARD_BORDER,
-              'border',
             )}
           >
             {!floorId ? (
@@ -334,53 +364,51 @@ export default function MobileAppPage() {
               />
             )}
 
-            {sceneVersionId && statusHint && pageStatus !== 'loading' && (
-              <div className="pointer-events-none absolute bottom-4 left-4 right-4">
-                <p className="rounded-lg border border-[#E5EAF2] bg-white/95 px-4 py-2.5 text-center text-xs text-muted-foreground shadow-sm backdrop-blur">
-                  {statusHint}
-                </p>
-              </div>
+            {sceneVersionId && statusHint && bubbleLeftPx != null && (
+              <CanvasStatusBubble message={statusHint} leftPx={bubbleLeftPx} />
             )}
           </div>
 
-          {/* 진행 단계 카드 — 캔버스 아래 */}
           <div
             className={cn(
-              'shrink-0 rounded-2xl bg-white px-6 py-5 shadow-sm',
+              'shrink-0 rounded-lg border bg-white px-3 py-2.5',
               CARD_BORDER,
-              'border',
             )}
           >
-            <ProgressStepper activeStep={activeStep} pageStatus={pageStatus} />
+            <ProgressStepper
+              activeStep={activeStep}
+              pageStatus={pageStatus}
+              registerStepIconRef={registerStepIconRef}
+            />
           </div>
         </div>
 
-        {/* 우측: 추천 결과 패널 (모바일에서는 하단 카드) */}
         <aside
           className={cn(
-            'flex min-h-[280px] flex-col overflow-hidden rounded-2xl bg-white shadow-sm lg:min-h-0 lg:self-stretch',
+            'flex min-h-[260px] flex-col overflow-hidden rounded-xl border bg-white shadow-sm lg:min-h-0 lg:self-stretch',
             CARD_BORDER,
-            'border',
           )}
         >
-          <div className="border-b border-[#E5EAF2] px-5 py-4">
-            <h2 className="text-base font-bold text-foreground">최적 배치 추천</h2>
+          <div className="border-b border-slate-200 px-5 py-4">
+            <h2 className="text-base font-semibold text-slate-900">최적 배치 추천</h2>
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
             {recommendations.length === 0 ? (
               <div className="flex h-full min-h-[200px] flex-col items-center justify-center gap-2 px-4 text-center">
-                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-                  <Sparkles className="h-5 w-5 text-muted-foreground" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100">
+                  <Sparkles className="h-5 w-5 text-slate-400" />
                 </div>
-                <p className="text-sm font-medium text-foreground/80">
+                <p className="text-sm font-medium text-slate-700">
                   {pageStatus === 'loading'
                     ? '최적 위치를 계산하고 있습니다…'
-                    : '추천 결과가 여기에 표시됩니다'}
+                    : '추천 결과가 아직 없습니다'}
                 </p>
-                <p className="text-xs text-muted-foreground">
-                  도면에서 우선 개선 영역을 드래그한 뒤 「최적 배치 추천」을 눌러주세요.
-                </p>
+                {pageStatus !== 'loading' && (
+                  <p className="text-xs leading-relaxed text-slate-500">
+                    도면에서 개선이 필요한 영역을 드래그한 뒤, 최적 배치 추천을 실행하세요.
+                  </p>
+                )}
               </div>
             ) : (
               <div className="space-y-3">
@@ -388,10 +416,10 @@ export default function MobileAppPage() {
                   <RecommendationCard
                     key={rec.rank}
                     rec={rec}
-                    selected={selectedRank === rec.rank}
                     saved={savedRank === rec.rank}
                     saving={createLayout.isPending && selectedRank === rec.rank}
                     saveDisabled={!latestRfRunId || createLayout.isPending}
+                    hasExistingAps={existingAps.length > 0}
                     onSelect={() => handleSelectRecommendation(rec)}
                   />
                 ))}
@@ -404,6 +432,40 @@ export default function MobileAppPage() {
   );
 }
 
+function CanvasStatusBubble({
+  message,
+  leftPx,
+}: {
+  message: string;
+  leftPx: number;
+}) {
+  return (
+    <div
+      className="pointer-events-none absolute bottom-3 z-10 -translate-x-1/2"
+      style={{ left: leftPx }}
+    >
+      <div
+        key={message}
+        className="relative w-max max-w-md animate-bubble-rise rounded-xl border border-sky-200 bg-sky-50/95 px-4 py-2.5 shadow-sm backdrop-blur-sm"
+      >
+        <p className="text-center text-xs leading-relaxed text-sky-900/90">{message}</p>
+        <span
+          className="absolute -bottom-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 border-b border-r border-sky-200 bg-sky-50/95"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}
+
+function getHintStepId(pageStatus: PageStatus, activeStep: number): number {
+  if (pageStatus === 'idle') return 1;
+  if (pageStatus === 'areaSelected') return 2;
+  if (pageStatus === 'loading') return 2;
+  if (pageStatus === 'success') return 3;
+  return Math.min(activeStep, 3);
+}
+
 function getStatusHint(
   pageStatus: PageStatus,
   pageError: string | null,
@@ -411,13 +473,15 @@ function getStatusHint(
 ): string | null {
   switch (pageStatus) {
     case 'idle':
-      return '도면 위에서 우선 개선할 영역을 드래그하여 선택하세요.';
+      return '개선이 필요한 영역을 드래그해 선택하세요.';
     case 'areaSelected':
-      return '영역이 선택되었습니다. 우측 상단 「최적 배치 추천」 버튼을 눌러주세요.';
+      return '영역이 선택되었습니다. 우측 상단 「최적 배치 추천」을 실행하세요.';
+    case 'loading':
+      return null;
     case 'success':
       return savedRank != null
-        ? '추천 위치가 AP 배치로 저장되었습니다. 다른 영역을 선택하려면 「다시 생성하기」를 눌러주세요.'
-        : '추천 위치를 확인하고 우측 패널에서 선택하세요. 다른 영역을 선택하려면 「다시 생성하기」를 눌러주세요.';
+        ? 'AP 배치가 저장되었습니다. 다른 영역은 다시 생성하기로 선택하세요.'
+        : '추천 위치를 확인한 뒤 우측 패널에서 저장할 수 있습니다.';
     case 'error':
       return pageError ?? '추천 계산에 실패했습니다. 다시 시도해 주세요.';
     default:
@@ -435,24 +499,26 @@ function EmptyState({ message }: { message: string }) {
 
 function RecommendationCard({
   rec,
-  selected,
   saved,
   saving,
   saveDisabled,
+  hasExistingAps,
   onSelect,
 }: {
   rec: ApRecommendationResult;
-  selected: boolean;
   saved: boolean;
   saving: boolean;
   saveDisabled: boolean;
+  hasExistingAps: boolean;
   onSelect: () => void;
 }) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
   return (
     <article
       className={cn(
         'rounded-xl border bg-white p-4 transition-colors',
-        saved || selected ? 'border-emerald-300 shadow-sm' : 'border-[#E5EAF2]',
+        saved ? 'border-emerald-200 shadow-sm' : 'border-slate-200',
       )}
     >
       <div className="flex items-start gap-3">
@@ -460,47 +526,96 @@ function RecommendationCard({
           AP
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-bold text-foreground">추천 위치</h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            위치 X {rec.recommended_x.toFixed(0)}m / Y {rec.recommended_y.toFixed(0)}m
-          </p>
-          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
-            우선 개선 영역 커버리지 가장 높음
-          </p>
-          <p className="mt-2 text-xs text-muted-foreground">
-            후보 점수{' '}
-            <span className="font-semibold text-foreground">{rec.score.toFixed(1)}</span>
-          </p>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
-            탐색 후보 수 {rec.candidates_evaluated}
+          <h3 className="text-sm font-semibold leading-snug text-slate-900">
+            이 위치에 AP를 설치하는 것을
+            <br />
+            추천합니다
+          </h3>
+          <p className="mt-1.5 text-xs leading-relaxed text-slate-500">
+            선택한 영역을 더 안정적으로 커버할 수 있는
+            <br />
+            위치입니다.
           </p>
         </div>
       </div>
-      <button
-        type="button"
-        onClick={onSelect}
-        disabled={saveDisabled && !saved}
-        className={cn(
-          'mt-4 w-full rounded-lg border py-2.5 text-sm font-medium transition-colors',
-          saved
-            ? 'border-emerald-500 bg-emerald-500 text-white'
-            : 'border-[#E5EAF2] bg-[#F8FAFC] text-foreground hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-50',
+
+      <div className="mt-4 space-y-1.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs">
+        <div>
+          <p className="text-slate-500">도면 기준 위치</p>
+          <p className="mt-0.5 font-medium text-slate-900">
+            가로 {rec.recommended_x.toFixed(0)}m · 세로 {rec.recommended_y.toFixed(0)}m
+          </p>
+        </div>
+        {rec.candidates_evaluated > 0 && (
+          <p className="text-slate-500">
+            총 {rec.candidates_evaluated}개 후보 위치를 비교했습니다.
+          </p>
         )}
-      >
-        {saving ? (
-          <span className="inline-flex items-center justify-center gap-1.5">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            저장 중…
-          </span>
-        ) : saved ? (
-          <span className="inline-flex items-center justify-center gap-1.5">
-            <CheckCircle2 className="h-4 w-4" />
-            저장됨
-          </span>
-        ) : (
-          '이 위치 선택'
+      </div>
+
+      <div className="mt-4">
+        <p className="text-xs font-semibold text-slate-900">추천 이유</p>
+        <ul className="mt-1.5 list-inside list-disc space-y-1 text-xs leading-relaxed text-slate-500">
+          <li>선택한 우선 개선 영역을 기준으로 계산했습니다.</li>
+          {hasExistingAps && <li>기존 AP 위치를 함께 고려했습니다.</li>}
+        </ul>
+      </div>
+
+      <div className="mt-3 border-t border-slate-200 pt-3">
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((v) => !v)}
+          className="flex w-full items-center justify-between text-xs text-slate-500 hover:text-slate-700"
+          aria-expanded={detailsOpen}
+        >
+          <span>상세 정보</span>
+          <ChevronDown
+            className={cn('h-3.5 w-3.5 transition-transform', detailsOpen && 'rotate-180')}
+            aria-hidden="true"
+          />
+        </button>
+        {detailsOpen && (
+          <p className="mt-2 text-[11px] text-slate-500">
+            상세 점수: {rec.score.toFixed(1)}
+          </p>
         )}
-      </button>
+      </div>
+
+      {saved ? (
+        <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+          <div className="flex gap-2.5">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-emerald-900">AP 배치로 저장 완료</p>
+              <p className="mt-1 text-xs leading-relaxed text-emerald-800/90">
+                저장된 AP 배치 목록에 반영됩니다.
+              </p>
+              <p className="mt-1.5 text-xs leading-relaxed text-emerald-800/75">
+                다른 영역을 추천하려면 다시 생성하기를 눌러주세요.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onSelect}
+          disabled={saveDisabled}
+          className={cn(
+            'mt-4 w-full rounded-lg border border-slate-200 bg-slate-50 py-2.5 text-sm font-medium text-slate-900 transition-colors',
+            'hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50',
+          )}
+        >
+          {saving ? (
+            <span className="inline-flex items-center justify-center gap-1.5">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              저장 중…
+            </span>
+          ) : (
+            '이 위치에 AP 배치하기'
+          )}
+        </button>
+      )}
     </article>
   );
 }
@@ -508,58 +623,70 @@ function RecommendationCard({
 function ProgressStepper({
   activeStep,
   pageStatus,
+  registerStepIconRef,
 }: {
   activeStep: number;
   pageStatus: PageStatus;
+  registerStepIconRef?: (index: number, el: HTMLDivElement | null) => void;
 }) {
   return (
-    <ol className="flex items-start">
-      {PROGRESS_STEPS.map((step, index) => {
-        const done =
-          step.id < activeStep ||
-          (step.id === 1 && pageStatus !== 'idle') ||
-          (step.id === 2 && (pageStatus === 'success' || pageStatus === 'loading'));
-        const current = step.id === activeStep && pageStatus !== 'error';
-        const isLast = index === PROGRESS_STEPS.length - 1;
+    <div className="flex justify-center">
+      <ol className="flex items-center">
+        {PROGRESS_STEPS.map((step, index) => {
+          const done =
+            step.id < activeStep ||
+            (step.id === 1 && pageStatus !== 'idle') ||
+            (step.id === 2 && (pageStatus === 'success' || pageStatus === 'loading'));
+          const current = step.id === activeStep && pageStatus !== 'error';
+          const isLast = index === PROGRESS_STEPS.length - 1;
 
-        return (
-          <li key={step.id} className="flex min-w-0 flex-1 items-start">
-            <div className="flex min-w-0 flex-1 flex-col items-center gap-2">
-              <div
-                className={cn(
-                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold',
-                  done && !current && 'bg-emerald-500 text-white',
-                  current && 'bg-blue-600 text-white',
-                  !done && !current && 'bg-muted text-muted-foreground',
-                )}
-              >
-                {done && !current ? (
-                  <CheckCircle2 className="h-4 w-4" />
-                ) : (
-                  step.id
-                )}
+          return (
+            <li key={step.id} className="flex items-center">
+              <div className="flex flex-col items-center gap-1.5">
+                <div
+                  ref={(el) => registerStepIconRef?.(index, el)}
+                  className={cn(
+                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
+                    done &&
+                      !current &&
+                      'bg-emerald-500 text-white ring-1 ring-emerald-200/80',
+                    current &&
+                      'bg-blue-500 text-white ring-4 ring-blue-100 shadow-sm shadow-blue-500/20',
+                    !done && !current && 'bg-slate-200 text-slate-500',
+                  )}
+                >
+                  {done && !current ? (
+                    <CheckCircle2 className="h-4 w-4" />
+                  ) : (
+                    step.id
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    'w-[7.5rem] text-center text-xs leading-snug',
+                    current
+                      ? 'font-medium text-slate-900'
+                      : done
+                        ? 'text-slate-600'
+                        : 'text-slate-500',
+                  )}
+                >
+                  {step.label}
+                </span>
               </div>
-              <span
-                className={cn(
-                  'max-w-28 text-center text-xs leading-tight',
-                  current ? 'font-semibold text-foreground' : 'text-muted-foreground',
-                )}
-              >
-                {step.label}
-              </span>
-            </div>
-            {!isLast && (
-              <div
-                className={cn(
-                  'mt-4 h-0.5 min-w-4 flex-1',
-                  step.id < activeStep ? 'bg-emerald-400' : 'bg-[#E5EAF2]',
-                )}
-                aria-hidden="true"
-              />
-            )}
-          </li>
-        );
-      })}
-    </ol>
+              {!isLast && (
+                <div
+                  className={cn(
+                    'mx-3 mb-[1.625rem] h-0.5 w-20 sm:w-28',
+                    step.id < activeStep ? 'bg-emerald-200' : 'bg-slate-200',
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </div>
   );
 }

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -8,6 +8,7 @@ import { useApLayouts, useCreateApLayout } from '@/hooks/use-ap-layouts';
 import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { useApRecommendation } from '@/hooks/use-ap-recommendation';
+import { useApRecommendationSession } from '@/hooks/use-ap-recommendation-session';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import { DEFAULT_TX_POWER_DBM } from '@/features/simulation/SimulationCanvas';
 import {
@@ -77,11 +78,20 @@ export default function MobileAppPage() {
     return apsFromRfRunRequest(latestRfRun?.request_json as Record<string, unknown> | undefined);
   }, [apLayoutsQuery.data, latestRfRun?.request_json]);
 
-  const [selectionBBox, setSelectionBBox] = useState<MeterBBox | null>(null);
-  const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
-  const [selectedRank, setSelectedRank] = useState<number | null>(null);
-  const [savedRank, setSavedRank] = useState<number | null>(null);
   const [pageError, setPageError] = useState<string | null>(null);
+
+  const {
+    selectionBBox,
+    recommendations,
+    selectedRank,
+    savedRank,
+    setSelectionBBox,
+    setRecommendations,
+    setSelectedRank,
+    setSavedRank,
+    persistSavedSession,
+    resetSession,
+  } = useApRecommendationSession(floorId, sceneVersionId);
 
   const recommendMutation = useApRecommendation();
   const createLayout = useCreateApLayout();
@@ -100,12 +110,19 @@ export default function MobileAppPage() {
   ]);
 
   const activeStep = useMemo(() => {
-    if (savedRank != null || selectedRank != null) return 3;
+    if (savedRank != null) return 4;
+    if (selectedRank != null) return 3;
     if (pageStatus === 'success') return 3;
     if (pageStatus === 'loading') return 2;
     if (pageStatus === 'areaSelected') return 1;
     return 1;
   }, [pageStatus, selectedRank, savedRank]);
+
+  /** 저장 완료 후 — 선택한 순위 AP만 캔버스에 표시, 나머지 추천 마커 숨김 */
+  const canvasRecommendations = useMemo(() => {
+    if (savedRank == null) return recommendations;
+    return recommendations.filter((r) => r.rank === savedRank);
+  }, [recommendations, savedRank]);
 
   const handleSelectionChange = (bbox: MeterBBox | null) => {
     setSelectionBBox(bbox);
@@ -151,6 +168,20 @@ export default function MobileAppPage() {
     });
   };
 
+  const handleResetRecommendation = () => {
+    resetSession();
+    setPageError(null);
+    recommendMutation.reset();
+  };
+
+  const handleHeaderAction = () => {
+    if (recommendations.length > 0) {
+      handleResetRecommendation();
+      return;
+    }
+    handleRecommend();
+  };
+
   const handleSelectRecommendation = (rec: ApRecommendationResult) => {
     if (!latestRfRunId) {
       setPageError('AP 배치를 저장하려면 먼저 시뮬레이션을 실행해 주세요.');
@@ -176,6 +207,13 @@ export default function MobileAppPage() {
       {
         onSuccess: () => {
           setSavedRank(rec.rank);
+          persistSavedSession({
+            sceneVersionId,
+            selectionBBox,
+            recommendations,
+            selectedRank: rec.rank,
+            savedRank: rec.rank,
+          });
         },
         onError: (err) => {
           const e = err as HttpError | null;
@@ -186,8 +224,17 @@ export default function MobileAppPage() {
     );
   };
 
+  const hasRecommendation = recommendations.length > 0;
+  const isRecommendPending = recommendMutation.isPending;
+
   const canRecommend =
-    !!sceneVersionId && isValidSelectionBBox(selectionBBox) && !recommendMutation.isPending;
+    !hasRecommendation &&
+    !!sceneVersionId &&
+    isValidSelectionBBox(selectionBBox) &&
+    !isRecommendPending;
+
+  const headerButtonDisabled =
+    isRecommendPending || (!hasRecommendation && !canRecommend);
 
   const sceneLoading =
     versionsQuery.isLoading ||
@@ -212,20 +259,31 @@ export default function MobileAppPage() {
           <div className="flex shrink-0 flex-col items-stretch gap-1.5 sm:items-end">
             <button
               type="button"
-              onClick={handleRecommend}
-              disabled={!canRecommend}
+              onClick={handleHeaderAction}
+              disabled={headerButtonDisabled}
               className={cn(
                 'inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold shadow-sm transition-colors',
-                canRecommend
-                  ? 'bg-blue-600 text-white hover:bg-blue-700'
-                  : 'cursor-not-allowed bg-muted text-muted-foreground',
+                isRecommendPending && 'cursor-not-allowed bg-muted text-muted-foreground',
+                !isRecommendPending &&
+                  hasRecommendation &&
+                  'border border-blue-200 bg-white text-blue-600 hover:bg-blue-50',
+                !isRecommendPending &&
+                  !hasRecommendation &&
+                  canRecommend &&
+                  'bg-blue-600 text-white hover:bg-blue-700',
+                !isRecommendPending &&
+                  !hasRecommendation &&
+                  !canRecommend &&
+                  'cursor-not-allowed bg-muted text-muted-foreground',
               )}
             >
-              {recommendMutation.isPending ? (
+              {isRecommendPending ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
                   최적 위치 계산 중…
                 </>
+              ) : hasRecommendation ? (
+                '다시 생성하기'
               ) : (
                 <>
                   <Sparkles className="h-4 w-4" />
@@ -269,9 +327,10 @@ export default function MobileAppPage() {
                 existingAps={existingAps}
                 selectionBBox={selectionBBox}
                 onSelectionChange={handleSelectionChange}
-                recommendations={recommendations}
+                recommendations={canvasRecommendations}
                 selectedRecommendationRank={selectedRank}
-                disabled={recommendMutation.isPending || createLayout.isPending}
+                disabled={isRecommendPending || createLayout.isPending}
+                dragDisabled={isRecommendPending || hasRecommendation}
               />
             )}
 
@@ -357,8 +416,8 @@ function getStatusHint(
       return '영역이 선택되었습니다. 우측 상단 「최적 배치 추천」 버튼을 눌러주세요.';
     case 'success':
       return savedRank != null
-        ? '추천 위치가 AP 배치로 저장되었습니다.'
-        : '추천 위치를 확인하고 우측 패널에서 선택하세요.';
+        ? '추천 위치가 AP 배치로 저장되었습니다. 다른 영역을 선택하려면 「다시 생성하기」를 눌러주세요.'
+        : '추천 위치를 확인하고 우측 패널에서 선택하세요. 다른 영역을 선택하려면 「다시 생성하기」를 눌러주세요.';
     case 'error':
       return pageError ?? '추천 계산에 실패했습니다. 다시 시도해 주세요.';
     default:
@@ -398,10 +457,10 @@ function RecommendationCard({
     >
       <div className="flex items-start gap-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-sm font-bold text-white">
-          {rec.rank}
+          AP
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-bold text-foreground">{rec.rank}순위 추천</h3>
+          <h3 className="text-sm font-bold text-foreground">추천 위치</h3>
           <p className="mt-1 text-xs text-muted-foreground">
             위치 X {rec.recommended_x.toFixed(0)}m / Y {rec.recommended_y.toFixed(0)}m
           </p>
@@ -459,8 +518,7 @@ function ProgressStepper({
         const done =
           step.id < activeStep ||
           (step.id === 1 && pageStatus !== 'idle') ||
-          (step.id === 2 && (pageStatus === 'success' || pageStatus === 'loading')) ||
-          (step.id === 3 && activeStep >= 3);
+          (step.id === 2 && (pageStatus === 'success' || pageStatus === 'loading'));
         const current = step.id === activeStep && pageStatus !== 'error';
         const isLast = index === PROGRESS_STEPS.length - 1;
 

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -15,8 +15,9 @@ import { useMemo, useEffect } from 'react';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import { useCreateRfRun, useFloorRfRuns, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
+import { useRfMapImageUrl } from '@/hooks/use-rf-map-image-url';
 import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
-import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
+import { useLocalFloorplanImage, linkFloorImageToAsset } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import {
   useApCandidates,
@@ -39,7 +40,8 @@ import { extractColorScale } from '@/features/simulation/HeatmapColorLegend';
 import { DbmColorBar } from '@/features/simulation/DbmColorBar';
 import { FloorSpaceTypeSelector } from '@/features/floor/FloorSpaceTypeSelector';
 import { toast } from '@/stores/toast-store';
-import type { ApCandidate, ApLayout } from '@/types/ap-layout';
+import type { SceneVersion } from '@/types/scene';
+import type { UUID } from '@/types/common';
 import type { RfBackend } from '@/types/rf';
 import { cn } from '@/lib/utils';
 import { nextApSequentialName } from '@/lib/ap-layout-naming';
@@ -75,38 +77,11 @@ export default function SimulationPage() {
   const [frequencyBand, setFrequencyBand] = useState<FrequencyBand>('5');
   const [txPowerDbm, setTxPowerDbm] = useState(20);
 
-  // 캔버스 배경으로 보여줄 확정 버전 상세 (rooms/walls/openings/objects 포함).
-  const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
-
-  // 배경 도면 이미지 — 공간편집/대시보드와 동일한 방식.
-  // (a) version 의 source_asset_id 가 있으면 presigned URL, (b) 없으면 floor 의
-  // 가장 최근 floorplan_image asset, (c) 백엔드 자산 없으면 localStorage 캐시.
-  const versionAsDraft = versionDetailQuery.data
-    ? versionToDraftShape(versionDetailQuery.data)
-    : null;
-  const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
-  const fallbackAsset = (floorAssetsQuery.data ?? [])
-    .slice()
-    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
-  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
-  const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
-  // sourceAssetId 우선 — 히스토리 버전 클릭 시 그 자산 이미지로 정확히 복원.
-  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
-  const assetUrl = assetUrlQuery.data?.url ?? null;
-  const usableAssetUrl =
-    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
-  const backgroundImageUrl = usableAssetUrl ?? localImage ?? null;
-
   // 층의 과거 RF Run 목록 (이력 카드 + 자동 복원용).
   const pastRunsQuery = useFloorRfRuns(floorId, { page_size: 20 });
   const pastRuns = useMemo(() => pastRunsQuery.data?.items ?? [], [pastRunsQuery.data]);
 
   // 활성 run = 사용자가 명시 선택한 것 ?? 현재 scene_version 으로 돌린 최근 succeeded.
-  // → 새로고침/재진입 시에도 자동 활성, 단 **현재 버전과 일치하는 run** 만 대상.
-  //   공간편집으로 새 버전 만든 직후 시뮬 페이지로 오면 옛 run 은 자동복원 안 됨 → idle.
-  // 단 사용자가 명시적으로 "다시 실행" 누른 직후엔 idle 유지.
-  // 명시 선택(pickedRunId) 은 버전 일치 무관 — 사용자가 기록에서 직접 골랐으니 존중.
   const activeRunId = useMemo(() => {
     if (resetCleared) return null;
     if (pickedRunId) return pickedRunId;
@@ -122,24 +97,43 @@ export default function SimulationPage() {
     setPickedRunId(id);
   };
 
-  // 시뮬레이션 페이지는 배경 도면 이미지를 안 깔음 — 도형만 + 히트맵 오버레이.
-  // (배경 이미지는 공간편집/대시보드 한정.)
-
   const createRfRun = useCreateRfRun();
   const rfRunPoll = useRfRun(activeRunId);
   const rfMapsQuery = useRfMaps(activeRunId, rfRunPoll.isSucceeded);
-  // 활성 RfRun 이 현재 버전이 아닌 옛 버전에서 돌린 것이면 → 도면이 바뀌어서 히트맵이 도면과 안 맞음.
-  // 사용자 혼란 방지로 그런 경우엔 히트맵 숨김 (메트릭은 그대로 표시).
   const activeRunSceneVersionId = rfRunPoll.rfRun?.scene_version_id ?? null;
-  const isRunForCurrentVersion =
-    !activeRunSceneVersionId ||
-    !currentVersion ||
-    activeRunSceneVersionId === currentVersion.id;
+
+  const state: SimulationState = (() => {
+    if (!activeRunId) return 'idle';
+    if (rfRunPoll.isSucceeded) return 'complete';
+    if (rfRunPoll.isFailed) return 'idle';
+    return 'running';
+  })();
+
+  /** complete 상태에선 run 당시 scene_version, idle/running 은 현재 도면. */
+  const canvasSceneVersionId = useMemo(() => {
+    if (state === 'complete' && activeRunSceneVersionId) {
+      return activeRunSceneVersionId;
+    }
+    return currentVersion?.id ?? null;
+  }, [state, activeRunSceneVersionId, currentVersion?.id]);
+
+  const canvasVersionQuery = useSceneVersion(canvasSceneVersionId);
+  const backgroundImageUrl = useSceneFloorplanBackground(
+    floorId,
+    canvasVersionQuery.data,
+  );
+
+  const isViewingHistoricalRun =
+    state === 'complete' &&
+    !!currentVersion &&
+    !!activeRunSceneVersionId &&
+    activeRunSceneVersionId !== currentVersion.id;
 
   // 활성 run(과거/자동복원 포함)의 AP 를 캔버스에 복원 — 결과 화면에 AP 마커가 보이도록.
   // (aps state 는 사용자가 직접 찍은 것만 담기는데, 과거 run 을 불러올 땐 비어 있어 마커가 안 떴음)
   useEffect(() => {
-    const aps_raw = (rfRunPoll.rfRun?.request_json?.['access_points'] ?? []) as Array<
+    if (!activeRunId || !rfRunPoll.rfRun) return;
+    const aps_raw = (rfRunPoll.rfRun.request_json?.['access_points'] ?? []) as Array<
       Record<string, unknown>
     >;
     if (!Array.isArray(aps_raw) || aps_raw.length === 0) return;
@@ -150,17 +144,20 @@ export default function SimulationPage() {
       z_m: Number(a['z_m'] ?? a['z'] ?? 2.5),
     }));
     setAps(restored);
-  }, [rfRunPoll.rfRun]);
-  // 백엔드가 RfMapResponse 에 presigned `url` 을 자동 채워주므로 (PR #70)
-  // /rf-jobs 별도 호출 없이 /maps 응답 하나로 heatmap URL + bounds 둘 다 처리.
+  }, [activeRunId, rfRunPoll.rfRun]);
+
   const heatmapMap = useMemo(() => {
-    if (!isRunForCurrentVersion) return null;
     const maps = rfMapsQuery.data ?? [];
     return maps.find((m) => m.map_type === 'heatmap') ?? maps[0] ?? null;
-  }, [rfMapsQuery.data, isRunForCurrentVersion]);
-  const heatmapUrl = heatmapMap?.url ?? null;
-  // 히트맵 색 스케일 (vmin/vmax dBm) — color legend 가 같은 inferno 그라데이션 +
-  // 동일 범위로 표시. local backend / 최신 sagemaker container 가 응답에 채워넣음.
+  }, [rfMapsQuery.data]);
+  const heatmapSourceUrl = useMemo(() => {
+    if (!heatmapMap) return null;
+    if (heatmapMap.url) return heatmapMap.url;
+    const raw = heatmapMap.storage_url;
+    if (raw && /^https?:\/\//i.test(raw)) return raw;
+    return null;
+  }, [heatmapMap]);
+  const heatmapUrl = useRfMapImageUrl(heatmapSourceUrl);
   const heatmapColorScale = useMemo(
     () =>
       extractColorScale(
@@ -172,14 +169,6 @@ export default function SimulationPage() {
     () => parseHeatmapBounds(heatmapMap?.bounds_json),
     [heatmapMap],
   );
-
-  // 백엔드 상태 → UI 상태 매핑
-  const state: SimulationState = (() => {
-    if (!activeRunId) return 'idle';
-    if (rfRunPoll.isSucceeded) return 'complete';
-    if (rfRunPoll.isFailed) return 'idle'; // 토스트로 알림 + 다시 시작 가능
-    return 'running';
-  })();
 
   const handleStart = () => {
     if (!currentVersion) return;
@@ -219,10 +208,13 @@ export default function SimulationPage() {
   };
 
   const handleReset = () => {
+    const wasHistorical =
+      state === 'complete' &&
+      !!activeRunSceneVersionId &&
+      activeRunSceneVersionId !== currentVersion?.id;
     setPickedRunId(null);
     setResetCleared(true);
-    // AP 위치는 유지 — 보정 후 동일 배치로 재시뮬하는 케이스가 많음.
-    // 새로 찍고 싶으면 캔버스에서 개별 삭제하면 됨.
+    if (wasHistorical) setAps([]);
   };
 
   const handleAddAp = (ap: PlacedAp) => setAps((prev) => [...prev, ap]);
@@ -258,8 +250,7 @@ export default function SimulationPage() {
           const m = parseMetrics(...sources);
           return {
             id: r.id,
-            label: `시뮬레이션 결과 #${r.id.slice(0, 6)}`,
-            timeLabel: formatRunTime(r.created_at),
+            createdAt: r.created_at,
             avgRssiDbm: m.avgRssiDbm,
             coveragePercent: m.coveragePercent,
             active: r.id === activeRunId,
@@ -269,7 +260,7 @@ export default function SimulationPage() {
   );
 
   return (
-    <div className="relative flex h-full flex-col p-6">
+    <div className="relative flex h-full flex-col p-5 lg:p-6">
       <PageHeader
         state={state}
         hasVersion={!!currentVersion}
@@ -302,13 +293,13 @@ export default function SimulationPage() {
           ctaTo="/editor"
         />
       ) : (
-        <div className="mt-5 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
-          <div className="relative min-h-0 overflow-hidden rounded-2xl border bg-background shadow-sm">
+        <div className="mt-4 grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-[1fr_300px]">
+          <div className="relative min-h-0 overflow-hidden rounded-lg border border-slate-200 bg-white">
             {state === 'idle' ? (
               <>
                 <CanvasModeBar apsCount={aps.length} />
                 <SimulationCanvas
-                  sceneVersion={versionDetailQuery.data}
+                  sceneVersion={canvasVersionQuery.data}
                   backgroundImageUrl={backgroundImageUrl}
                   aps={aps}
                   onAdd={handleAddAp}
@@ -324,20 +315,15 @@ export default function SimulationPage() {
                 />
               </>
             ) : state === 'running' ? (
-              <div className="h-full p-6">
+              <div className="h-full p-4">
                 <SimulationVisualization state={state} />
               </div>
             ) : (
               // 'complete' — 도형/AP + 히트맵 오버레이를 한 SVG 안에 겹쳐 표시 (read-only).
               <>
-                {!isRunForCurrentVersion && (
-                  <div className="absolute left-3 right-3 top-3 z-10 rounded-md border border-amber-300 bg-amber-50/95 px-3 py-2 text-[11px] leading-relaxed text-amber-900 shadow-sm backdrop-blur">
-                    이 시뮬레이션은 이전 버전 도면 기준이라 현재 도면과 다를 수 있어
-                    히트맵을 표시하지 않습니다. 새 버전으로 다시 실행해주세요.
-                  </div>
-                )}
+                {isViewingHistoricalRun && <HistoricalRunBubble />}
                 <SimulationCanvas
-                  sceneVersion={versionDetailQuery.data}
+                  sceneVersion={canvasVersionQuery.data}
                   backgroundImageUrl={backgroundImageUrl}
                   aps={aps}
                   onAdd={handleAddAp}
@@ -349,9 +335,7 @@ export default function SimulationPage() {
                   heatmapBounds={heatmapBounds}
                   readOnly
                 />
-                {heatmapUrl && isRunForCurrentVersion && (
-                  // 좌상단 — gradient + tick 값이 수직 정렬돼 "이 색 = 이 dBm" 직관적.
-                  // MeasurementPage 와 동일 위치/크기로 통일.
+                {heatmapUrl && (
                   <div className="pointer-events-none absolute left-3 top-3 z-10 w-70">
                     <DbmColorBar
                       vmin={heatmapColorScale?.vminDbm ?? -85}
@@ -364,16 +348,12 @@ export default function SimulationPage() {
             )}
           </div>
 
-          <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
+          <aside className="flex min-h-0 flex-col gap-3 overflow-y-auto">
             {state === 'complete' && (
               <SimulationResultCard
-                avgRssiDbm={isRunForCurrentVersion ? metrics.avgRssiDbm : null}
-                coveragePercent={isRunForCurrentVersion ? metrics.coveragePercent : null}
-                staleReason={
-                  isRunForCurrentVersion
-                    ? null
-                    : '이전 버전 도면에서 돌린 시뮬레이션이라 현재 도면과 비교 가치가 없어 결과를 숨겼습니다.'
-                }
+                avgRssiDbm={metrics.avgRssiDbm}
+                coveragePercent={metrics.coveragePercent}
+                staleReason={null}
               />
             )}
             {/* AP 배치 (§14) 카드 — 백엔드 ap-candidates 미구현 상태라 임시로 숨김.
@@ -384,9 +364,9 @@ export default function SimulationPage() {
             */}
             <SimulationHistory
               items={history}
+              isLoading={pastRunsQuery.isLoading}
               showCompareButton={false}
               onSelect={(id) => setActiveRunId(id)}
-              emptyMessage="아직 시뮬레이션 기록이 없습니다. AP 를 배치하고 시뮬레이션을 실행해보세요."
             />
           </aside>
         </div>
@@ -397,16 +377,42 @@ export default function SimulationPage() {
   );
 }
 
+/** 설정 바 segmented control 공통 스타일. */
+function simSegmentBtn(active: boolean, disabled?: boolean) {
+  return cn(
+    'inline-flex h-7 items-center rounded-md px-2.5 text-xs transition-colors',
+    disabled && 'cursor-not-allowed opacity-50',
+    active
+      ? 'bg-blue-50 font-medium text-blue-700'
+      : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900',
+  );
+}
+
+/** 캔버스 상단 — 과거 run 도면/히트맵 열람 안내 말풍선. */
+function HistoricalRunBubble() {
+  return (
+    <div className="pointer-events-none absolute right-3 top-3 z-10 max-w-[calc(100%-1.5rem)]">
+      <div className="relative w-max max-w-none animate-bubble-rise rounded-xl border border-sky-200 bg-sky-50/95 px-3.5 py-2.5 shadow-sm backdrop-blur-sm">
+        <p className="text-xs leading-relaxed text-sky-900/90 sm:whitespace-nowrap">
+          시뮬레이션 당시 도면과 히트맵을 보고 있습니다. 「다시 실행」을 누르면 현재 공간 편집 도면으로 돌아갑니다.
+        </p>
+        <span
+          className="absolute -bottom-1 right-5 h-2 w-2 rotate-45 border-b border-r border-sky-200 bg-sky-50/95"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}
+
 /** 캔버스 좌상단 모드 안내. */
 function CanvasModeBar({ apsCount }: { apsCount: number }) {
   return (
-    <div className="pointer-events-none absolute left-4 top-4 z-10 flex items-center gap-2 rounded-full border bg-card/95 px-3 py-1.5 text-xs shadow-sm backdrop-blur">
-      <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-primary/10 text-primary">
-        <Play className="h-2.5 w-2.5 fill-current" />
-      </span>
-      <span className="font-semibold">AP 배치 모드</span>
-      <span className="text-muted-foreground">
-        — 우측 "AP 추가" 누르고 도면을 클릭하세요 ({apsCount}/8)
+    <div className="pointer-events-none absolute left-3 top-3 z-10 flex items-center gap-1.5 rounded-md border border-slate-200/80 bg-white/90 px-2.5 py-1 text-[11px] text-slate-600 backdrop-blur-sm">
+      <span className="font-medium text-slate-700">AP 배치 모드</span>
+      <span className="text-slate-400">·</span>
+      <span className="text-slate-500">
+        AP 추가 후 도면 클릭 ({apsCount}/8)
       </span>
     </div>
   );
@@ -430,45 +436,40 @@ function ApAddPanel({
         type="button"
         onClick={onToggle}
         title="클릭하여 배치 모드 취소"
-        className="absolute right-4 top-4 z-10 inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary/10 px-3 py-1.5 text-[11px] font-medium text-primary shadow-sm backdrop-blur hover:bg-primary/20"
+        className="absolute right-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-md border border-blue-200 bg-blue-50/80 px-2.5 py-1 text-[11px] font-medium text-blue-700 backdrop-blur-sm hover:bg-blue-50"
       >
-        <span
-          className="flex h-4 w-4 items-center justify-center rounded-full text-white"
-          style={{ backgroundColor: 'oklch(0.55 0.22 254)' }}
-        >
-          <Wifi className="h-2.5 w-2.5" />
-        </span>
-        도면 클릭으로 배치 · 취소
+        <Wifi className="h-3.5 w-3.5" />
+        배치 중 · 취소
       </button>
     );
   }
 
   return (
-    <div className="absolute right-4 top-4 z-10 w-32 rounded-xl border bg-card p-3 shadow-md">
-      <p className="mb-2 text-center text-xs font-semibold text-muted-foreground">
-        AP 추가하기
-      </p>
-      <button
-        type="button"
-        onClick={onToggle}
-        disabled={disabled}
-        className={cn(
-          'flex w-full flex-col items-center gap-1.5 rounded-lg border bg-background p-2 text-[11px] font-medium transition-colors hover:bg-accent',
-          disabled && 'cursor-not-allowed opacity-50',
-        )}
-      >
-        <span
-          className="flex h-9 w-9 items-center justify-center rounded-full text-white"
-          style={{ backgroundColor: 'oklch(0.55 0.22 254)' }}
-        >
-          <Wifi className="h-4 w-4" />
-        </span>
-        AP 추가
-      </button>
-      {disabled && (
-        <p className="mt-2 text-center text-[10px] text-destructive">최대 8개</p>
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      title={disabled ? 'AP는 최대 8개까지 배치할 수 있습니다' : 'AP 추가 모드 시작'}
+      aria-label="AP 추가"
+      className={cn(
+        'absolute right-3 top-3 z-10 flex w-[5.5rem] flex-col items-center gap-2 rounded-lg border border-slate-200 bg-white/95 p-2 backdrop-blur-sm transition-colors',
+        !disabled && 'cursor-pointer hover:border-slate-300 hover:bg-slate-50/95',
+        disabled && 'cursor-not-allowed opacity-50',
       )}
-    </div>
+    >
+      <span className="w-full rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-medium text-slate-700">
+        AP 추가
+      </span>
+      <span
+        className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500 text-white shadow-sm shadow-blue-500/20"
+        aria-hidden
+      >
+        <Wifi className="h-4 w-4" strokeWidth={2.5} />
+      </span>
+      {disabled && (
+        <span className="text-center text-[10px] leading-tight text-slate-400">최대 8개</span>
+      )}
+    </button>
   );
 }
 
@@ -504,56 +505,64 @@ function PageHeader({
   onReset: () => void;
 }) {
   return (
-    <header className="flex items-start justify-between gap-4">
-      <div className="space-y-1.5">
-        <h1 className="text-2xl font-semibold tracking-tight">시뮬레이션</h1>
-        <p className="text-sm text-muted-foreground">
+    <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">시뮬레이션</h1>
+        <p className="mt-0.5 text-sm text-slate-500">
           저장된 도면을 불러와 가구와 AP를 자유롭게 배치하고 예상 품질을 비교합니다.
         </p>
       </div>
 
-      <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
-        {state === 'idle' && (
-          <>
-            {/* 공간 유형 — Floor.space_type 직접 수정. 변경 시 즉시 저장 (다음 calibration 에 자동 반영).
-                현재 sim 동작에는 영향 없지만 사용자는 "이 공간을 시뮬한다" 라는 멘탈모델로 여기서 정함. */}
-            <FloorSpaceTypeSelector
-              floorId={floorId}
-              projectId={projectId}
-              showLabel={false}
-            />
-            <RfPhysicalControls
-              frequencyBand={frequencyBand}
-              onFrequencyBandChange={onFrequencyBandChange}
-              txPowerDbm={txPowerDbm}
-              onTxPowerDbmChange={onTxPowerDbmChange}
-              disabled={isStarting}
-            />
-            <BackendToggle value={backend} onChange={onBackendChange} disabled={isStarting} />
-          </>
-        )}
+      <div className="flex shrink-0 flex-wrap items-center justify-end">
         {state === 'idle' ? (
-          <button
-            type="button"
-            onClick={onStart}
-            disabled={!hasVersion || isStarting || apsCount === 0}
-            title={
-              apsCount === 0
-                ? 'AP 를 1개 이상 배치해주세요'
-                : '시뮬레이션 실행'
-            }
-            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <Play className="h-4 w-4 fill-current" />
-            {isStarting ? '요청 중...' : '시뮬레이션 실행'}
-          </button>
+          <div className="inline-flex flex-wrap items-center rounded-lg border border-slate-200 bg-white p-1">
+            <div className="border-b border-slate-100 px-1.5 py-0.5 sm:border-b-0 sm:border-r">
+              <div className="inline-flex h-8 items-center rounded-md bg-slate-50 p-0.5">
+                <FloorSpaceTypeSelector
+                  floorId={floorId}
+                  projectId={projectId}
+                  showLabel={false}
+                  className="h-8"
+                  selectClassName="inline-flex h-7 min-w-[6.5rem] cursor-pointer appearance-none rounded-md border-0 bg-blue-50 py-0 pl-2.5 pr-6 text-xs font-medium text-blue-700 shadow-none focus:outline-none focus:ring-0 disabled:opacity-50"
+                />
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-1 border-b border-slate-100 px-1.5 py-0.5 sm:border-b-0 sm:border-r">
+              <RfPhysicalControls
+                frequencyBand={frequencyBand}
+                onFrequencyBandChange={onFrequencyBandChange}
+                txPowerDbm={txPowerDbm}
+                onTxPowerDbmChange={onTxPowerDbmChange}
+                disabled={isStarting}
+              />
+            </div>
+            <div className="border-b border-slate-100 px-1.5 py-0.5 sm:border-b-0 sm:border-r">
+              <BackendToggle value={backend} onChange={onBackendChange} disabled={isStarting} />
+            </div>
+            <div className="px-1.5 py-0.5">
+              <button
+                type="button"
+                onClick={onStart}
+                disabled={!hasVersion || isStarting || apsCount === 0}
+                title={
+                  apsCount === 0
+                    ? 'AP 를 1개 이상 배치해주세요'
+                    : '시뮬레이션 실행'
+                }
+                className="inline-flex h-8 items-center gap-1.5 rounded-md bg-blue-500 px-3 text-xs font-medium text-white shadow-sm shadow-blue-500/20 transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Play className="h-3 w-3 fill-current" />
+                {isStarting ? '요청 중...' : '시뮬레이션 실행'}
+              </button>
+            </div>
+          </div>
         ) : (
           <button
             type="button"
             onClick={onReset}
-            className="inline-flex items-center gap-2 rounded-lg border bg-background px-3.5 py-2 text-sm font-medium text-foreground/80 shadow-sm hover:bg-accent"
+            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-50"
           >
-            <RotateCcw className="h-4 w-4" />
+            <RotateCcw className="h-3.5 w-3.5" />
             다시 실행
           </button>
         )}
@@ -562,7 +571,7 @@ function PageHeader({
   );
 }
 
-/** SageMaker | Local 백엔드 토글 (idle 일 때만 노출). */
+/** Wi-Fi 대역 · AP 출력 — idle 시 설정 바에 노출. */
 function RfPhysicalControls({
   frequencyBand,
   onFrequencyBandChange,
@@ -587,8 +596,12 @@ function RfPhysicalControls({
   };
 
   return (
-    <div className="inline-flex items-center gap-2 rounded-lg border bg-background p-1 shadow-sm">
-      <div className="inline-flex items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+    <div className="flex flex-wrap items-center gap-2">
+      <div
+        role="group"
+        aria-label="Wi-Fi 대역"
+        className="inline-flex h-8 items-center rounded-md bg-slate-50 p-0.5"
+      >
         {bands.map((band) => {
           const active = frequencyBand === band.key;
           return (
@@ -598,20 +611,15 @@ function RfPhysicalControls({
               onClick={() => onFrequencyBandChange(band.key)}
               disabled={disabled}
               title={band.hint}
-              className={cn(
-                'rounded px-2 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-                active
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
+              className={simSegmentBtn(active, disabled)}
             >
               {band.label}
             </button>
           );
         })}
       </div>
-      <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-        Tx
+      <label className="inline-flex h-8 items-center gap-1.5 px-1 text-xs">
+        <span className="text-slate-500">출력</span>
         <input
           type="number"
           min={0}
@@ -620,9 +628,10 @@ function RfPhysicalControls({
           value={txPowerDbm}
           onChange={(event) => handleTxPowerChange(event.target.value)}
           disabled={disabled}
-          className="h-7 w-14 rounded-md border bg-background px-2 text-right text-xs font-medium text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="AP 출력 (dBm)"
+          className="h-6 min-w-11 w-11 rounded border border-slate-200 bg-white px-1.5 text-center text-xs font-medium tabular-nums text-slate-800 [appearance:textfield] focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         />
-        dBm
+        <span className="text-[10px] text-slate-400">dBm</span>
       </label>
     </div>
   );
@@ -645,7 +654,7 @@ function BackendToggle({
     <div
       role="radiogroup"
       aria-label="시뮬 실행 백엔드"
-      className="inline-flex items-center gap-0.5 rounded-lg border bg-background p-0.5 shadow-sm"
+      className="inline-flex h-8 items-center rounded-md bg-slate-50 p-0.5"
     >
       {options.map((opt) => {
         const active = value === opt.key;
@@ -658,12 +667,7 @@ function BackendToggle({
             onClick={() => onChange(opt.key)}
             disabled={disabled}
             title={opt.hint}
-            className={cn(
-              'rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-              active
-                ? 'bg-primary text-primary-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
+            className={simSegmentBtn(active, disabled)}
           >
             {opt.label}
           </button>
@@ -677,22 +681,22 @@ function BackendToggle({
 function SimulationVisualization({ state }: { state: SimulationState }) {
   if (state === 'running') {
     return (
-      <div className="flex h-full min-h-80 flex-col items-center justify-center gap-2 text-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-        <p className="text-sm font-medium">RF 시뮬레이션 진행 중</p>
-        <p className="max-w-sm text-xs leading-relaxed text-muted-foreground">
+      <div className="flex h-full min-h-80 flex-col items-center justify-center gap-2 p-4 text-center">
+        <Loader2 className="h-7 w-7 animate-spin text-blue-600" />
+        <p className="text-sm font-medium text-slate-800">RF 시뮬레이션 진행 중</p>
+        <p className="max-w-sm text-xs leading-relaxed text-slate-500">
           서버에서 결과를 계산하는 동안 잠시만 기다려주세요. 최대 약 15분이 소요될 수 있습니다.
         </p>
       </div>
     );
   }
   return (
-    <div className="flex h-full min-h-80 flex-col items-center justify-center gap-2 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
-        <Play className="h-5 w-5 text-primary" />
+    <div className="flex h-full min-h-80 flex-col items-center justify-center gap-2 p-4 text-center">
+      <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50">
+        <Play className="h-4 w-4 text-blue-600" />
       </div>
-      <p className="text-sm font-medium">시뮬레이션 실행 대기 중</p>
-      <p className="max-w-sm text-xs leading-relaxed text-muted-foreground">
+      <p className="text-sm font-medium text-slate-800">시뮬레이션 실행 대기 중</p>
+      <p className="max-w-sm text-xs leading-relaxed text-slate-500">
         상단의 시뮬레이션 실행 버튼을 누르면 확정된 도면 기준으로 RF 시뮬레이션이 시작됩니다.
       </p>
     </div>
@@ -891,25 +895,28 @@ function ApLayoutRow({
  * 백엔드 응답 예: { z: 1, min_x, min_y, max_x, max_y }.
  * 4개 좌표 중 하나라도 유효하지 않으면 null → 히트맵 오버레이 생략.
  */
-/** RF Run.created_at → "방금 전" / "오늘 14:32" / "어제 09:10" / "5/18 14:32". */
-function formatRunTime(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
-  if (diffMs < 60_000) return '방금 전';
-  if (diffMs < 3600_000) return `${Math.floor(diffMs / 60_000)}분 전`;
-  const hh = String(d.getHours()).padStart(2, '0');
-  const mm = String(d.getMinutes()).padStart(2, '0');
-  const yesterday = new Date(now);
-  yesterday.setDate(now.getDate() - 1);
-  const sameDay = (a: Date, b: Date) =>
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
-  if (sameDay(d, now)) return `오늘 ${hh}:${mm}`;
-  if (sameDay(d, yesterday)) return `어제 ${hh}:${mm}`;
-  return `${d.getMonth() + 1}/${d.getDate()} ${hh}:${mm}`;
+function useSceneFloorplanBackground(
+  floorId: string | null,
+  sceneVersion: SceneVersion | null | undefined,
+): string | null {
+  const versionAsDraft = sceneVersion ? versionToDraftShape(sceneVersion) : null;
+  const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
+  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
+  const fallbackAsset = useMemo(() => {
+    const list = floorAssetsQuery.data ?? [];
+    if (list.length === 0) return null;
+    return [...list].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
+  }, [floorAssetsQuery.data]);
+  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
+  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  useEffect(() => {
+    if (floorId && sourceAssetId) linkFloorImageToAsset(floorId, sourceAssetId);
+  }, [floorId, sourceAssetId]);
+  const assetUrl = assetUrlQuery.data?.url ?? null;
+  const usableAssetUrl =
+    assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
+  return usableAssetUrl ?? localImage ?? null;
 }
 
 function parseHeatmapBounds(

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -42,6 +42,7 @@ import { toast } from '@/stores/toast-store';
 import type { ApCandidate, ApLayout } from '@/types/ap-layout';
 import type { RfBackend } from '@/types/rf';
 import { cn } from '@/lib/utils';
+import { nextApSequentialName } from '@/lib/ap-layout-naming';
 
 type SimulationState = 'idle' | 'running' | 'complete';
 type FrequencyBand = '2.4' | '5';
@@ -753,10 +754,9 @@ function ApPlacementPanel({ rfRunId }: { rfRunId: string }) {
 
   const handleConfirmCandidate = (c: ApCandidate) => {
     if (!c.point_geom) return;
-    const seq = layouts.length + 1;
     createLayout.mutate({
       rf_run_id: rfRunId,
-      ap_name: `AP-${String(seq).padStart(2, '0')}`,
+      ap_name: nextApSequentialName(layouts.map((l) => l.ap_name)),
       point_geom: c.point_geom,
       z_m: c.z_m ?? 2.5,
     });

--- a/frontend/src/stores/ap-recommendation-store.ts
+++ b/frontend/src/stores/ap-recommendation-store.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { MeterBBox } from '@/features/ap-recommendation/recommendation-utils';
+import type { ApRecommendationResult } from '@/types/ap-recommendation';
+import type { UUID } from '@/types/common';
+
+/** 층(floor)별 AP 배치 추천 UI 세션 — 페이지 이동 후에도 복원. */
+export interface ApRecommendationSession {
+  sceneVersionId: UUID | null;
+  selectionBBox: MeterBBox | null;
+  recommendations: ApRecommendationResult[];
+  selectedRank: number | null;
+  savedRank: number | null;
+}
+
+export const EMPTY_AP_RECOMMENDATION_SESSION: ApRecommendationSession = {
+  sceneVersionId: null,
+  selectionBBox: null,
+  recommendations: [],
+  selectedRank: null,
+  savedRank: null,
+};
+
+interface ApRecommendationStore {
+  byFloor: Record<string, ApRecommendationSession>;
+  patchFloor: (floorId: string, patch: Partial<ApRecommendationSession>) => void;
+  clearFloor: (floorId: string) => void;
+}
+
+export const useApRecommendationStore = create<ApRecommendationStore>()(
+  persist(
+    (set) => ({
+      byFloor: {},
+      patchFloor: (floorId, patch) =>
+        set((s) => ({
+          byFloor: {
+            ...s.byFloor,
+            [floorId]: {
+              ...EMPTY_AP_RECOMMENDATION_SESSION,
+              ...s.byFloor[floorId],
+              ...patch,
+            },
+          },
+        })),
+      clearFloor: (floorId) =>
+        set((s) => {
+          const next = { ...s.byFloor };
+          delete next[floorId];
+          return { byFloor: next };
+        }),
+    }),
+    {
+      name: 'wifang.ap-recommendation',
+      partialize: (s) => ({
+        byFloor: Object.fromEntries(
+          Object.entries(s.byFloor).filter(([, v]) => v.savedRank != null),
+        ),
+      }),
+    },
+  ),
+);

--- a/frontend/src/stores/toast-store.ts
+++ b/frontend/src/stores/toast-store.ts
@@ -24,21 +24,59 @@ const nextId = () => {
   return `t-${Date.now()}-${counter}`;
 };
 
+const dismissTimers = new Map<string, number>();
+
+function toastDedupeKey(toast: Pick<Toast, 'kind' | 'title' | 'description'>): string {
+  return `${toast.kind}\0${toast.title}\0${toast.description ?? ''}`;
+}
+
+function scheduleDismiss(id: string, durationMs: number, dismiss: (id: string) => void) {
+  const prev = dismissTimers.get(id);
+  if (prev !== undefined) window.clearTimeout(prev);
+  const timer = window.setTimeout(() => {
+    dismissTimers.delete(id);
+    dismiss(id);
+  }, durationMs);
+  dismissTimers.set(id, timer);
+}
+
 export const useToastStore = create<ToastStore>((set, get) => ({
   toasts: [],
   show: (toast) => {
+    const key = toastDedupeKey(toast);
+    const existing = get().toasts.find((t) => toastDedupeKey(t) === key);
+    if (existing) {
+      const duration = toast.durationMs ?? 4000;
+      if (duration > 0) {
+        scheduleDismiss(existing.id, duration, get().dismiss);
+      }
+      return existing.id;
+    }
+
     const id = nextId();
     set((state) => ({ toasts: [...state.toasts, { id, ...toast }] }));
 
     const duration = toast.durationMs ?? 4000;
     if (duration > 0) {
-      window.setTimeout(() => get().dismiss(id), duration);
+      scheduleDismiss(id, duration, get().dismiss);
     }
     return id;
   },
-  dismiss: (id) =>
-    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
-  clearAll: () => set({ toasts: [] }),
+  dismiss: (id) => {
+    const timer = dismissTimers.get(id);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      dismissTimers.delete(id);
+    }
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+  },
+  clearAll: () => {
+    for (const timer of dismissTimers.values()) {
+      window.clearTimeout(timer);
+    }
+    dismissTimers.clear();
+    set({ toasts: [] });
+  },
 }));
 
 // 편의 함수

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,17 +1,39 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'node:path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const aiApiTarget = (env.VITE_AI_API_BASE_URL || 'http://localhost:9000').replace(/\/$/, '')
+  const internalApiKey = env.INTERNAL_API_KEY || env.AI_INTERNAL_API_KEY || ''
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    port: 5173,
-  },
+    server: {
+      port: 5173,
+      // local RF 시뮬 heatmap — DB 에 저장된 ai_api URL(localhost:9000) 을
+      // 브라우저 same-origin 으로 우회. ai_api 가 실행 중이어야 함.
+      proxy: {
+        '/__ai_api__': {
+          target: aiApiTarget,
+          changeOrigin: true,
+          rewrite: (reqPath) => reqPath.replace(/^\/__ai_api__/, ''),
+          configure: (proxy) => {
+            proxy.on('proxyReq', (proxyReq) => {
+              if (internalApiKey) {
+                proxyReq.setHeader('X-Internal-API-Key', internalApiKey)
+              }
+            })
+          },
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
- **디자인 토 통일**: `--primary`를 Tailwind blue-500으로 변경하고, 도면 공통 색상(`canvas-scene-colors`)으로 문·창(teal-500)·AP·객체·선택 강조를 전 캔버스에 일관 적용
- **시뮬레이션 페이지**: 설정(공간 유형/Wi-Fi/Tx/백엔드/실행)을 상단 통합 toolbar로 재구성, 접이식 시뮬레이션 기록(최고 결과·커버리지 상태·스켈레톤), 과거 run 선택 시 **당시 scene_version 도면 + 히트맵** 표시 및 sky 말풍선 안내
- **local heatmap 로딩**: dev 환경에서 `localhost:9000` ai_api URL을 Vite `/__ai_api__` 프록시로 우회 (`ai-api-image-proxy`, `useRfMapImageUrl`, `.env.example`/`vite.config.ts`)
- **실측·보정**: `CalibrationCard` 상태 배지·선행 조건(gate) 안내·측정/시뮬 이동 링크 추가, 실측 페이지에서 보정 버튼 노출 및 공간 유형 중복 입력 제거
- **AP 배치 추천**: 우선 개선 영역 lemon yellow, ProgressStepper/CTA blue-500, 단계 아이콘에 맞춘 sky 말풍선, 레이아웃·타이포 정리
- **기타 UX**: 토스트 dedupe·진입/퇴장 애니메이션, RF run 완료 토스트 중복 방지, 미구현 모바일 AR 스캔 카드 숨김