### PR TITLE
style: AP 다중 추천·SaaS UI 톤 정리 및 버전 확정 패널 개선

### DIFF
--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -26,14 +26,22 @@ class ApRecommendationRequest(BaseModel):
     shadow_threshold_dbm: float = Field(default=-80.0)
     # 음영 패널티 점수
     shadow_penalty: float = Field(default=100.0)
+    # 반환할 추천 개수
+    n_recommendations: int = Field(default=3, ge=1, le=10)
+
+
+class ApRecommendationItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: int
+    recommended_x: float
+    recommended_y: float
+    score: float
 
 
 class ApRecommendationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    recommended_x: float
-    recommended_y: float
-    score: float
+    recommendations: list[ApRecommendationItem]
     status: str = "success"
-    # 탐색된 후보 수
     candidates_evaluated: int

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -20,7 +20,7 @@ from app.core.geom import wkb_to_geojson
 from app.models.scene_version import SceneVersion
 from app.models.project import Project
 from app.models.user import User
-from app.schemas.rf.ap_recommendation import ApRecommendationRequest, ApRecommendationResponse
+from app.schemas.rf.ap_recommendation import ApRecommendationItem, ApRecommendationRequest, ApRecommendationResponse
 from app.services.rf.calibration_worker.path_loss import (
     AccessPoint,
     CalibrationParams,
@@ -93,8 +93,8 @@ def recommend_ap_location(
         sv.id, len(candidates), len(eval_points), len(existing_aps),
     )
 
-    # 7) Grid Search
-    best_x, best_y, best_score = _grid_search(
+    # 7) Grid Search — 상위 n_recommendations개 반환
+    top_results = _grid_search_topn(
         candidates=candidates,
         eval_points=eval_points,
         existing_aps=existing_aps,
@@ -102,17 +102,24 @@ def recommend_ap_location(
         params=params,
         shadow_threshold_dbm=request.shadow_threshold_dbm,
         shadow_penalty=request.shadow_penalty,
+        n=request.n_recommendations,
     )
 
     logger.info(
-        "AP 추천 완료: best=(%.2f, %.2f) score=%.1f",
-        best_x, best_y, best_score,
+        "AP 추천 완료: top%d, best=(%.2f, %.2f) score=%.1f",
+        len(top_results), top_results[0][0], top_results[0][1], top_results[0][2],
     )
 
     return ApRecommendationResponse(
-        recommended_x=round(best_x, 3),
-        recommended_y=round(best_y, 3),
-        score=round(best_score, 2),
+        recommendations=[
+            ApRecommendationItem(
+                rank=i + 1,
+                recommended_x=round(x, 3),
+                recommended_y=round(y, 3),
+                score=round(score, 2),
+            )
+            for i, (x, y, score) in enumerate(top_results)
+        ],
         candidates_evaluated=len(candidates),
     )
 
@@ -255,7 +262,7 @@ def _parse_existing_aps(raw: list[dict]) -> list[AccessPoint]:
     return aps
 
 
-def _grid_search(
+def _grid_search_topn(
     *,
     candidates: list[tuple[float, float]],
     eval_points: list[Measurement],
@@ -264,9 +271,10 @@ def _grid_search(
     params: CalibrationParams,
     shadow_threshold_dbm: float,
     shadow_penalty: float,
-) -> tuple[float, float, float]:
-    """모든 후보 좌표에 대해 점수 계산 후 최적 좌표 반환."""
-    best_x, best_y, best_score = candidates[0][0], candidates[0][1], float("-inf")
+    n: int,
+) -> list[tuple[float, float, float]]:
+    """모든 후보 좌표에 대해 점수 계산 후 상위 n개 반환 (x, y, score)."""
+    scored: list[tuple[float, float, float]] = []
 
     for (cx, cy) in candidates:
         test_ap = AccessPoint(name="test", x=cx, y=cy)
@@ -280,8 +288,7 @@ def _grid_search(
             else:
                 score += pred
 
-        if score > best_score:
-            best_score = score
-            best_x, best_y = cx, cy
+        scored.append((cx, cy, score))
 
-    return best_x, best_y, best_score
+    scored.sort(key=lambda t: t[2], reverse=True)
+    return scored[:n]

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -34,26 +34,40 @@ const DRAG_THRESHOLD_M = 0.15;
 const CANVAS_LABEL_VB_RATIO = 0.018;
 
 const SELECTION_BADGE_LABEL = '우선 개선 영역';
-/** 우선 개선 영역 — bright lemon yellow (문·창문·primary blue 와 구분) */
-const SELECTION_FILL = 'rgba(254, 240, 138, 0.35)';
-const SELECTION_FILL_PREVIEW = 'rgba(254, 240, 138, 0.28)';
-const SELECTION_STROKE = '#FACC15';
-const SELECTION_LABEL_BG = '#FACC15';
-const SELECTION_LABEL_TEXT = '#111827';
-/** 선택 rect 모서리 — 도면 미터 좌표 기준 */
-const SELECTION_CORNER_R = 0.14;
+/** 우선 개선 영역 오버레이 — 개나리색 계열 annotation */
+const SELECTION_FILL = 'rgba(245, 196, 0, 0.17)';
+const SELECTION_FILL_PREVIEW = 'rgba(245, 196, 0, 0.12)';
+const SELECTION_STROKE = 'rgba(212, 160, 0, 0.52)';
+/** 내부 pill badge — 12px / pad 5×9 / inset 10px 기준 (미터 좌표 비율) */
+const SELECTION_LABEL_BG = 'rgba(255, 220, 70, 0.94)';
+const SELECTION_LABEL_BORDER = 'rgba(196, 142, 0, 0.48)';
+const SELECTION_LABEL_TEXT = '#7A5200';
+const SELECTION_BADGE_FONT_RATIO = 0.0145;
 
-function selectionBadgeMetrics(labelFontM: number) {
-  const font = labelFontM * 0.92;
-  const padX = labelFontM * 0.24;
+function selectionBadgeMetrics(badgeFontM: number) {
+  const font = badgeFontM;
+  const padX = badgeFontM * (9 / 12);
+  const padY = badgeFontM * (5 / 12);
+  const height = font + padY * 2;
+  const cornerR = height / 2;
   let textWidth = 0;
   for (const ch of SELECTION_BADGE_LABEL) {
-    textWidth += ch === ' ' ? font * 0.28 : font * 0.88;
+    textWidth += ch === ' ' ? font * 0.26 : font * 0.78;
   }
   const width = padX * 2 + textWidth;
-  const height = labelFontM * 1.45;
-  const cornerR = labelFontM * 0.22;
-  return { font, padX, width, height, cornerR };
+  return { font, width, height, cornerR };
+}
+
+function selectionBadgeFontM(viewBoxW: number): number {
+  return viewBoxW * SELECTION_BADGE_FONT_RATIO;
+}
+
+function selectionBadgeInsetM(badgeFontM: number): number {
+  return badgeFontM * (10 / 12);
+}
+
+function selectionCornerM(badgeFontM: number): number {
+  return badgeFontM * (10 / 12);
 }
 
 function canvasLabelFontM(viewBoxW: number): number {
@@ -215,10 +229,10 @@ export function ApRecommendationCanvas({
   const showDragPreview =
     dragRect && (dragRect.w >= DRAG_THRESHOLD_M || dragRect.h >= DRAG_THRESHOLD_M);
   const labelFontM = canvasLabelFontM(vb.w);
-  const selectionBadge = selectionBadgeMetrics(labelFontM);
-  const selectionBadgeY = clampedSelectionBBox
-    ? Math.max(sceneBounds.yMin, clampedSelectionBBox.y_min - selectionBadge.height)
-    : 0;
+  const badgeFontM = selectionBadgeFontM(vb.w);
+  const selectionBadge = selectionBadgeMetrics(badgeFontM);
+  const badgeInset = selectionBadgeInsetM(badgeFontM);
+  const selectionCornerR = selectionCornerM(badgeFontM);
 
   return (
     <div className="relative h-full w-full overflow-hidden bg-[#f8fafc] [background-image:radial-gradient(circle,oklch(0.92_0_0)_1px,transparent_1px)] bg-size-[18px_18px] bg-position-[0_0]">
@@ -272,7 +286,7 @@ export function ApRecommendationCanvas({
           ))}
         </g>
 
-        {/* 선택 영역 — clamp된 좌표, clipPath 밖(배지가 상단에서 잘리지 않도록) */}
+        {/* 선택 영역 + 내부 pill badge */}
         <g pointerEvents="none">
           {clampedSelectionBBox && (
             <g>
@@ -281,31 +295,37 @@ export function ApRecommendationCanvas({
                 y={clampedSelectionBBox.y_min}
                 width={clampedSelectionBBox.x_max - clampedSelectionBBox.x_min}
                 height={clampedSelectionBBox.y_max - clampedSelectionBBox.y_min}
-                rx={SELECTION_CORNER_R}
-                ry={SELECTION_CORNER_R}
+                rx={selectionCornerR}
+                ry={selectionCornerR}
                 fill={SELECTION_FILL}
                 stroke={SELECTION_STROKE}
                 strokeWidth="1.5"
                 vectorEffect="non-scaling-stroke"
               />
               <rect
-                x={clampedSelectionBBox.x_min}
-                y={selectionBadgeY}
+                x={clampedSelectionBBox.x_min + badgeInset}
+                y={clampedSelectionBBox.y_min + badgeInset}
                 width={selectionBadge.width}
                 height={selectionBadge.height}
                 rx={selectionBadge.cornerR}
                 ry={selectionBadge.cornerR}
                 fill={SELECTION_LABEL_BG}
+                stroke={SELECTION_LABEL_BORDER}
+                strokeWidth="1"
+                vectorEffect="non-scaling-stroke"
               />
               <text
-                x={clampedSelectionBBox.x_min + selectionBadge.padX}
-                y={selectionBadgeY + selectionBadge.height * 0.62}
+                x={clampedSelectionBBox.x_min + badgeInset + selectionBadge.width / 2}
+                y={clampedSelectionBBox.y_min + badgeInset + selectionBadge.height / 2}
+                textAnchor="middle"
+                dominantBaseline="middle"
                 fontSize={selectionBadge.font}
-                fontWeight="500"
+                fontWeight="600"
                 fill={SELECTION_LABEL_TEXT}
-                style={{ userSelect: 'none' }}
+                pointerEvents="none"
+                style={{ userSelect: 'none', letterSpacing: '-0.01em' }}
               >
-                우선 개선 영역
+                {SELECTION_BADGE_LABEL}
               </text>
             </g>
           )}
@@ -316,8 +336,8 @@ export function ApRecommendationCanvas({
               y={dragRect.y}
               width={dragRect.w}
               height={dragRect.h}
-              rx={SELECTION_CORNER_R}
-              ry={SELECTION_CORNER_R}
+              rx={selectionCornerR}
+              ry={selectionCornerR}
               fill={SELECTION_FILL_PREVIEW}
               stroke={SELECTION_STROKE}
               strokeWidth="1.5"
@@ -482,7 +502,7 @@ function RecommendationMarker({
         dominantBaseline="middle"
         fontSize={Math.max(r * 0.55, labelFontM * 0.65)}
         fontWeight="600"
-        fill="white"
+        fill={ui.markerLabelFill}
         pointerEvents="none"
         style={{ userSelect: 'none' }}
       >

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -14,6 +14,7 @@ import {
   clampMeterBBox,
   clampRectToBounds,
   computeSceneBounds,
+  getRecommendationRankUi,
   isValidSelectionBBox,
   meterBBoxFromRect,
   normalizeRect,
@@ -67,6 +68,9 @@ interface Props {
   onSelectionChange: (bbox: MeterBBox | null) => void;
   recommendations: ApRecommendationResult[];
   selectedRecommendationRank: number | null;
+  /** 패널 hover·선택과 연동 — 라벨 강조용 */
+  highlightedRank?: number | null;
+  onMarkerHover?: (rank: number | null) => void;
   disabled?: boolean;
   /** true면 새 우선 개선 영역 드래그 불가 (추천 완료·계산 중) */
   dragDisabled?: boolean;
@@ -121,6 +125,8 @@ export function ApRecommendationCanvas({
   onSelectionChange,
   recommendations,
   selectedRecommendationRank,
+  highlightedRank = null,
+  onMarkerHover,
   disabled = false,
   dragDisabled = false,
 }: Props) {
@@ -322,13 +328,16 @@ export function ApRecommendationCanvas({
         </g>
 
         {/* 추천 AP 마커 — 선택 영역 위에 표시 */}
-        <g pointerEvents="none">
+        <g>
           {recommendations.map((rec) => (
             <RecommendationMarker
               key={rec.rank}
               rec={rec}
-              selected={selectedRecommendationRank === rec.rank}
+              highlighted={
+                highlightedRank === rec.rank || selectedRecommendationRank === rec.rank
+              }
               labelFontM={labelFontM}
+              onHover={(active) => onMarkerHover?.(active ? rec.rank : null)}
             />
           ))}
         </g>
@@ -431,25 +440,40 @@ function ExistingApMarker({ ap }: { ap: CanvasExistingAp }) {
 
 function RecommendationMarker({
   rec,
-  selected,
+  highlighted,
   labelFontM,
+  onHover,
 }: {
   rec: ApRecommendationResult;
-  selected: boolean;
+  highlighted: boolean;
   labelFontM: number;
+  onHover?: (active: boolean) => void;
 }) {
   const r = RECOMMEND_RADIUS_M;
-  const fill = selected ? '#059669' : '#10b981';
+  const ui = getRecommendationRankUi(rec.rank);
+  const fill = highlighted ? ui.fillHighlighted : ui.fill;
   return (
-    <g pointerEvents="none">
+    <g
+      onPointerEnter={() => onHover?.(true)}
+      onPointerLeave={() => onHover?.(false)}
+      className="cursor-default"
+    >
       <circle
         cx={rec.recommended_x}
         cy={rec.recommended_y}
-        r={r}
+        r={r + 0.06}
+        fill="transparent"
+        pointerEvents="all"
+      />
+      <circle
+        cx={rec.recommended_x}
+        cy={rec.recommended_y}
+        r={highlighted ? r * 1.08 : r}
         fill={fill}
         stroke="white"
-        strokeWidth="1.5"
+        strokeWidth={highlighted ? 2 : 1.5}
         vectorEffect="non-scaling-stroke"
+        pointerEvents="none"
       />
       <text
         x={rec.recommended_x}
@@ -459,25 +483,29 @@ function RecommendationMarker({
         fontSize={Math.max(r * 0.55, labelFontM * 0.65)}
         fontWeight="600"
         fill="white"
+        pointerEvents="none"
         style={{ userSelect: 'none' }}
       >
-        AP
+        {rec.rank}
       </text>
-      <text
-        x={rec.recommended_x}
-        y={rec.recommended_y + r + labelFontM * 1.05}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fontSize={labelFontM}
-        fontWeight="600"
-        fill={fill}
-        stroke="white"
-        strokeWidth={labelFontM * 0.1}
-        paintOrder="stroke fill"
-        style={{ userSelect: 'none' }}
-      >
-        추천 위치
-      </text>
+      {highlighted && (
+        <text
+          x={rec.recommended_x}
+          y={rec.recommended_y + r + labelFontM * 1.05}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={labelFontM * 0.92}
+          fontWeight="600"
+          fill={ui.fillHighlighted}
+          stroke="white"
+          strokeWidth={labelFontM * 0.1}
+          paintOrder="stroke fill"
+          pointerEvents="none"
+          style={{ userSelect: 'none' }}
+        >
+          {rec.rank}순위
+        </text>
+      )}
     </g>
   );
 }

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -8,7 +8,7 @@ import {
 import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import type { DraftOpening, DraftWall, SceneVersion } from '@/types/scene';
 import { cn } from '@/lib/utils';
-import { CANVAS_BLUE, CANVAS_WINDOW } from '@/lib/canvas-scene-colors';
+import { CANVAS_BLUE, CANVAS_WINDOW_STROKE } from '@/lib/canvas-scene-colors';
 import {
   clampCoord,
   clampMeterBBox,
@@ -365,7 +365,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
   const end = g.coordinates[g.coordinates.length - 1];
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW;
+  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW_STROKE;
   return (
     <line
       x1={start[0]}

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -6,6 +6,18 @@ import type {
 } from '@/types/ap-recommendation';
 import type { UUID } from '@/types/common';
 import { parseGeometry } from '@/features/editor/geometry-utils';
+import { CANVAS_BLUE } from '@/lib/canvas-scene-colors';
+
+/** AP 추천 순위 — 하늘색 단일 계열 (진→옅, 명도 차이 확대) */
+const RANK1_SKY = '#3B82F6';
+const RANK2_SKY = '#60A5FA';
+const RANK3_SKY = '#BFDBFE';
+const RANK_SKY_MUTED = '#EAF4FF';
+const RANK2_SKY_HOVER = '#3B82F6';
+const RANK3_SKY_HOVER = '#93C5FD';
+
+/** primary hover — blue-600, 1위 캔버스 마커 강조용 */
+const CANVAS_BLUE_HOVER = 'oklch(0.546 0.245 262.881)';
 
 /** AP 설치 높이 기본값 — SimulationCanvas DEFAULT_AP_Z_M 과 동일. */
 export const AP_DEFAULT_Z_M = 2.5;
@@ -187,16 +199,16 @@ export function computeSceneBounds(
   return { xMin: b.minX, yMin: b.minY, xMax: b.maxX, yMax: b.maxY };
 }
 
-/** AP 추천 순위 — 패널·캔버스 공통 색 (emerald / orange / violet). */
+/** AP 추천 순위 — 패널 accent/badge·캔버스 마커 (하늘색 계열). */
 export interface RecommendationRankUi {
-  /** 캔버스 마커 fill */
+  accent: string;
+  accentMuted: string;
   fill: string;
-  /** 캔버스 마커 hover·라벨 accent */
   fillHighlighted: string;
+  markerLabelFill: string;
   badgeClass: string;
   cardAccentClass: string;
-  /** 1순위 카드만 — 과하지 않은 강조 */
-  cardEmphasisClass: string;
+  cardHighlightClass: string;
   title: string;
 }
 
@@ -204,29 +216,38 @@ export function getRecommendationRankUi(rank: number): RecommendationRankUi {
   switch (rank) {
     case 1:
       return {
-        fill: '#10B981',
-        fillHighlighted: '#059669',
-        badgeClass: 'bg-emerald-500 text-white',
-        cardAccentClass: 'border-l-emerald-500',
-        cardEmphasisClass: 'ring-1 ring-emerald-100',
+        accent: RANK1_SKY,
+        accentMuted: RANK_SKY_MUTED,
+        fill: CANVAS_BLUE,
+        fillHighlighted: CANVAS_BLUE_HOVER,
+        markerLabelFill: '#FFFFFF',
+        badgeClass: 'bg-[#3B82F6] text-white font-bold',
+        cardAccentClass: 'border-l-[#3B82F6]',
+        cardHighlightClass: 'bg-[#EAF4FF]/70',
         title: '1위 추천 위치',
       };
     case 2:
       return {
-        fill: '#F97316',
-        fillHighlighted: '#EA580C',
-        badgeClass: 'bg-orange-500 text-white',
-        cardAccentClass: 'border-l-orange-500',
-        cardEmphasisClass: '',
+        accent: RANK2_SKY,
+        accentMuted: RANK_SKY_MUTED,
+        fill: RANK2_SKY,
+        fillHighlighted: RANK2_SKY_HOVER,
+        markerLabelFill: '#1E3A8A',
+        badgeClass: 'bg-[#60A5FA] text-[#1E3A8A] font-semibold',
+        cardAccentClass: 'border-l-[#60A5FA]',
+        cardHighlightClass: 'bg-white',
         title: '2위 추천 위치',
       };
     default:
       return {
-        fill: '#8B5CF6',
-        fillHighlighted: '#7C3AED',
-        badgeClass: 'bg-violet-500 text-white',
-        cardAccentClass: 'border-l-violet-500',
-        cardEmphasisClass: '',
+        accent: RANK3_SKY,
+        accentMuted: RANK_SKY_MUTED,
+        fill: RANK3_SKY,
+        fillHighlighted: RANK3_SKY_HOVER,
+        markerLabelFill: '#2563EB',
+        badgeClass: 'bg-[#BFDBFE] text-[#2563EB] font-semibold',
+        cardAccentClass: 'border-l-[#BFDBFE]',
+        cardHighlightClass: 'bg-white',
         title: `${rank}위 추천 위치`,
       };
   }

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -59,19 +59,17 @@ export function buildApRecommendationPayload(params: {
   };
 }
 
-/** 단일 응답 → rank 배열. 추후 복수 추천 API 대응용. */
+/** 응답 → UI 표시용 배열로 normalize. */
 export function normalizeRecommendations(
-  response: ApRecommendationResponse | ApRecommendationResponse[] | null | undefined,
+  response: ApRecommendationResponse | null | undefined,
 ): ApRecommendationResult[] {
   if (!response) return [];
-  const list = Array.isArray(response) ? response : [response];
-  return list.map((item, i) => ({
-    rank: i + 1,
+  return response.recommendations.map((item) => ({
+    rank: item.rank,
     recommended_x: item.recommended_x,
     recommended_y: item.recommended_y,
     score: item.score,
-    status: item.status,
-    candidates_evaluated: item.candidates_evaluated,
+    candidates_evaluated: response.candidates_evaluated,
   }));
 }
 

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -186,3 +186,133 @@ export function computeSceneBounds(
   }
   return { xMin: b.minX, yMin: b.minY, xMax: b.maxX, yMax: b.maxY };
 }
+
+/** AP 추천 순위 — 패널·캔버스 공통 색 (emerald / orange / violet). */
+export interface RecommendationRankUi {
+  /** 캔버스 마커 fill */
+  fill: string;
+  /** 캔버스 마커 hover·라벨 accent */
+  fillHighlighted: string;
+  badgeClass: string;
+  cardAccentClass: string;
+  /** 1순위 카드만 — 과하지 않은 강조 */
+  cardEmphasisClass: string;
+  title: string;
+}
+
+export function getRecommendationRankUi(rank: number): RecommendationRankUi {
+  switch (rank) {
+    case 1:
+      return {
+        fill: '#10B981',
+        fillHighlighted: '#059669',
+        badgeClass: 'bg-emerald-500 text-white',
+        cardAccentClass: 'border-l-emerald-500',
+        cardEmphasisClass: 'ring-1 ring-emerald-100',
+        title: '1위 추천 위치',
+      };
+    case 2:
+      return {
+        fill: '#F97316',
+        fillHighlighted: '#EA580C',
+        badgeClass: 'bg-orange-500 text-white',
+        cardAccentClass: 'border-l-orange-500',
+        cardEmphasisClass: '',
+        title: '2위 추천 위치',
+      };
+    default:
+      return {
+        fill: '#8B5CF6',
+        fillHighlighted: '#7C3AED',
+        badgeClass: 'bg-violet-500 text-white',
+        cardAccentClass: 'border-l-violet-500',
+        cardEmphasisClass: '',
+        title: `${rank}위 추천 위치`,
+      };
+  }
+}
+
+function getScoreGapMetrics(
+  rec: ApRecommendationResult,
+  first: ApRecommendationResult,
+  all: ApRecommendationResult[],
+) {
+  const gap = first.score - rec.score;
+  const scores = all.map((r) => r.score);
+  const scoreSpan = Math.max(...scores) - Math.min(...scores);
+  const normalized = scoreSpan > 0 ? gap / scoreSpan : 0;
+  return { gap, normalized };
+}
+
+function isNearBboxEdge(rec: ApRecommendationResult, bbox: MeterBBox): boolean {
+  const w = bbox.x_max - bbox.x_min;
+  const h = bbox.y_max - bbox.y_min;
+  const thresholdX = Math.max(w * 0.12, 0.4);
+  const thresholdY = Math.max(h * 0.12, 0.4);
+  return (
+    rec.recommended_x - bbox.x_min < thresholdX ||
+    bbox.x_max - rec.recommended_x < thresholdX ||
+    rec.recommended_y - bbox.y_min < thresholdY ||
+    bbox.y_max - rec.recommended_y < thresholdY
+  );
+}
+
+function distanceBetween(a: ApRecommendationResult, b: ApRecommendationResult): number {
+  return Math.hypot(a.recommended_x - b.recommended_x, a.recommended_y - b.recommended_y);
+}
+
+function describeCoverageAdvantage(
+  rec: ApRecommendationResult,
+  first: ApRecommendationResult,
+  all: ApRecommendationResult[],
+): string {
+  const { gap, normalized } = getScoreGapMetrics(rec, first, all);
+  const distFromFirst = distanceBetween(rec, first);
+  const nearEqual = gap <= 0.5 || normalized <= 0.08;
+  const moderate = normalized <= 0.35;
+
+  if (rec.rank === 2) {
+    if (nearEqual && distFromFirst >= 0.8) {
+      return '1위와 거의 같은 신호 커버를 내면서, 다른 지점이라 천장·전원 등 설치 제약에 맞추기 좋습니다.';
+    }
+    if (nearEqual) {
+      return '1위와 성능이 거의 같아, 1위 설치가 어려울 때 바로 쓸 수 있는 대안입니다.';
+    }
+    if (moderate) {
+      return '1위보다 일부 구역 신호는 약간 낮지만, 두 번째로 균형 잡힌 커버를 기대할 수 있습니다.';
+    }
+    return '1위보다 커버는 낮지만, 다른 지점 배치가 필요할 때 고려할 수 있습니다.';
+  }
+
+  if (nearEqual && distFromFirst >= 0.8) {
+    return '1위와 비슷한 커버를 유지하면서, 분산·예비 배치에 활용하기 좋습니다.';
+  }
+  if (moderate) {
+    return `${rec.rank}순위이지만 1위와 비슷한 수준을 유지하며, 다른 위치의 대안으로 쓸 수 있습니다.`;
+  }
+  return '1위보다 커버는 낮지만, 1·2위 설치가 어렵거나 배치 변경 시 참고할 수 있는 옵션입니다.';
+}
+
+/** API score 기반 추천 이유 문장 (raw 점수 미노출) */
+export function getRecommendationReason(
+  rec: ApRecommendationResult,
+  all: ApRecommendationResult[],
+  bbox: MeterBBox | null,
+): string {
+  const first = all.find((r) => r.rank === 1) ?? all[0];
+  const parts: string[] = [];
+
+  if (rec.rank === 1) {
+    parts.push(
+      '우선 개선 영역·도면 평가 지점에서 음영 구역을 줄이고 예측 신호가 가장 잘 닿는 위치입니다.',
+    );
+    if (bbox && isNearBboxEdge(rec, bbox)) {
+      parts.push('선택 영역 가장자리 근처입니다.');
+    }
+    return parts.join(' ');
+  }
+
+  if (!first) return '';
+
+  return describeCoverageAdvantage(rec, first, all);
+}

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -35,7 +35,9 @@ import {
   CANVAS_OBJECT_LABEL,
   CANVAS_OBJECT_STROKE,
   CANVAS_WALL,
-  CANVAS_WINDOW,
+  CANVAS_WINDOW_ACTIVE,
+  CANVAS_WINDOW_LABEL,
+  CANVAS_WINDOW_STROKE,
 } from '@/lib/canvas-scene-colors';
 import type { EditorTool } from '@/stores/editor-store';
 
@@ -229,7 +231,7 @@ const POLYGON_CLOSE_THRESHOLD_M = 0.4;
 /** 벽·문·창 실선/미리보기 점선 공통 stroke (OpeningShape·WallShape 와 동일). */
 const STROKE_WALL = CANVAS_WALL;
 const STROKE_DOOR = CANVAS_BLUE;
-const STROKE_WINDOW = CANVAS_WINDOW;
+const STROKE_WINDOW = CANVAS_WINDOW_STROKE;
 
 /** 끝점 스냅 반경 (미터). 이 안에 기존 끝점이 있으면 딱 붙음. */
 const SNAP_RADIUS_M = 0.25;
@@ -1956,7 +1958,12 @@ function OpeningShape({
   const [start, end] = coords;
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const baseColor = isDoor ? STROKE_DOOR : STROKE_WINDOW;
+  const strokeColor = isDoor
+    ? STROKE_DOOR
+    : selected
+      ? CANVAS_WINDOW_ACTIVE
+      : STROKE_WINDOW;
+  const labelColor = isDoor ? STROKE_DOOR : CANVAS_WINDOW_LABEL;
   const label = isDoor ? '문' : '창문';
   // 라벨은 선의 중점에서 수직 방향으로 살짝 떨어뜨려 배치.
   const midX = (start[0] + end[0]) / 2;
@@ -1988,7 +1995,7 @@ function OpeningShape({
         y1={start[1]}
         x2={end[0]}
         y2={end[1]}
-        stroke={baseColor}
+        stroke={strokeColor}
         strokeWidth={selected ? 8 : 5}
         strokeLinecap="butt"
         vectorEffect="non-scaling-stroke"
@@ -2001,7 +2008,7 @@ function OpeningShape({
         dominantBaseline="middle"
         fontSize={OPENING_LABEL_FONT_SIZE_M}
         fontWeight="500"
-        fill={baseColor}
+        fill={labelColor}
         pointerEvents="none"
         style={{ userSelect: 'none' }}
       >

--- a/frontend/src/features/editor/PromotedCard.tsx
+++ b/frontend/src/features/editor/PromotedCard.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { CheckCircle2, ChevronUp, History, Minimize2, Radio } from 'lucide-react';
+import { CheckCircle2, ChevronUp, Minimize2, Radio } from 'lucide-react';
 import type { SceneVersion } from '@/types/scene';
-import { useVersionPatchLogs } from '@/hooks/use-patch-logs';
 import { VersionHistoryPanel } from './VersionHistoryPanel';
 
 interface PromotedCardProps {
@@ -27,13 +26,6 @@ export function PromotedCard({
   // (justPromoted 로 캡처된 stale version prop 이 전환 후에도 따라오지 않는 문제 해결.)
   const displayVersion = versions?.find((v) => v.is_current) ?? version;
 
-  // 확정본 변경 이력 (§9.1) — Draft 단계 변경은 안 쌓이고, 확정 후 PATCH 시 기록됨.
-  const patchLogsQuery = useVersionPatchLogs(displayVersion.id, {
-    page: 1,
-    page_size: 1,
-  });
-  const totalPatchLogs = patchLogsQuery.data?.total ?? 0;
-
   if (minimized) {
     return (
       <div
@@ -57,67 +49,64 @@ export function PromotedCard({
   return (
     <div
       key="promoted-full"
-      className="rounded-xl border bg-card p-6 shadow-sm motion-safe:animate-in motion-safe:fade-in motion-safe:duration-500 motion-safe:ease-out"
+      className="flex flex-col overflow-hidden rounded-xl border bg-card shadow-sm motion-safe:animate-in motion-safe:fade-in motion-safe:duration-500 motion-safe:ease-out"
     >
-      <div className="flex items-start gap-3">
-        <CheckCircle2 className="mt-0.5 h-6 w-6 text-primary" />
-        <div className="flex-1">
-          <h3 className="text-lg font-semibold">버전 #{displayVersion.version_no} 확정 완료</h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {displayVersion.is_current
-              ? '이어서 편집하시려면 오른쪽 위 최소화 버튼을 눌러 캔버스로 돌아가세요.'
-              : '새 버전이 저장되었습니다.'}
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => setMinimized(true)}
-          aria-label="패널 최소화"
-          className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-        >
-          <Minimize2 className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="mt-5 flex items-center gap-1.5 text-xs text-muted-foreground">
-        <History className="h-3.5 w-3.5" />
-        변경 이력 {totalPatchLogs} 건 (확정 후 수정 시 기록됩니다)
-      </div>
-
-      {versions && versions.length > 1 && (
-        <VersionHistoryPanel
-          versions={versions}
-          onSwitched={() => setMinimized(true)}
-        />
-      )}
-
-      <div className="mt-5 flex flex-wrap justify-end gap-2">
-        <button
-          type="button"
-          onClick={onReupload}
-          className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
-        >
-          새 버전 업로드
-        </button>
-        {onStartBlank && (
+      <div className="p-6 pb-4">
+        <div className="flex items-start gap-3">
+          <CheckCircle2 className="mt-0.5 h-6 w-6 text-primary" />
+          <div className="flex-1">
+            <h3 className="text-lg font-semibold">버전 #{displayVersion.version_no} 확정 완료</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {displayVersion.is_current
+                ? '이어서 편집하시려면 오른쪽 위 최소화 버튼을 눌러 캔버스로 돌아가세요.'
+                : '새 버전이 저장되었습니다.'}
+            </p>
+          </div>
           <button
             type="button"
-            onClick={onStartBlank}
-            disabled={isStartingBlank}
-            className="rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+            onClick={() => setMinimized(true)}
+            aria-label="패널 최소화"
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
           >
-            {isStartingBlank ? '생성 중…' : '빈 도면으로 시작'}
+            <Minimize2 className="h-4 w-4" />
           </button>
+        </div>
+
+        {versions && versions.length > 1 && (
+          <VersionHistoryPanel
+            versions={versions}
+            onSwitched={() => setMinimized(true)}
+          />
         )}
-        <Link
-          to="/simulation"
-          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-        >
-          <Radio className="h-4 w-4" />
-          시뮬레이션 실행
-        </Link>
+
+        <div className="mt-5 flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={onReupload}
+            className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
+          >
+            새 버전 업로드
+          </button>
+          {onStartBlank && (
+            <button
+              type="button"
+              onClick={onStartBlank}
+              disabled={isStartingBlank}
+              className="rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+            >
+              {isStartingBlank ? '생성 중…' : '빈 도면으로 시작'}
+            </button>
+          )}
+          <Link
+            to="/simulation"
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <Radio className="h-4 w-4" />
+            시뮬레이션 실행
+          </Link>
+        </div>
       </div>
-      <p className="mt-3 text-[11px] text-muted-foreground">
+      <p className="border-t border-slate-100 px-6 py-2.5 text-[11px] leading-relaxed text-muted-foreground">
         ※ 우측 상단 아이콘으로 패널을 최소화하면 캔버스에서 도면을 확인할 수 있어요.
       </p>
     </div>

--- a/frontend/src/features/editor/VersionHistoryPanel.tsx
+++ b/frontend/src/features/editor/VersionHistoryPanel.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 /**
- * §7.3 버전 히스토리 패널. PromotedCard 하단에 토글로 노출.
+ * §7.3 도면 버전 패널. PromotedCard 하단에 토글로 노출.
  * - 클릭 → PATCH /scene-versions/{id}/set-current
  * - 휴지통 → DELETE /scene-versions/{id} (children · rf_runs · patch_logs cascade)
  */
@@ -47,7 +47,7 @@ export function VersionHistoryPanel({ versions, onSwitched }: Props) {
       >
         <span className="inline-flex items-center gap-1.5">
           <History className="h-3.5 w-3.5 text-muted-foreground" />
-          버전 히스토리 ({versions.length}개)
+          도면 버전 ({versions.length}개)
         </span>
         {open ? (
           <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -17,7 +17,7 @@ import {
   CANVAS_OBJECT_FILL,
   CANVAS_OBJECT_LABEL,
   CANVAS_OBJECT_STROKE,
-  CANVAS_WINDOW,
+  CANVAS_WINDOW_STROKE,
 } from '@/lib/canvas-scene-colors';
 
 export type MeasurementPointQuality = 'good' | 'warning' | 'poor';
@@ -558,7 +558,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
   const end = g.coordinates[g.coordinates.length - 1];
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW;
+  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW_STROKE;
   return (
     <line
       x1={start[0]}

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -19,7 +19,8 @@ import {
   CANVAS_OBJECT_FILL,
   CANVAS_OBJECT_LABEL,
   CANVAS_OBJECT_STROKE,
-  CANVAS_WINDOW,
+  CANVAS_WINDOW_LABEL,
+  CANVAS_WINDOW_STROKE,
 } from '@/lib/canvas-scene-colors';
 
 export interface PlacedAp {
@@ -423,7 +424,8 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
   const end = g.coordinates[g.coordinates.length - 1];
   if (!start || !end) return null;
   const isDoor = opening.opening_type === 'door';
-  const color = isDoor ? CANVAS_BLUE : CANVAS_WINDOW;
+  const strokeColor = isDoor ? CANVAS_BLUE : CANVAS_WINDOW_STROKE;
+  const labelColor = isDoor ? CANVAS_BLUE : CANVAS_WINDOW_LABEL;
   const label = isDoor ? '문' : '창문';
   const midX = (start[0] + end[0]) / 2;
   const midY = (start[1] + end[1]) / 2;
@@ -442,7 +444,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
         y1={start[1]}
         x2={end[0]}
         y2={end[1]}
-        stroke={color}
+        stroke={strokeColor}
         strokeWidth="5"
         strokeLinecap="butt"
         vectorEffect="non-scaling-stroke"
@@ -454,7 +456,7 @@ function OpeningShape({ opening }: { opening: DraftOpening }) {
         dominantBaseline="middle"
         fontSize={OPENING_LABEL_FONT_SIZE_M}
         fontWeight="500"
-        fill={color}
+        fill={labelColor}
         style={{ userSelect: 'none' }}
       >
         {label}

--- a/frontend/src/features/simulation/SimulationHistory.tsx
+++ b/frontend/src/features/simulation/SimulationHistory.tsx
@@ -29,12 +29,12 @@ export function SimulationHistory({ items, isLoading, showCompareButton, onSelec
 
   return (
     <section className="rounded-lg border border-slate-200 bg-white p-3">
-      <header className={cn(expanded && 'mb-2.5')}>
+      <header className={cn('py-[3px]', expanded && 'mb-3')}>
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          className="flex w-full items-start justify-between gap-2 text-left"
+          className="flex w-full items-start justify-between gap-2 py-[3px] text-left"
         >
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
@@ -45,7 +45,7 @@ export function SimulationHistory({ items, isLoading, showCompareButton, onSelec
               )}
             </div>
             {expanded && (
-              <p className="mt-0.5 pl-5 text-[11px] leading-relaxed text-slate-500">
+              <p className="mt-1 pl-5 text-[11px] leading-relaxed text-slate-500">
                 최근 실행 결과를 비교해볼 수 있습니다.
               </p>
             )}
@@ -124,7 +124,7 @@ function HistoryCard({
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <span className="text-xs font-medium text-slate-800">{title}</span>
+        <span className="text-[13px] font-medium text-slate-800">{title}</span>
         {isBest ? (
           <span className="shrink-0 rounded border border-blue-100 bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
             최고
@@ -143,7 +143,7 @@ function HistoryCard({
         )}
       </div>
 
-      <div className="mt-2 space-y-1">
+      <div className="mt-1 space-y-1">
         <p className="text-[11px] text-slate-500">
           평균 신호 세기
           <span className="ml-2 font-medium tabular-nums text-slate-700">
@@ -182,7 +182,7 @@ function HistoryCardSkeleton() {
         <div className="h-3.5 w-24 rounded bg-slate-100" />
         <div className="h-5 w-10 rounded bg-slate-100" />
       </div>
-      <div className="mt-2 space-y-1">
+      <div className="mt-1 space-y-1">
         <div className="h-2.5 w-36 rounded bg-slate-100" />
         <div className="flex items-center justify-between gap-2">
           <div className="h-2.5 w-32 rounded bg-slate-100" />

--- a/frontend/src/lib/canvas-scene-colors.ts
+++ b/frontend/src/lib/canvas-scene-colors.ts
@@ -12,8 +12,17 @@ export const CANVAS_OBJECT_LABEL = 'oklch(0.45 0.08 260)';
 
 export const CANVAS_AP_LABEL_BORDER = 'oklch(0.85 0.06 260)';
 
-/** 창문 — Tailwind teal-500 (#14B8A6), blue-500 과 톤 맞춘 세련된 민트 */
-export const CANVAS_WINDOW = 'oklch(0.704 0.14 182.503)';
+/** 창문 stroke — Aruba Blue (진한 톤, #4FB8B4) */
+export const CANVAS_WINDOW_STROKE = '#4FB8B4';
+
+/** 창문 라벨 — Aruba Blue deep (#1F7573) */
+export const CANVAS_WINDOW_LABEL = '#1F7573';
+
+/** 창문 선택/active — (#3BA8A4) */
+export const CANVAS_WINDOW_ACTIVE = '#3BA8A4';
+
+/** @deprecated stroke 전용 — CANVAS_WINDOW_STROKE 사용 */
+export const CANVAS_WINDOW = CANVAS_WINDOW_STROKE;
 
 /** 벽 */
 export const CANVAS_WALL = 'oklch(0.25 0 0)';

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -325,7 +325,7 @@ export default function MeasurementPage() {
           subtitle="공간 편집에서 도면을 분석·확정한 후 모바일 앱으로 실측을 진행할 수 있습니다."
         />
       ) : (
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_350px]">
           <section className="flex min-h-0 flex-col gap-3">
             <TabBar mode={mode} onChange={setMode} />
             <div className="relative min-h-0 flex-1 overflow-hidden rounded-2xl border bg-background shadow-sm">
@@ -836,8 +836,9 @@ function DiagnosticCard({
           예측·실측 통합 진단
         </h2>
         <p className="mt-3 text-xs text-muted-foreground">
-          측정 데이터가 없습니다. 모바일 앱으로 측정을 진행하면 가장 신호가 약한 지점의
-          진단이 자동으로 표시됩니다.
+          측정 데이터가 없습니다. 모바일 앱으로 측정을 진행하면 가장
+          <br />
+          신호가 약한 지점의 진단이 자동으로 표시됩니다.
         </p>
       </div>
     );

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { CheckCircle2, ChevronDown, Loader2, RotateCcw, Sparkles } from 'lucide-react';
+import { CheckCircle2, Loader2, RotateCcw, Sparkles } from 'lucide-react';
 import type { HttpError } from '@/api/client';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
@@ -20,6 +20,8 @@ import { ApRecommendationCanvas } from '@/features/ap-recommendation/ApRecommend
 import {
   AP_DEFAULT_Z_M,
   buildApRecommendationPayload,
+  getRecommendationRankUi,
+  getRecommendationReason,
   isValidSelectionBBox,
   normalizeRecommendations,
   type MeterBBox,
@@ -79,6 +81,7 @@ export default function MobileAppPage() {
   }, [apLayoutsQuery.data, latestRfRun?.request_json]);
 
   const [pageError, setPageError] = useState<string | null>(null);
+  const [hoveredRank, setHoveredRank] = useState<number | null>(null);
 
   const {
     selectionBBox,
@@ -92,6 +95,8 @@ export default function MobileAppPage() {
     persistSavedSession,
     resetSession,
   } = useApRecommendationSession(floorId, sceneVersionId);
+
+  const highlightedRank = selectedRank ?? hoveredRank;
 
   const recommendMutation = useApRecommendation();
   const createLayout = useCreateApLayout();
@@ -129,6 +134,7 @@ export default function MobileAppPage() {
     setRecommendations([]);
     setSelectedRank(null);
     setSavedRank(null);
+    setHoveredRank(null);
     setPageError(null);
     recommendMutation.reset();
   };
@@ -153,6 +159,7 @@ export default function MobileAppPage() {
 
     setPageError(null);
     setSavedRank(null);
+    setHoveredRank(null);
     recommendMutation.mutate(payload, {
       onSuccess: (data) => {
         const normalized = normalizeRecommendations(data);
@@ -171,6 +178,7 @@ export default function MobileAppPage() {
   const handleResetRecommendation = () => {
     resetSession();
     setPageError(null);
+    setHoveredRank(null);
     recommendMutation.reset();
   };
 
@@ -359,6 +367,8 @@ export default function MobileAppPage() {
                 onSelectionChange={handleSelectionChange}
                 recommendations={canvasRecommendations}
                 selectedRecommendationRank={selectedRank}
+                highlightedRank={highlightedRank}
+                onMarkerHover={setHoveredRank}
                 disabled={isRecommendPending || createLayout.isPending}
                 dragDisabled={isRecommendPending || hasRecommendation}
               />
@@ -391,6 +401,17 @@ export default function MobileAppPage() {
         >
           <div className="border-b border-slate-200 px-5 py-4">
             <h2 className="text-base font-semibold text-slate-900">최적 배치 추천</h2>
+            {recommendations.length > 0 && (
+              <p className="mt-1.5 text-xs leading-relaxed text-slate-500">
+                선택한 우선 개선 영역과 기존 AP 위치를 함께 고려해 추천했습니다.
+                {recommendations[0]?.candidates_evaluated > 0 && (
+                  <>
+                    {' '}
+                    (총 {recommendations[0].candidates_evaluated}개 후보 비교)
+                  </>
+                )}
+              </p>
+            )}
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
@@ -416,11 +437,13 @@ export default function MobileAppPage() {
                   <RecommendationCard
                     key={rec.rank}
                     rec={rec}
+                    reason={getRecommendationReason(rec, recommendations, selectionBBox)}
+                    highlighted={highlightedRank === rec.rank}
                     saved={savedRank === rec.rank}
                     saving={createLayout.isPending && selectedRank === rec.rank}
                     saveDisabled={!latestRfRunId || createLayout.isPending}
-                    hasExistingAps={existingAps.length > 0}
                     onSelect={() => handleSelectRecommendation(rec)}
+                    onHover={(active) => setHoveredRank(active ? rec.rank : null)}
                   />
                 ))}
               </div>
@@ -499,102 +522,64 @@ function EmptyState({ message }: { message: string }) {
 
 function RecommendationCard({
   rec,
+  reason,
+  highlighted,
   saved,
   saving,
   saveDisabled,
-  hasExistingAps,
   onSelect,
+  onHover,
 }: {
   rec: ApRecommendationResult;
+  reason: string;
+  highlighted: boolean;
   saved: boolean;
   saving: boolean;
   saveDisabled: boolean;
-  hasExistingAps: boolean;
   onSelect: () => void;
+  onHover: (active: boolean) => void;
 }) {
-  const [detailsOpen, setDetailsOpen] = useState(false);
+  const ui = getRecommendationRankUi(rec.rank);
+  const isPrimary = rec.rank === 1;
 
   return (
     <article
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
       className={cn(
-        'rounded-xl border bg-white p-4 transition-colors',
-        saved ? 'border-emerald-200 shadow-sm' : 'border-slate-200',
+        'rounded-xl border border-l-4 border-slate-200 bg-white p-4 transition-colors',
+        ui.cardAccentClass,
+        isPrimary && !saved && ui.cardEmphasisClass,
+        highlighted && !saved && 'shadow-sm',
+        saved && 'border-l-emerald-500 ring-1 ring-emerald-100',
       )}
     >
       <div className="flex items-start gap-3">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-sm font-bold text-white">
-          AP
+        <div
+          className={cn(
+            'flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold',
+            saved ? 'bg-emerald-500 text-white' : ui.badgeClass,
+          )}
+        >
+          {rec.rank}
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-semibold leading-snug text-slate-900">
-            이 위치에 AP를 설치하는 것을
-            <br />
-            추천합니다
-          </h3>
-          <p className="mt-1.5 text-xs leading-relaxed text-slate-500">
-            선택한 영역을 더 안정적으로 커버할 수 있는
-            <br />
-            위치입니다.
-          </p>
+          <h3 className="text-sm font-semibold leading-snug text-slate-900">{ui.title}</h3>
+          <p className="mt-1 text-xs leading-relaxed text-slate-600">{reason}</p>
         </div>
       </div>
 
-      <div className="mt-4 space-y-1.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs">
-        <div>
-          <p className="text-slate-500">도면 기준 위치</p>
-          <p className="mt-0.5 font-medium text-slate-900">
-            가로 {rec.recommended_x.toFixed(0)}m · 세로 {rec.recommended_y.toFixed(0)}m
-          </p>
-        </div>
-        {rec.candidates_evaluated > 0 && (
-          <p className="text-slate-500">
-            총 {rec.candidates_evaluated}개 후보 위치를 비교했습니다.
-          </p>
-        )}
-      </div>
-
-      <div className="mt-4">
-        <p className="text-xs font-semibold text-slate-900">추천 이유</p>
-        <ul className="mt-1.5 list-inside list-disc space-y-1 text-xs leading-relaxed text-slate-500">
-          <li>선택한 우선 개선 영역을 기준으로 계산했습니다.</li>
-          {hasExistingAps && <li>기존 AP 위치를 함께 고려했습니다.</li>}
-        </ul>
-      </div>
-
-      <div className="mt-3 border-t border-slate-200 pt-3">
-        <button
-          type="button"
-          onClick={() => setDetailsOpen((v) => !v)}
-          className="flex w-full items-center justify-between text-xs text-slate-500 hover:text-slate-700"
-          aria-expanded={detailsOpen}
-        >
-          <span>상세 정보</span>
-          <ChevronDown
-            className={cn('h-3.5 w-3.5 transition-transform', detailsOpen && 'rotate-180')}
-            aria-hidden="true"
-          />
-        </button>
-        {detailsOpen && (
-          <p className="mt-2 text-[11px] text-slate-500">
-            상세 점수: {rec.score.toFixed(1)}
-          </p>
-        )}
+      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-xs">
+        <p className="text-slate-500">도면 기준 위치</p>
+        <p className="mt-0.5 font-medium tabular-nums text-slate-900">
+          가로 {rec.recommended_x.toFixed(1)}m · 세로 {rec.recommended_y.toFixed(1)}m
+        </p>
       </div>
 
       {saved ? (
-        <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
-          <div className="flex gap-2.5">
-            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" aria-hidden="true" />
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-emerald-900">AP 배치로 저장 완료</p>
-              <p className="mt-1 text-xs leading-relaxed text-emerald-800/90">
-                저장된 AP 배치 목록에 반영됩니다.
-              </p>
-              <p className="mt-1.5 text-xs leading-relaxed text-emerald-800/75">
-                다른 영역을 추천하려면 다시 생성하기를 눌러주세요.
-              </p>
-            </div>
-          </div>
+        <div className="mt-3 flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5">
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+          <p className="text-sm font-medium text-emerald-900">AP 배치로 저장됨</p>
         </div>
       ) : (
         <button
@@ -602,8 +587,8 @@ function RecommendationCard({
           onClick={onSelect}
           disabled={saveDisabled}
           className={cn(
-            'mt-4 w-full rounded-lg border border-slate-200 bg-slate-50 py-2.5 text-sm font-medium text-slate-900 transition-colors',
-            'hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50',
+            'mt-3 w-full rounded-lg border border-slate-200 bg-white py-2.5 text-sm font-medium text-slate-900 transition-colors',
+            'hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50',
           )}
         >
           {saving ? (

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -586,11 +586,8 @@ function RecommendationCard({
           onClick={onSelect}
           disabled={saveDisabled}
           className={cn(
-            'flex h-11 w-full items-center justify-center rounded-xl text-sm font-medium transition-colors',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            isPrimary
-              ? 'border border-[#3B82F6] bg-[#3B82F6] text-white hover:bg-[#2563EB] hover:border-[#2563EB]'
-              : 'border border-[#CBD5E1] bg-white text-[#0F172A] hover:border-[#94A3B8] hover:bg-[#F8FAFC]',
+            'flex h-11 w-full items-center justify-center rounded-xl border border-[#CBD5E1] bg-white text-sm font-medium text-[#0F172A] transition-colors',
+            'hover:border-[#94A3B8] hover:bg-[#F8FAFC] disabled:cursor-not-allowed disabled:opacity-50',
           )}
         >
           {saving ? (

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { CheckCircle2, Loader2, RotateCcw, Sparkles } from 'lucide-react';
+import { Check, CheckCircle2, Loader2, RotateCcw, Sparkles } from 'lucide-react';
 import type { HttpError } from '@/api/client';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
@@ -37,7 +37,11 @@ const PROGRESS_STEPS = [
   { id: 3, label: '추천 위치 선택' },
 ] as const;
 
-const CARD_BORDER = 'border-slate-200';
+const CARD_BORDER = 'border-[#E5E7EB]';
+
+/** 추천 패널 스크롤 영역 — 연한 하늘/회색 scrollbar */
+const PANEL_SCROLL =
+  '[scrollbar-width:thin] [scrollbar-color:#BDE0FE_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[#CBD5E1] hover:[&::-webkit-scrollbar-thumb]:bg-[#A2D2FF]';
 
 export default function MobileAppPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -340,12 +344,20 @@ export default function MobileAppPage() {
         </div>
       </header>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 px-6 pb-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:gap-5 lg:px-8">
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 px-6 pb-5 lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-5 lg:px-8">
         <div className="flex min-h-0 flex-col gap-3">
+          <div className="w-full shrink-0 rounded-lg border border-[#E5E7EB] bg-white px-8 py-3 sm:px-10">
+            <ProgressStepper
+              activeStep={activeStep}
+              pageStatus={pageStatus}
+              registerStepIconRef={registerStepIconRef}
+            />
+          </div>
+
           <div
             ref={canvasAreaRef}
             className={cn(
-              'relative flex min-h-[min(52vh,32rem)] flex-1 flex-col overflow-hidden rounded-xl border bg-white shadow-sm',
+              'relative flex min-h-[min(52vh,32rem)] flex-1 flex-col overflow-hidden rounded-xl border bg-white',
               CARD_BORDER,
             )}
           >
@@ -378,31 +390,18 @@ export default function MobileAppPage() {
               <CanvasStatusBubble message={statusHint} leftPx={bubbleLeftPx} />
             )}
           </div>
-
-          <div
-            className={cn(
-              'shrink-0 rounded-lg border bg-white px-3 py-2.5',
-              CARD_BORDER,
-            )}
-          >
-            <ProgressStepper
-              activeStep={activeStep}
-              pageStatus={pageStatus}
-              registerStepIconRef={registerStepIconRef}
-            />
-          </div>
         </div>
 
         <aside
           className={cn(
-            'flex min-h-[260px] flex-col overflow-hidden rounded-xl border bg-white shadow-sm lg:min-h-0 lg:self-stretch',
+            'flex min-h-[260px] flex-col overflow-hidden rounded-xl border bg-white lg:min-h-0 lg:self-stretch',
             CARD_BORDER,
           )}
         >
-          <div className="border-b border-slate-200 px-5 py-4">
-            <h2 className="text-base font-semibold text-slate-900">최적 배치 추천</h2>
+          <div className="border-b border-[#E5E7EB] px-5 py-4">
+            <h2 className="text-base font-semibold text-[#0F172A]">최적 배치 추천</h2>
             {recommendations.length > 0 && (
-              <p className="mt-1.5 text-xs leading-relaxed text-slate-500">
+              <p className="mt-1.5 text-xs leading-relaxed text-[#64748B]">
                 선택한 우선 개선 영역과 기존 AP 위치를 함께 고려해 추천했습니다.
                 {recommendations[0]?.candidates_evaluated > 0 && (
                   <>
@@ -414,25 +413,25 @@ export default function MobileAppPage() {
             )}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div className={cn('min-h-0 flex-1 overflow-y-auto bg-[#F8FAFC] p-4', PANEL_SCROLL)}>
             {recommendations.length === 0 ? (
               <div className="flex h-full min-h-[200px] flex-col items-center justify-center gap-2 px-4 text-center">
-                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100">
-                  <Sparkles className="h-5 w-5 text-slate-400" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#E2E8F0] bg-white">
+                  <Sparkles className="h-5 w-5 text-[#94A3B8]" />
                 </div>
-                <p className="text-sm font-medium text-slate-700">
+                <p className="text-sm font-medium text-[#0F172A]">
                   {pageStatus === 'loading'
                     ? '최적 위치를 계산하고 있습니다…'
                     : '추천 결과가 아직 없습니다'}
                 </p>
                 {pageStatus !== 'loading' && (
-                  <p className="text-xs leading-relaxed text-slate-500">
+                  <p className="text-xs leading-relaxed text-[#64748B]">
                     도면에서 개선이 필요한 영역을 드래그한 뒤, 최적 배치 추천을 실행하세요.
                   </p>
                 )}
               </div>
             ) : (
-              <div className="space-y-3">
+              <div className="space-y-4">
                 {recommendations.map((rec) => (
                   <RecommendationCard
                     key={rec.rank}
@@ -464,18 +463,18 @@ function CanvasStatusBubble({
 }) {
   return (
     <div
-      className="pointer-events-none absolute bottom-3 z-10 -translate-x-1/2"
+      className="pointer-events-none absolute top-3 z-10 -translate-x-1/2"
       style={{ left: leftPx }}
     >
       <div
         key={message}
         className="relative w-max max-w-md animate-bubble-rise rounded-xl border border-sky-200 bg-sky-50/95 px-4 py-2.5 shadow-sm backdrop-blur-sm"
       >
-        <p className="text-center text-xs leading-relaxed text-sky-900/90">{message}</p>
         <span
-          className="absolute -bottom-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 border-b border-r border-sky-200 bg-sky-50/95"
+          className="absolute -top-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 border-l border-t border-sky-200 bg-sky-50/95"
           aria-hidden="true"
         />
+        <p className="text-center text-xs leading-relaxed text-sky-900/90">{message}</p>
       </div>
     </div>
   );
@@ -547,39 +546,39 @@ function RecommendationCard({
       onMouseEnter={() => onHover(true)}
       onMouseLeave={() => onHover(false)}
       className={cn(
-        'rounded-xl border border-l-4 border-slate-200 bg-white p-4 transition-colors',
+        'flex flex-col gap-4 rounded-xl border border-l-4 bg-white p-5 transition-colors',
+        CARD_BORDER,
         ui.cardAccentClass,
-        isPrimary && !saved && ui.cardEmphasisClass,
-        highlighted && !saved && 'shadow-sm',
-        saved && 'border-l-emerald-500 ring-1 ring-emerald-100',
+        highlighted && isPrimary && !saved && ui.cardHighlightClass,
+        highlighted && !isPrimary && !saved && 'bg-[#EAF4FF]/30',
       )}
     >
       <div className="flex items-start gap-3">
         <div
           className={cn(
-            'flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold',
-            saved ? 'bg-emerald-500 text-white' : ui.badgeClass,
+            'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs',
+            saved ? 'bg-[#3B82F6] text-white font-bold' : ui.badgeClass,
           )}
         >
           {rec.rank}
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-semibold leading-snug text-slate-900">{ui.title}</h3>
-          <p className="mt-1 text-xs leading-relaxed text-slate-600">{reason}</p>
+          <h3 className="text-sm font-medium leading-snug text-[#0F172A]">{ui.title}</h3>
+          <p className="mt-1.5 text-xs font-normal leading-relaxed text-[#64748B]">{reason}</p>
         </div>
       </div>
 
-      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-xs">
-        <p className="text-slate-500">도면 기준 위치</p>
-        <p className="mt-0.5 font-medium tabular-nums text-slate-900">
+      <div className="rounded-lg bg-[#F8FAFC] px-3 py-2.5 text-xs">
+        <p className="text-[#64748B]">도면 기준 위치</p>
+        <p className="mt-1 font-medium tabular-nums text-[#0F172A]">
           가로 {rec.recommended_x.toFixed(1)}m · 세로 {rec.recommended_y.toFixed(1)}m
         </p>
       </div>
 
       {saved ? (
-        <div className="mt-3 flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5">
-          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
-          <p className="text-sm font-medium text-emerald-900">AP 배치로 저장됨</p>
+        <div className="flex items-center gap-2 rounded-lg bg-[#F8FAFC] px-3 py-2.5">
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-[#3B82F6]" aria-hidden="true" />
+          <p className="text-sm font-normal text-[#0F172A]">AP 배치로 저장됨</p>
         </div>
       ) : (
         <button
@@ -587,8 +586,11 @@ function RecommendationCard({
           onClick={onSelect}
           disabled={saveDisabled}
           className={cn(
-            'mt-3 w-full rounded-lg border border-slate-200 bg-white py-2.5 text-sm font-medium text-slate-900 transition-colors',
-            'hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50',
+            'flex h-11 w-full items-center justify-center rounded-xl text-sm font-medium transition-colors',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            isPrimary
+              ? 'border border-[#3B82F6] bg-[#3B82F6] text-white hover:bg-[#2563EB] hover:border-[#2563EB]'
+              : 'border border-[#CBD5E1] bg-white text-[#0F172A] hover:border-[#94A3B8] hover:bg-[#F8FAFC]',
           )}
         >
           {saving ? (
@@ -614,64 +616,67 @@ function ProgressStepper({
   pageStatus: PageStatus;
   registerStepIconRef?: (index: number, el: HTMLDivElement | null) => void;
 }) {
-  return (
-    <div className="flex justify-center">
-      <ol className="flex items-center">
-        {PROGRESS_STEPS.map((step, index) => {
-          const done =
-            step.id < activeStep ||
-            (step.id === 1 && pageStatus !== 'idle') ||
-            (step.id === 2 && (pageStatus === 'success' || pageStatus === 'loading'));
-          const current = step.id === activeStep && pageStatus !== 'error';
-          const isLast = index === PROGRESS_STEPS.length - 1;
+  const isStepDone = (stepId: number) =>
+    stepId < activeStep ||
+    (stepId === 1 && pageStatus !== 'idle') ||
+    (stepId === 2 && (pageStatus === 'success' || pageStatus === 'loading'));
 
-          return (
-            <li key={step.id} className="flex items-center">
-              <div className="flex flex-col items-center gap-1.5">
-                <div
-                  ref={(el) => registerStepIconRef?.(index, el)}
-                  className={cn(
-                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
-                    done &&
-                      !current &&
-                      'bg-emerald-500 text-white ring-1 ring-emerald-200/80',
-                    current &&
-                      'bg-blue-500 text-white ring-4 ring-blue-100 shadow-sm shadow-blue-500/20',
-                    !done && !current && 'bg-slate-200 text-slate-500',
-                  )}
-                >
-                  {done && !current ? (
-                    <CheckCircle2 className="h-4 w-4" />
-                  ) : (
-                    step.id
-                  )}
-                </div>
-                <span
-                  className={cn(
-                    'w-[7.5rem] text-center text-xs leading-snug',
-                    current
-                      ? 'font-medium text-slate-900'
-                      : done
-                        ? 'text-slate-600'
-                        : 'text-slate-500',
-                  )}
-                >
-                  {step.label}
-                </span>
+  return (
+    <ol className="grid w-full grid-cols-3 items-start">
+      {PROGRESS_STEPS.map((step, index) => {
+        const done = isStepDone(step.id);
+        const current = step.id === activeStep && pageStatus !== 'error';
+        const isFirst = index === 0;
+        const isLast = index === PROGRESS_STEPS.length - 1;
+        const lineBeforeDone = !isFirst && isStepDone(PROGRESS_STEPS[index - 1]!.id);
+        const lineAfterDone = !isLast && isStepDone(step.id);
+
+        return (
+          <li key={step.id} className="flex min-w-0 flex-col items-center">
+            <div className="flex w-full items-center">
+              <div
+                className={cn(
+                  'h-px flex-1',
+                  isFirst ? 'bg-transparent' : lineBeforeDone ? 'bg-primary/20' : 'bg-[#E5E7EB]',
+                )}
+                aria-hidden="true"
+              />
+              <div
+                ref={(el) => registerStepIconRef?.(index, el)}
+                className={cn(
+                  'mx-2 flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[10px] font-medium',
+                  done &&
+                    !current &&
+                    'border border-primary/25 bg-primary/10 text-primary',
+                  current && 'bg-primary text-primary-foreground',
+                  !done && !current && 'border border-[#E5E7EB] bg-white text-[#64748B]',
+                )}
+              >
+                {done && !current ? (
+                  <Check className="h-2.5 w-2.5" strokeWidth={2.5} aria-hidden="true" />
+                ) : (
+                  step.id
+                )}
               </div>
-              {!isLast && (
-                <div
-                  className={cn(
-                    'mx-3 mb-[1.625rem] h-0.5 w-20 sm:w-28',
-                    step.id < activeStep ? 'bg-emerald-200' : 'bg-slate-200',
-                  )}
-                  aria-hidden="true"
-                />
+              <div
+                className={cn(
+                  'h-px flex-1',
+                  isLast ? 'bg-transparent' : lineAfterDone ? 'bg-primary/20' : 'bg-[#E5E7EB]',
+                )}
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className={cn(
+                'mt-1.5 w-full px-1 text-center text-xs leading-snug',
+                current ? 'font-normal text-primary' : 'font-normal text-[#64748B]',
               )}
-            </li>
-          );
-        })}
-      </ol>
-    </div>
+            >
+              {step.label}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
   );
 }

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -293,7 +293,7 @@ export default function SimulationPage() {
           ctaTo="/editor"
         />
       ) : (
-        <div className="mt-4 grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-[1fr_300px]">
+        <div className="mt-4 grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-[1fr_340px]">
           <div className="relative min-h-0 overflow-hidden rounded-lg border border-slate-200 bg-white">
             {state === 'idle' ? (
               <>

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -22,21 +22,26 @@ export interface ApRecommendationRequest {
   shadow_penalty?: number;
 }
 
-/** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
-export interface ApRecommendationResponse {
+/** POST /ap-recommendation 응답 내 단일 추천 항목. */
+export interface ApRecommendationItem {
+  rank: number;
   recommended_x: number;
   recommended_y: number;
   score: number;
+}
+
+/** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
+export interface ApRecommendationResponse {
+  recommendations: ApRecommendationItem[];
   status: string;
   candidates_evaluated: number;
 }
 
-/** UI 표시용 — 단일/복수 응답 모두 배열로 normalize. */
+/** UI 표시용. */
 export interface ApRecommendationResult {
   rank: number;
   recommended_x: number;
   recommended_y: number;
   score: number;
-  status: string;
   candidates_evaluated: number;
 }


### PR DESCRIPTION
- AP 배치 추천 API가 단일 결과 대신 상위 N개(기본 3개) 순위를 반환하도록 확장하고, 프론트엔드에 1·2·3순위 카드·캔버스 마커 UI를 추가
- AP 추천·시뮬레이션 이력·에디터 확정 패널 등 주요 화면을 SaaS 대시보드 톤(blue 계열, 얇은 border, compact spacing)으로 정리
- 창문 색상(Aruba Blue), 시뮬·실측 사이드바 레이아웃, 버전 확정 패널 문구/구조를 함께 다듬음

## 주요 변경
### AP 배치 추천 (backend + frontend)
- `ApRecommendationResponse`를 `recommendations[]` 배열 구조로 변경, grid search 상위 N개 반환
- 1·2·3순위 카드·마커·accent line을 하늘색 계열로 통일
- 스텝퍼를 도면 상단으로 이동, 안내 말풍선 꼬리 방향 조정
- 우선 개선 영역 오버레이를 개나리색 pill badge 스타일로 개선
- 추천 이유 문구를 커버 기준 설명 중심으로 정리
- 1위 카드 버튼을 2·3위와 동일한 outline 스타일로 통일
### 시뮬레이션 / 실측 / 에디터
- 시뮬레이션 기록 카드 날짜·간격 미세 조정
- 창문 색상 Aruba Blue 적용, 시뮬·실측 사이드바 레이아웃 조정
- 버전 확정 패널에서 변경 이력 metadata 제거, 최소화 안내를 footer로 분리
- 「버전 히스토리」→「도면 버전」 라벨 변경