### PR TITLE
feat: 히트맵 색감 변경, 랜딩페이지 추가

### DIFF
--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -728,9 +728,17 @@ def evaluate_calibration_run(
     ]
     invalid_points = [p for p in sampled if p.invalid_reason is not None]
     if not valid_calibration:
+        outside = sum(1 for p in invalid_points if p.invalid_reason == "outside_bounds")
+        invalid_cell = sum(1 for p in invalid_points if p.invalid_reason == "invalid_radio_cell")
         raise AppError(
             ErrorCode.INVALID_REQUEST_BODY,
-            "No valid calibration points remain after radio map sampling.",
+            (
+                "측정점이 시뮬레이션 영역 밖에 있어 보정할 수 없습니다. "
+                f"(전체 {len(sampled)}점, 영역 밖 {outside}점, 무효 셀 {invalid_cell}점). "
+                f"시뮬 영역: x={radio_map.min_x:.1f}~{radio_map.max_x:.1f}m, "
+                f"y={radio_map.min_y:.1f}~{radio_map.max_y:.1f}m. "
+                "모바일 앱에서 도면 벽 안쪽의 시작 위치를 지정한 뒤 다시 측정해주세요."
+            ),
             400,
         )
     rssi_transfer = _fit_rssi_transfer(valid_calibration)

--- a/backend/app/services/rf/measurement_estimation/heatmap.py
+++ b/backend/app/services/rf/measurement_estimation/heatmap.py
@@ -1,9 +1,15 @@
 """GP 보간 결과 → matplotlib heatmap PNG → S3 업로드.
 
 mean heatmap (예측 RSSI) 과 uncertainty heatmap (표준편차) 두 개 PNG 생성.
-mean 은 jet/viridis 같은 신호 강도 컬러맵, uncertainty 는 흑백 / hot 컬러맵 사용.
+mean 은 warm-thermal 컬러맵 (frontend rssi-colormap.ts 와 동일 palette),
+uncertainty 는 흑백 계열 사용.
 """
 from __future__ import annotations
+from .gp_estimator import CoverageEstimate
+from app.services import _s3
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 
 import io
 import logging
@@ -12,11 +18,26 @@ import uuid
 import matplotlib
 
 matplotlib.use("Agg")  # 서버 환경 — GUI backend 비활성
-import matplotlib.pyplot as plt
-import numpy as np
 
-from app.services import _s3
-from .gp_estimator import CoverageEstimate
+# frontend rssi-colormap.ts 의 RSSI_HEATMAP_STOPS_RGB 와 동일한 stops.
+# t=0 (weak) → medium blue, t=1 (strong) → medium-bright red.
+_RSSI_CMAP = mcolors.LinearSegmentedColormap.from_list(
+    "wifi_thermal",
+    [
+        np.array([30,  80, 235]) / 255,
+        np.array([ 0, 140, 255]) / 255,
+        np.array([ 0, 210, 255]) / 255,
+        np.array([ 0, 240, 190]) / 255,
+        np.array([30, 240,  70]) / 255,
+        np.array([160, 240,   0]) / 255,
+        np.array([255, 235,   0]) / 255,
+        np.array([255, 160,   0]) / 255,
+        np.array([255,  55,   0]) / 255,
+        np.array([235,   0,   0]) / 255,
+        np.array([195,   0,   0]) / 255,
+    ],
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -112,21 +133,20 @@ def render_and_upload(
         (mean_s3_uri, uncertainty_s3_uri) — s3:// 형식.
     """
     overlay = (
-        [(p[0], p[1]) for p in measurement_points] if measurement_points else None
+        [(p[0], p[1])
+         for p in measurement_points] if measurement_points else None
     )
 
     mean = estimate.mean_grid
     std = estimate.std_grid
 
     # mean 색 범위 — _resolve_mean_color_limits 가 narrow spread / NaN / empty 안전 처리.
-    # cmap='inferno' — Sionna RT heatmap, frontend Legend/측정점 그라데이션과 동일 palette.
-    # (이전엔 jet 라서 frontend 측정점 inferno 와 색 mismatch 발생.)
     mean_vmin, mean_vmax = _resolve_mean_color_limits(mean)
     mean_png = _render_to_png(
         mean,
         estimate.xs,
         estimate.ys,
-        cmap="inferno",
+        cmap=_RSSI_CMAP,
         vmin=mean_vmin,
         vmax=mean_vmax,
         title=f"Estimated RSSI Coverage (GP, N={estimate.input_point_count})",

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { dbmToHeatmapColor } from '@/lib/rssi-colormap';
 import type {
   CalibrationEvaluationResponse,
   CalibrationRun,
@@ -33,6 +34,7 @@ const SPACE_TYPE_OPTIONS: { value: SpaceType; label: string }[] = [
 export type CalibrationGate =
   | 'no_measurement'
   | 'insufficient_points'
+  | 'outside_sim_area'
   | 'no_simulation'
   | 'ready';
 
@@ -375,6 +377,21 @@ function CalibrationGateNotice({
     );
   }
 
+  if (gate === 'outside_sim_area') {
+    return (
+      <div className="mt-3 flex gap-2.5 rounded-xl border border-amber-200/80 bg-amber-50 px-3 py-2.5">
+        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-medium text-foreground">측정 위치가 도면 밖입니다</p>
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {disabledReason ??
+              '모바일 앱에서 도면 벽 안쪽의 시작 위치를 지정하고, 건물 안을 따라 다시 측정해주세요.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="mt-3 flex gap-2.5 rounded-xl border border-slate-200/80 bg-slate-50 px-3 py-2.5">
       <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-500" />
@@ -481,17 +498,17 @@ function CalibrationEvaluationPanel({
     'metric_point_source' in evaluation.evaluation.split
       ? String((evaluation.evaluation.split as Record<string, unknown>).metric_point_source)
       : 'reference';
+  const comparisonLabelKo = formatComparisonPointSource(comparisonLabel);
   const frequencyText = formatFrequencyCheck(evaluation);
   const fmt = (v: unknown, digits = 1) =>
     typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
   return (
     <section className="mt-3 space-y-3 rounded-lg border bg-muted/30 p-3">
       <div>
-        <p className="text-[11px] font-semibold text-foreground">
-          Reference comparison 기준
-        </p>
+        <p className="text-[11px] font-semibold text-foreground">참조 비교 기준</p>
         <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-          Metrics use {comparisonLabel} points as the measured comparison data. Reference maps are interpolated measurements, not absolute ground truth.
+          지표는 {comparisonLabelKo} 포인트를 실측 비교 데이터로 사용합니다. 참조맵은 측정값을
+          보간한 결과이며, 절대적인 정답(ground truth)이 아닙니다.
         </p>
         {frequencyText && (
           <p className="mt-1 rounded-md border bg-background px-2 py-1 text-[10px] leading-relaxed text-muted-foreground">
@@ -506,7 +523,7 @@ function CalibrationEvaluationPanel({
         className="inline-flex w-full items-center justify-center gap-1 rounded-md border bg-background px-2 py-1.5 text-[11px] font-medium hover:bg-accent"
       >
         <Maximize2 className="h-3 w-3" />
-        Detail view
+        자세히 보기
       </button>
       {onAddReferenceMeasurement && (
         <button
@@ -535,10 +552,10 @@ function CalibrationEvaluationPanel({
 
       <div className="rounded-md border bg-background p-2 text-[11px]">
         <div className="grid grid-cols-4 gap-2 font-semibold text-muted-foreground">
-          <span>Metric</span>
-          <span>Before</span>
-          <span>After</span>
-          <span>Improvement</span>
+          <span>지표</span>
+          <span>보정 전</span>
+          <span>보정 후</span>
+          <span>개선</span>
         </div>
         <MetricRow
           label="MAE"
@@ -559,18 +576,18 @@ function CalibrationEvaluationPanel({
 
       <details className="rounded-md border bg-background text-[11px]">
         <summary className="cursor-pointer px-3 py-2 font-medium">
-          Reference comparison errors ({comparisonPoints.length})
+          참조 비교 오차 ({comparisonPoints.length}개)
         </summary>
         <div className="max-h-48 overflow-auto">
           <table className="w-full min-w-[520px] text-left">
             <thead className="sticky top-0 bg-background text-muted-foreground">
               <tr>
-                <th className="px-2 py-1">Point</th>
-                <th className="px-2 py-1">Measured</th>
-                <th className="px-2 py-1">Baseline</th>
-                <th className="px-2 py-1">Calibrated</th>
-                <th className="px-2 py-1">Before</th>
-                <th className="px-2 py-1">After</th>
+                <th className="px-2 py-1">포인트</th>
+                <th className="px-2 py-1">실측</th>
+                <th className="px-2 py-1">보정 전</th>
+                <th className="px-2 py-1">보정 후</th>
+                <th className="px-2 py-1">보정 전 오차</th>
+                <th className="px-2 py-1">보정 후 오차</th>
               </tr>
             </thead>
             <tbody>
@@ -637,6 +654,7 @@ function CalibrationEvaluationDetailModal({
     'metric_point_source' in evaluation.evaluation.split
       ? String((evaluation.evaluation.split as Record<string, unknown>).metric_point_source)
       : 'reference';
+  const comparisonLabelKo = formatComparisonPointSource(comparisonLabel);
   const frequencyText = formatFrequencyCheck(evaluation);
   const fmt = (v: unknown, digits = 1) =>
     typeof v === 'number' && Number.isFinite(v) ? v.toFixed(digits) : '--';
@@ -652,9 +670,10 @@ function CalibrationEvaluationDetailModal({
       >
         <header className="flex items-center justify-between gap-3 border-b px-5 py-3">
           <div>
-            <h2 className="text-base font-semibold">3-way RSSI map comparison</h2>
+            <h2 className="text-base font-semibold">3-way RSSI 맵 비교</h2>
             <p className="text-xs text-muted-foreground">
-              Same floorplan, grid, bounds, and RSSI color scale. Metrics use {comparisonLabel} points as measured comparison data.
+              동일 도면·격자·범위·색상 스케일 기준. 지표는 {comparisonLabelKo} 포인트를 실측
+              비교 데이터로 사용합니다.
             </p>
             {frequencyText && (
               <p className="mt-1 text-xs text-muted-foreground">{frequencyText}</p>
@@ -677,7 +696,7 @@ function CalibrationEvaluationDetailModal({
               type="button"
               onClick={onClose}
               className="inline-flex h-8 w-8 items-center justify-center rounded-md border hover:bg-accent"
-              aria-label="Close"
+              aria-label="닫기"
             >
               <X className="h-4 w-4" />
             </button>
@@ -702,15 +721,15 @@ function CalibrationEvaluationDetailModal({
 
           <div className="mt-4 grid gap-4 lg:grid-cols-[24rem_1fr]">
             <div className="rounded-lg border bg-muted/20 p-4 text-sm">
-              <p className="font-semibold">Comparison metrics</p>
+              <p className="font-semibold">비교 지표</p>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                 MAE는 각 측정 지점의 평균 오차입니다. RMSE는 큰 오차를 더 크게 반영해서, 보정 후에도 크게 틀린 구간이 남아 있는지 보여줍니다.
               </p>
               <div className="mt-3 grid grid-cols-4 gap-2 text-xs font-semibold text-muted-foreground">
-                <span>Metric</span>
-                <span>Before</span>
-                <span>After</span>
-                <span>Improvement</span>
+                <span>지표</span>
+                <span>보정 전</span>
+                <span>보정 후</span>
+                <span>개선</span>
               </div>
               <MetricRow
                 label="MAE"
@@ -727,19 +746,19 @@ function CalibrationEvaluationDetailModal({
               <div className="mt-4 flex flex-wrap gap-3 text-xs text-muted-foreground">
                 <span className="inline-flex items-center gap-1">
                   <span className="h-2.5 w-2.5 rounded-full bg-[#0f766e]" />
-                  calibration
+                  보정용
                 </span>
                 <span className="inline-flex items-center gap-1">
                   <span className="h-0 w-0 border-x-[5px] border-b-[9px] border-x-transparent border-b-[#dc2626]" />
-                  comparison
+                  비교용
                 </span>
               </div>
             </div>
 
             <div className="rounded-lg border bg-background p-4 text-xs">
               <div className="mb-3 flex items-center justify-between gap-3">
-                <p className="font-semibold">Point error chart</p>
-                <p className="text-muted-foreground">Before vs after, dB</p>
+                <p className="font-semibold">포인트별 오차</p>
+                <p className="text-muted-foreground">보정 전 vs 보정 후 (dB)</p>
               </div>
               <ErrorBarChart points={comparisonPoints} />
             </div>
@@ -747,18 +766,18 @@ function CalibrationEvaluationDetailModal({
 
           <div className="mt-4 rounded-lg border bg-background text-xs">
               <div className="border-b px-4 py-3 font-semibold">
-                Reference comparison errors ({comparisonPoints.length})
+                참조 비교 오차 ({comparisonPoints.length}개)
               </div>
               <div className="max-h-72 overflow-auto">
                 <table className="w-full min-w-[640px] text-left">
                   <thead className="sticky top-0 bg-background text-muted-foreground">
                     <tr>
-                      <th className="px-3 py-2">Point</th>
-                      <th className="px-3 py-2">Measured</th>
-                      <th className="px-3 py-2">Baseline Pred</th>
-                      <th className="px-3 py-2">Calibrated Pred</th>
-                      <th className="px-3 py-2">Before Error</th>
-                      <th className="px-3 py-2">After Error</th>
+                      <th className="px-3 py-2">포인트</th>
+                      <th className="px-3 py-2">실측</th>
+                      <th className="px-3 py-2">보정 전 예측</th>
+                      <th className="px-3 py-2">보정 후 예측</th>
+                      <th className="px-3 py-2">보정 전 오차</th>
+                      <th className="px-3 py-2">보정 후 오차</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -829,11 +848,11 @@ function MiniRssiMap({
     <div className={size === 'large' ? 'rounded-lg border bg-background p-3' : 'rounded-md border bg-background p-2'}>
       <div className="mb-2 flex items-center justify-between gap-2">
         <p className={size === 'large' ? 'truncate text-sm font-semibold' : 'truncate text-[11px] font-semibold'}>
-          {map.label}
+          {formatEvaluationMapLabel(map.label)}
         </p>
         {size === 'large' && (
           <span className="text-[11px] text-muted-foreground">
-            {colorScale.min_dbm} to {colorScale.max_dbm} dBm
+            {colorScale.min_dbm} ~ {colorScale.max_dbm} dBm
           </span>
         )}
       </div>
@@ -923,15 +942,15 @@ function pointTooltip(
   kind: 'calibration' | 'comparison',
 ): string {
   const pointName = `P${String(index + 1).padStart(2, '0')}`;
-  const purpose = kind === 'calibration' ? 'calibration' : 'comparison';
+  const purpose = kind === 'calibration' ? '보정용' : '비교용';
   const lines = [
     `${pointName} (${purpose})`,
-    `Measured RSSI: ${formatTooltipNumber(point.rssi_dbm, 'dBm')}`,
-    `Baseline pred: ${formatTooltipNumber(point.baseline_pred_dbm, 'dBm')}`,
-    `Calibrated pred: ${formatTooltipNumber(point.calibrated_pred_dbm, 'dBm')}`,
-    `Before error: ${formatTooltipNumber(point.baseline_error_db, 'dB')}`,
-    `After error: ${formatTooltipNumber(point.calibrated_error_db, 'dB')}`,
-    `Position: ${formatTooltipNumber(point.x_m, 'm')}, ${formatTooltipNumber(point.y_m, 'm')}`,
+    `실측 RSSI: ${formatTooltipNumber(point.rssi_dbm, 'dBm')}`,
+    `보정 전 예측: ${formatTooltipNumber(point.baseline_pred_dbm, 'dBm')}`,
+    `보정 후 예측: ${formatTooltipNumber(point.calibrated_pred_dbm, 'dBm')}`,
+    `보정 전 오차: ${formatTooltipNumber(point.baseline_error_db, 'dB')}`,
+    `보정 후 오차: ${formatTooltipNumber(point.calibrated_error_db, 'dB')}`,
+    `위치: ${formatTooltipNumber(point.x_m, 'm')}, ${formatTooltipNumber(point.y_m, 'm')}`,
   ];
   return lines.join('\n');
 }
@@ -974,7 +993,7 @@ function ErrorBarChart({
     ]),
   );
   if (visible.length === 0) {
-    return <p className="text-muted-foreground">No comparison points available.</p>;
+    return <p className="text-muted-foreground">비교할 포인트가 없습니다.</p>;
   }
   return (
     <div className="max-h-72 space-y-2 overflow-auto pr-1">
@@ -1006,12 +1025,12 @@ function ErrorBarChart({
       })}
       {points.length > visible.length && (
         <p className="pt-1 text-[11px] text-muted-foreground">
-          Showing first {visible.length} of {points.length} points. Full values are in the table below.
+          {points.length}개 중 상위 {visible.length}개만 표시합니다. 전체 값은 아래 표에서 확인하세요.
         </p>
       )}
       <div className="flex gap-3 pt-1 text-[11px] text-muted-foreground">
-        <span className="inline-flex items-center gap-1"><span className="h-2 w-4 rounded bg-rose-500" /> before</span>
-        <span className="inline-flex items-center gap-1"><span className="h-2 w-4 rounded bg-emerald-500" /> after</span>
+        <span className="inline-flex items-center gap-1"><span className="h-2 w-4 rounded bg-rose-500" /> 보정 전</span>
+        <span className="inline-flex items-center gap-1"><span className="h-2 w-4 rounded bg-emerald-500" /> 보정 후</span>
       </div>
     </div>
   );
@@ -1021,6 +1040,29 @@ function errorColor(errorDb: number): string {
   if (errorDb <= 3) return '#10b981';
   if (errorDb <= 7) return '#f59e0b';
   return '#ef4444';
+}
+
+function formatComparisonPointSource(source: string): string {
+  switch (source.toLowerCase()) {
+    case 'reference':
+      return '참조';
+    case 'validation':
+      return '검증';
+    case 'calibration':
+      return '보정';
+    case 'evaluation':
+      return '평가';
+    default:
+      return source;
+  }
+}
+
+function formatEvaluationMapLabel(label: string): string {
+  const lower = label.toLowerCase();
+  if (lower.includes('baseline')) return '보정 전 시뮬레이션';
+  if (lower.includes('calibrated')) return '보정 후 시뮬레이션';
+  if (lower.includes('measured reference') || lower.includes('reference map')) return '실측 참조맵';
+  return label;
 }
 
 function formatFrequencyCheck(evaluation: CalibrationEvaluationResponse): string | null {
@@ -1041,22 +1083,7 @@ function formatFrequencyCheck(evaluation: CalibrationEvaluationResponse): string
 }
 
 function rssiColor(value: number, min: number, max: number): string {
-  const t = Math.max(0, Math.min(1, (value - min) / Math.max(max - min, 1)));
-  const stops = [
-    [12, 7, 134],
-    [75, 3, 161],
-    [125, 3, 168],
-    [203, 71, 119],
-    [248, 149, 64],
-    [240, 249, 33],
-  ];
-  const pos = t * (stops.length - 1);
-  const i = Math.min(stops.length - 2, Math.floor(pos));
-  const local = pos - i;
-  const a = stops[i];
-  const b = stops[i + 1];
-  const rgb = a.map((v, idx) => Math.round(v + (b[idx] - v) * local));
-  return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  return dbmToHeatmapColor(value, min, max);
 }
 
 function extractEvaluationResponse(run: CalibrationRun | null): CalibrationEvaluationResponse | null {

--- a/frontend/src/features/editor/floorplan-image-extent.ts
+++ b/frontend/src/features/editor/floorplan-image-extent.ts
@@ -157,3 +157,22 @@ function resolveRealWidth(src: ImageExtentSource): number | null {
   }
   return null;
 }
+
+/** 벽 bounds + 이미지 픽셀 크기로 scale_ratio 를 역추정 (캐시 miss 시 fallback). */
+export function inferImageExtentFromWallBounds(
+  imageDims: { w: number; h: number } | null,
+  bounds: { minX: number; maxX: number; minY: number; maxY: number } | null,
+): { w: number; h: number } | null {
+  if (!imageDims || imageDims.w <= 0 || imageDims.h <= 0 || !bounds) return null;
+  const { minX, minY, maxX, maxY } = bounds;
+  if (!Number.isFinite(maxX) || !Number.isFinite(maxY) || maxX <= 0 || maxY <= 0) {
+    return null;
+  }
+  // 도면 분석 결과는 보통 (0,0) 근처에서 시작. 여백이 크면 추정 불가.
+  if (minX > 2 || minY > 2) return null;
+  const scaleX = maxX / imageDims.w;
+  const scaleY = maxY / imageDims.h;
+  const scale = Math.max(scaleX, scaleY);
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  return { w: imageDims.w * scale, h: imageDims.h * scale };
+}

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -19,6 +19,7 @@ import {
   CANVAS_OBJECT_STROKE,
   CANVAS_WINDOW_STROKE,
 } from '@/lib/canvas-scene-colors';
+import { dbmToHeatmapColor } from '@/lib/rssi-colormap';
 
 export type MeasurementPointQuality = 'good' | 'warning' | 'poor';
 
@@ -140,38 +141,6 @@ const QUALITY_HEATMAP_RGBA: Record<MeasurementPointQuality, string> = {
   warning: 'rgba(250, 204, 21, 0.45)',
   poor: 'rgba(248, 113, 113, 0.6)',
 };
-
-// matplotlib inferno cmap stops — Sionna heatmap 과 동일 visual language.
-// HeatmapColorLegend.tsx 와 동기화 유지.
-const INFERNO_STOPS = [
-  [0, 0, 4],
-  [22, 11, 57],
-  [66, 10, 104],
-  [106, 23, 110],
-  [147, 38, 103],
-  [188, 55, 84],
-  [221, 81, 58],
-  [243, 120, 25],
-  [252, 165, 10],
-  [246, 215, 70],
-  [252, 255, 164],
-] as const;
-
-/** dBm 값 → inferno cmap RGB. min/max 범위로 정규화 후 stops 사이 선형 보간. */
-function dbmToInfernoColor(dbm: number, min: number, max: number): string {
-  if (!Number.isFinite(dbm) || max <= min) return 'rgb(255, 255, 255)';
-  const t = Math.max(0, Math.min(1, (dbm - min) / (max - min)));
-  const scaled = t * (INFERNO_STOPS.length - 1);
-  const lo = Math.floor(scaled);
-  const hi = Math.min(INFERNO_STOPS.length - 1, lo + 1);
-  const frac = scaled - lo;
-  const c0 = INFERNO_STOPS[lo];
-  const c1 = INFERNO_STOPS[hi];
-  const r = Math.round(c0[0] + frac * (c1[0] - c0[0]));
-  const g = Math.round(c0[1] + frac * (c1[1] - c0[1]));
-  const b = Math.round(c0[2] + frac * (c1[2] - c0[2]));
-  return `rgb(${r}, ${g}, ${b})`;
-}
 
 /**
  * 실측/진단 캔버스. 확정 버전 도형 위에 측정 경로(line + 색상 dot) 와/또는
@@ -371,7 +340,7 @@ export function MeasurementCanvas({
                     y={bounds.min_y + rowIdx * cellH}
                     width={cellW}
                     height={cellH}
-                    fill={dbmToInfernoColor(value, range.min, range.max)}
+                    fill={dbmToHeatmapColor(value, range.min, range.max)}
                   />
                 );
               }),
@@ -387,6 +356,7 @@ export function MeasurementCanvas({
             height={estimatedHeatmap.bounds.max_y - estimatedHeatmap.bounds.min_y}
             preserveAspectRatio="none"
             opacity={0.65}
+            style={{ filter: 'contrast(0.65) saturate(1.4) brightness(1.15)' }}
             pointerEvents="none"
             onError={() => {
               console.warn(
@@ -439,7 +409,7 @@ export function MeasurementCanvas({
           sortedPoints.map((p) => {
             const fill =
               effectiveColorMode === 'dbm'
-                ? dbmToInfernoColor(
+                ? dbmToHeatmapColor(
                     pointRssiByOrder?.get(p.id) ?? Number.NaN,
                     dbmMin,
                     dbmMax,

--- a/frontend/src/features/mobile/MobileConnectModal.tsx
+++ b/frontend/src/features/mobile/MobileConnectModal.tsx
@@ -164,7 +164,7 @@ function ReadyState({
       </p>
 
       <div className="rounded-lg border bg-muted/20 px-3 py-2 text-center text-xs font-medium">
-        Recommended mode: {recommendedPurpose === 'reference' ? 'Reference comparison' : 'Calibration'}
+        권장 모드: {recommendedPurpose === 'reference' ? '참조 비교' : '보정용'}
       </div>
 
       <div className="flex justify-center rounded-xl border bg-white p-4">

--- a/frontend/src/features/simulation/DbmColorBar.tsx
+++ b/frontend/src/features/simulation/DbmColorBar.tsx
@@ -1,22 +1,13 @@
 import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { RSSI_HEATMAP_GRADIENT_CSS } from '@/lib/rssi-colormap';
 import { cn } from '@/lib/utils';
 
 /**
  * RSSI dBm → 색 그라데이션 + tick 라벨 colorbar.
  *
- * matplotlib horizontal colorbar 스타일 — gradient 아래에 tick 들이 정렬돼서
- * "이 색 = 이 dBm" 한눈에 매핑. 시뮬/측정 페이지 모두에서 같은 visual language.
- *
- * inferno cmap 11 stops — Sionna heatmap PNG, MeasurementCanvas 측정점 색, 본 컴포넌트
- * 모두 동일 stop 사용 (HeatmapColorLegend, MeasurementCanvas 와 동기화).
+ * matplotlib `jet` cmap — Sionna/GP heatmap PNG, MeasurementCanvas, 본 컴포넌트 동기화.
  */
-
-const INFERNO_GRADIENT =
-  'linear-gradient(to right, ' +
-  '#000004 0%, #160b39 10%, #420a68 20%, #6a176e 30%, ' +
-  '#932667 40%, #bc3754 50%, #dd513a 60%, #f37819 70%, ' +
-  '#fca50a 80%, #f6d746 90%, #fcffa4 100%)';
 
 const DBM_QUALITY_LABELS = [
   { dbm: -30, label: '매우 강함' },
@@ -82,7 +73,7 @@ export function DbmColorBar({
           {/* gradient bar */}
           <div
             className="h-3 w-full rounded-sm border border-border/60"
-            style={{ backgroundImage: INFERNO_GRADIENT }}
+            style={{ backgroundImage: RSSI_HEATMAP_GRADIENT_CSS }}
           />
           {/* tick marks — gradient 바로 아래 short vertical line + 값 */}
           <div className="relative h-4 w-full">

--- a/frontend/src/features/simulation/HeatmapColorLegend.tsx
+++ b/frontend/src/features/simulation/HeatmapColorLegend.tsx
@@ -1,39 +1,11 @@
 /**
  * RF 시뮬레이션 히트맵 색 → dBm 범례.
  *
- * 각 run 의 실제 사용된 색 스케일 (vmin/vmax, auto-scale p5-p95) 을 ai_api 가
- * `artifacts.radiomap.color_scale` 로 노출 → backend 가 RfMap.metrics_json.color_scale
- * 에 보관 → 이 컴포넌트가 그대로 사용. matplotlib inferno cmap 의 stops 을 CSS gradient
- * 로 재현해서 동일한 시각화 제공.
- *
- * color_scale 이 없는 경우 (옛 run / sagemaker 응답에 미포함) 합리적 기본값 -85~-30 dBm
- * 으로 표시 — 사용자는 대략의 범위라도 파악 가능.
+ * color_scale (vmin/vmax) 은 RfMap.metrics_json 에서 가져옴.
+ * matplotlib `jet` cmap 과 동일한 stops 로 CSS gradient 재현.
  */
 
-// matplotlib inferno 의 11개 stops (0.0 → 1.0). matplotlib.cm.inferno(t) 와 같은 색.
-const INFERNO_STOPS: ReadonlyArray<string> = [
-  '#000004',
-  '#160b39',
-  '#420a68',
-  '#6a176e',
-  '#932667',
-  '#bc3754',
-  '#dd513a',
-  '#f37819',
-  '#fca50a',
-  '#f6d746',
-  '#fcffa4',
-];
-
-function buildGradientCss(): string {
-  // 수평 그라데이션 — 왼쪽=낮은 신호(짙은 보라), 오른쪽=높은 신호(밝은 노랑).
-  const stops = INFERNO_STOPS.map(
-    (color, i) => `${color} ${((i / (INFERNO_STOPS.length - 1)) * 100).toFixed(1)}%`,
-  ).join(', ');
-  return `linear-gradient(to right, ${stops})`;
-}
-
-const GRADIENT_CSS = buildGradientCss();
+import { RSSI_HEATMAP_GRADIENT_CSS } from '@/lib/rssi-colormap';
 
 const DEFAULT_VMIN_DBM = -85;
 const DEFAULT_VMAX_DBM = -30;
@@ -80,7 +52,7 @@ export function HeatmapColorLegend({ scale, className }: Props) {
       </div>
       <div
         className="h-2.5 w-44 rounded-sm border border-border/60"
-        style={{ backgroundImage: GRADIENT_CSS }}
+        style={{ backgroundImage: RSSI_HEATMAP_GRADIENT_CSS }}
       />
       <div className="flex justify-between text-[10px] font-mono tabular-nums text-foreground/70">
         <span>{vmin.toFixed(0)}</span>

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { parseGeometry, type Coord } from '@/features/editor/geometry-utils';
 import { loadCachedViewBox } from '@/features/editor/viewbox-cache';
 import {
   deriveImageExtent,
+  inferImageExtentFromWallBounds,
+  saveCachedScaleRatio,
   useImageNaturalDimensions,
 } from '@/features/editor/floorplan-image-extent';
 import type {
@@ -133,6 +135,21 @@ function unionViewBoxWithHeatmapBounds(
   return { x: minX - padding, y: minY - padding, w: w + 2 * padding, h: h + 2 * padding };
 }
 
+/** 벽 centerline 기준 bbox — image scale fallback 용. */
+function computeWallBounds(
+  scene: SceneVersion | null | undefined,
+): { minX: number; minY: number; maxX: number; maxY: number } | null {
+  const b = emptyBounds();
+  for (const wall of scene?.walls ?? []) {
+    const g = parseGeometry(wall.centerline_geom);
+    if (g?.type === 'LineString') {
+      for (const [x, y] of g.coordinates) extendBounds(b, x, y);
+    }
+  }
+  if (!isFinite(b.minX)) return null;
+  return { minX: b.minX, minY: b.minY, maxX: b.maxX, maxY: b.maxY };
+}
+
 /**
  * 시뮬레이션 페이지 캔버스 — 확정 버전 도형(rooms/walls/openings/objects)을 read-only 로
  * 보여주고, 그 위에 사용자가 AP 를 자유롭게 배치/드래그/삭제. 최대 8개.
@@ -159,14 +176,33 @@ export function SimulationCanvas({
   // 있으면 image 는 (0,0)~(extent.w, extent.h) 에 그림 → 벽과 정확히 정렬.
   // 없으면 viewBox 영역에 fit 으로 fallback (정렬은 안 맞아도 결과는 보임).
   const imageDims = useImageNaturalDimensions(backgroundImageUrl ?? null);
-  const imageExtent = useMemo(
-    () =>
-      deriveImageExtent(imageDims, {
-        sourceAssetId: sceneVersion?.source_asset_id ?? null,
-        floorId: sceneVersion?.floor_id ?? null,
-      }),
-    [imageDims, sceneVersion?.source_asset_id, sceneVersion?.floor_id],
-  );
+  const wallBounds = useMemo(() => computeWallBounds(sceneVersion), [sceneVersion]);
+  const imageExtent = useMemo(() => {
+    const fromCache = deriveImageExtent(imageDims, {
+      sourceAssetId: sceneVersion?.source_asset_id ?? null,
+      floorId: sceneVersion?.floor_id ?? null,
+    });
+    if (fromCache) return fromCache;
+    return inferImageExtentFromWallBounds(imageDims, wallBounds);
+  }, [
+    imageDims,
+    wallBounds,
+    sceneVersion?.source_asset_id,
+    sceneVersion?.floor_id,
+  ]);
+  // fallback 으로 scale 을 추정했으면 캐시에 저장 — 다음 방문부터 editor/sim 동일 정렬.
+  useEffect(() => {
+    if (!imageExtent || !imageDims || imageDims.w <= 0) return;
+    const cached = deriveImageExtent(imageDims, {
+      sourceAssetId: sceneVersion?.source_asset_id ?? null,
+      floorId: sceneVersion?.floor_id ?? null,
+    });
+    if (cached) return;
+    const scale = imageExtent.w / imageDims.w;
+    if (!Number.isFinite(scale) || scale <= 0) return;
+    if (sceneVersion?.source_asset_id) saveCachedScaleRatio(sceneVersion.source_asset_id, scale);
+    if (sceneVersion?.floor_id) saveCachedScaleRatio(sceneVersion.floor_id, scale);
+  }, [imageExtent, imageDims, sceneVersion?.source_asset_id, sceneVersion?.floor_id]);
 
   // viewBox: AP 배치(idle) 는 editor 캐시 우선. 결과(히트맵) 보기는 과거 run 의 bounds 가
   // 현재 편집 캐시와 어긋나 clip 되는 경우가 있어 scene+image(+heatmap) union 으로 계산.
@@ -313,7 +349,8 @@ export function SimulationCanvas({
             width={heatmapBounds ? heatmapBounds.maxX - heatmapBounds.minX : vb.w}
             height={heatmapBounds ? heatmapBounds.maxY - heatmapBounds.minY : vb.h}
             preserveAspectRatio={heatmapBounds ? 'none' : 'xMidYMid meet'}
-            opacity={0.72}
+            opacity={0.66}
+            style={{ filter: 'contrast(0.65) saturate(1.4) brightness(1.15)' }}
             pointerEvents="none"
             onError={() => {
               console.warn('[SimulationCanvas] 히트맵 이미지 로드 실패:', heatmapUrl);

--- a/frontend/src/features/simulation/SimulationHistory.tsx
+++ b/frontend/src/features/simulation/SimulationHistory.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { ArrowLeftRight, ChevronDown, History } from 'lucide-react';
+import { ArrowLeftRight, ChevronDown, History, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface SimulationHistoryItem {
   id: string;
   /** RF Run.created_at (ISO) — 카드 제목·실행 시점 표시용. */
   createdAt: string;
+  status?: string;
   avgRssiDbm: number | null;
   coveragePercent: number | null;
   active?: boolean;
@@ -107,37 +108,50 @@ function HistoryCard({
   isBest: boolean;
   onSelect?: (id: string) => void;
 }) {
-  const status = getCoverageStatus(item.coveragePercent);
+  const runStatus = getRunStatus(item.status);
+  const coverageStatus = getCoverageStatus(item.coveragePercent);
   const title = formatExecutionLabel(item.createdAt);
   const shortId = item.id.slice(0, 6);
+  const isRunning = item.status === 'pending' || item.status === 'running';
 
   return (
     <button
       type="button"
       onClick={() => onSelect?.(item.id)}
-      disabled={!onSelect}
+      disabled={!onSelect || isRunning}
       className={cn(
-        'relative w-full rounded-md border border-slate-200 bg-white p-2.5 text-left transition-colors disabled:cursor-default',
-        isBest && 'border-l-4 border-l-blue-500 pl-2',
-        item.active && 'border-blue-300 bg-blue-50/60',
-        !item.active && 'hover:border-slate-300',
+        'relative w-full rounded-md border bg-white p-2.5 text-left transition-colors disabled:cursor-default',
+        isBest && !item.active && 'border-blue-400',
+        !isBest && 'border-slate-200',
+        item.active && 'border-blue-400 bg-blue-50/60',
+        !item.active && !isRunning && 'hover:border-slate-300',
       )}
     >
       <div className="flex items-start justify-between gap-2">
         <span className="text-[13px] font-medium text-slate-800">{title}</span>
-        {isBest ? (
+        {runStatus ? (
+          <span
+            className={cn(
+              'inline-flex shrink-0 items-center gap-1 rounded border px-1.5 py-0.5 text-xs',
+              runStatus.badgeClass,
+            )}
+          >
+            {isRunning && <Loader2 className="h-3 w-3 animate-spin" aria-hidden />}
+            {runStatus.label}
+          </span>
+        ) : isBest ? (
           <span className="shrink-0 rounded border border-blue-100 bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
             최고
           </span>
         ) : (
-          status && (
+          coverageStatus && (
             <span
               className={cn(
                 'shrink-0 rounded border px-1.5 py-0.5 text-xs',
-                status.badgeClass,
+                coverageStatus.badgeClass,
               )}
             >
-              {status.label}
+              {coverageStatus.label}
             </span>
           )
         )}
@@ -193,6 +207,22 @@ function HistoryCardSkeleton() {
   );
 }
 
+function getRunStatus(status: string | undefined): CoverageStatus | null {
+  if (status === 'running' || status === 'pending') {
+    return {
+      label: '실행 중',
+      badgeClass: 'border-blue-100 bg-blue-50 text-blue-600',
+    };
+  }
+  if (status === 'failed') {
+    return {
+      label: '실패',
+      badgeClass: 'border-red-100 bg-red-50 text-red-600',
+    };
+  }
+  return null;
+}
+
 /** 커버리지 ≥70% 양호 · ≥40% 일부 개선 필요 · 그 미만 개선 필요 */
 function getCoverageStatus(coverage: number | null): CoverageStatus | null {
   if (coverage == null) return null;
@@ -216,7 +246,9 @@ function getCoverageStatus(coverage: number | null): CoverageStatus | null {
 
 /** 커버리지 최대 → 동률이면 평균 신호 세기(dBm)가 더 높은(덜 음수) 항목. */
 function findBestResultId(items: SimulationHistoryItem[]): string | null {
-  const ranked = items.filter((item) => item.coveragePercent != null);
+  const ranked = items.filter(
+    (item) => item.status === 'succeeded' && item.coveragePercent != null,
+  );
   if (ranked.length === 0) return null;
 
   let best = ranked[0];

--- a/frontend/src/hooks/use-calibration-run.ts
+++ b/frontend/src/hooks/use-calibration-run.ts
@@ -35,12 +35,12 @@ export function useEvaluateCalibrationRun() {
     mutationFn: (body: CalibrationEvaluationRequest) => calibrationRunApi.evaluate(body),
     onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: ['calibration-run'] });
-      toast.success('Calibration evaluation complete', 'Validation metrics and 3-way maps are ready.');
+      toast.success('보정 평가 완료', '검증 지표와 보정맵을 확인할 수 있습니다.');
       return result;
     },
     onError: (err) => {
       const e = err as HttpError | null;
-      toast.error('Calibration evaluation failed', e?.message ?? 'Please check RF map and measurement points.');
+      toast.error('보정 실행 실패', e?.message ?? '측정점과 시뮬레이션 결과를 확인해주세요.');
     },
   });
 }

--- a/frontend/src/hooks/use-measurement-session.ts
+++ b/frontend/src/hooks/use-measurement-session.ts
@@ -4,12 +4,17 @@ import type { UUID } from '@/types/common';
 
 // §10.4 — 백엔드 GET 엔드포인트 구현 완료 (PR #77).
 
-export function useFloorMeasurementSessions(floorId: UUID | null) {
+export function useFloorMeasurementSessions(
+  floorId: UUID | null,
+  options?: { refetchInterval?: number | false },
+) {
   return useQuery({
     queryKey: ['measurement-sessions', floorId] as const,
     queryFn: () => measurementSessionApi.listByFloor(floorId as UUID),
     enabled: !!floorId,
     staleTime: 30_000,
+    refetchInterval: options?.refetchInterval ?? false,
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/frontend/src/hooks/use-rf-run.ts
+++ b/frontend/src/hooks/use-rf-run.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { rfJobApi, rfRunApi, type ListRfRunsParams } from '@/api/rf-run';
 import type { HttpError } from '@/api/client';
 import { toast } from '@/stores/toast-store';
-import type { UUID } from '@/types/common';
+import type { Paginated, UUID } from '@/types/common';
 import type { RfJob, RfRun, RfRunCreate } from '@/types/rf';
 import { isJobFailed, isJobSucceeded, isJobTerminal } from '@/types/job';
 
@@ -12,11 +12,50 @@ const POLL_INTERVAL_MS = 3_000;
 /** run id 별 완료/실패 토스트 1회만 (Strict Mode·리마운트 중복 방지). */
 const notifiedRfRunIds = new Set<string>();
 
+function rfRunsQueryKey(floorId: UUID, params?: ListRfRunsParams) {
+  return ['rf-runs', floorId, params ?? null] as const;
+}
+
+function prependRfRunToCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  floorId: UUID,
+  run: RfRun,
+  listParams?: ListRfRunsParams,
+) {
+  queryClient.setQueriesData<Paginated<RfRun>>(
+    { queryKey: ['rf-runs', floorId] },
+    (old) => {
+      if (!old) {
+        return {
+          items: [run],
+          total: 1,
+          page: 1,
+          page_size: listParams?.page_size ?? 20,
+        };
+      }
+      const items = [run, ...old.items.filter((r) => r.id !== run.id)];
+      return { ...old, items, total: Math.max(old.total, items.length) };
+    },
+  );
+}
+
+function invalidateFloorRfRuns(
+  queryClient: ReturnType<typeof useQueryClient>,
+  floorId: UUID,
+) {
+  void queryClient.invalidateQueries({ queryKey: ['rf-runs', floorId] });
+}
+
 /** POST /rf-runs — 시뮬레이션 큐 등록. */
-export function useCreateRfRun() {
+export function useCreateRfRun(floorId: UUID | null, listParams?: ListRfRunsParams) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (body: RfRunCreate) => rfRunApi.create(body),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      if (floorId) {
+        prependRfRunToCache(queryClient, floorId, data, listParams);
+        invalidateFloorRfRuns(queryClient, floorId);
+      }
       toast.info('RF 시뮬레이션 시작', '분석이 완료되면 결과를 알려드릴게요.');
     },
     onError: (err) => {
@@ -34,6 +73,7 @@ export function useCreateRfRun() {
  * succeeded/failed 시 자동 중지 + 토스트 (중복 발화 방지).
  */
 export function useRfRun(rfRunId: UUID | null) {
+  const queryClient = useQueryClient();
   const query = useQuery({
     queryKey: ['rf-run', rfRunId] as const,
     queryFn: () => rfRunApi.get(rfRunId as UUID),
@@ -49,16 +89,32 @@ export function useRfRun(rfRunId: UUID | null) {
   useEffect(() => {
     const data = query.data;
     if (!data || !rfRunId) return;
+
+    // 목록 캐시에 최신 status 반영 — 기록 패널이 새로고침 없이 갱신되도록.
+    queryClient.setQueriesData<Paginated<RfRun>>(
+      { queryKey: ['rf-runs', data.floor_id] },
+      (old) => {
+        if (!old) return old;
+        const idx = old.items.findIndex((r) => r.id === data.id);
+        if (idx < 0) return old;
+        const items = [...old.items];
+        items[idx] = data;
+        return { ...old, items };
+      },
+    );
+
     if (notifiedRfRunIds.has(rfRunId)) return;
     if (isJobSucceeded(data.status)) {
       notifiedRfRunIds.add(rfRunId);
+      invalidateFloorRfRuns(queryClient, data.floor_id);
       toast.success('RF 시뮬레이션 완료', '결과를 확인해주세요.');
     } else if (isJobFailed(data.status)) {
       notifiedRfRunIds.add(rfRunId);
+      invalidateFloorRfRuns(queryClient, data.floor_id);
       const err = (data.metrics_json?.['error_message'] as string | undefined) ?? undefined;
       toast.error('RF 시뮬레이션 실패', err ?? '잠시 후 다시 시도해주세요.');
     }
-  }, [query.data, rfRunId]);
+  }, [query.data, rfRunId, queryClient]);
 
   const rfRun: RfRun | null = query.data ?? null;
   const status = rfRun?.status;
@@ -76,10 +132,16 @@ export function useRfRun(rfRunId: UUID | null) {
  */
 export function useFloorRfRuns(floorId: UUID | null, params?: ListRfRunsParams) {
   return useQuery({
-    queryKey: ['rf-runs', floorId, params ?? null] as const,
+    queryKey: rfRunsQueryKey(floorId as UUID, params),
     queryFn: () => rfRunApi.listByFloor(floorId as UUID, params),
     enabled: !!floorId,
-    staleTime: 30_000,
+    staleTime: 5_000,
+    refetchInterval: (q) => {
+      const hasActive = q.state.data?.items.some(
+        (r) => r.status === 'pending' || r.status === 'running',
+      );
+      return hasActive ? POLL_INTERVAL_MS : false;
+    },
   });
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -146,6 +146,43 @@
   }
 }
 
+@keyframes lp-fade-up {
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes lp-fade-down {
+  from { opacity: 0; transform: translateY(-16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes lp-slide-up {
+  from { opacity: 0; transform: translateY(72px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes lp-float {
+  0%, 100% { transform: translateY(0px); }
+  50%       { transform: translateY(-12px); }
+}
+@keyframes lp-glass-wipe {
+  0%   { transform: translateY(0%); }
+  100% { transform: translateY(100%); }
+}
+@keyframes lp-shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+@keyframes lp-ping {
+  0%   { transform: translate(-50%, -50%) scale(0.4); opacity: 0.5; }
+  100% { transform: translate(-50%, -50%) scale(2.4); opacity: 0; }
+}
+@keyframes lp-btn-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(37,99,235,0.5); }
+  50%       { box-shadow: 0 0 0 14px rgba(37,99,235,0); }
+}
+@keyframes page-enter {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import {
   LayoutGrid,
   Map,
@@ -8,14 +7,12 @@ import {
   Activity,
   Settings,
   Wifi,
-  QrCode,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProjectSelector } from '@/features/header/ProjectSelector';
 import { FloorSelector } from '@/features/header/FloorSelector';
 import { ProfileMenu } from '@/features/header/ProfileMenu';
 import { InferenceModeToggle } from '@/features/header/InferenceModeToggle';
-import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
 
 const NAV = [
   { to: '/dashboard', label: '대시보드', icon: LayoutGrid },
@@ -26,7 +23,7 @@ const NAV = [
 ] as const;
 
 export function AppLayout() {
-  const [mobileConnectOpen, setMobileConnectOpen] = useState(false);
+  const location = useLocation();
 
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-background">
@@ -81,24 +78,21 @@ export function AppLayout() {
           </div>
           <div className="flex items-center gap-2">
             <InferenceModeToggle />
-            <button
-              type="button"
-              onClick={() => setMobileConnectOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium text-foreground/80 shadow-sm transition-colors hover:bg-accent"
-            >
-              <QrCode className="h-4 w-4" />
-              모바일 앱 연결
-            </button>
             <ProfileMenu />
           </div>
         </header>
 
         <main className="flex-1 overflow-hidden bg-background">
-          <Outlet />
+          <div
+            key={location.key}
+            className="h-full"
+            style={{ animation: 'page-enter 0.45s cubic-bezier(0.16, 1, 0.3, 1) both' }}
+          >
+            <Outlet />
+          </div>
         </main>
       </div>
 
-      <MobileConnectModal open={mobileConnectOpen} onClose={() => setMobileConnectOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/lib/rssi-colormap.ts
+++ b/frontend/src/lib/rssi-colormap.ts
@@ -1,0 +1,47 @@
+/**
+ * RSSI heatmap colormap — warm thermal (Wikipedia-style).
+ * Weak → deep navy → blue → teal → green → yellow (peak warmth) → orange → red.
+ * Strong signal appears as bright yellow/amber rather than dark red.
+ */
+
+/** RGB tuples at t = 0 (weakest) … 1 (strongest) */
+export const RSSI_HEATMAP_STOPS_RGB: ReadonlyArray<readonly [number, number, number]> = [
+  [30,  80, 235],  // bright blue       (very weak)
+  [0,  140, 255],  // royal blue
+  [0,  210, 255],  // sky blue / cyan
+  [0,  240, 190],  // teal
+  [30, 240,  70],  // green
+  [160, 240,   0], // yellow-green
+  [255, 235,   0], // bright yellow
+  [255, 160,   0], // amber
+  [255,  55,   0], // orange-red
+  [235,   0,   0], // bright red
+  [195,   0,   0], // medium red        (very strong)
+];
+
+export const RSSI_HEATMAP_GRADIENT_CSS = buildHeatmapGradientCss();
+
+export function buildHeatmapGradientCss(): string {
+  const stops = RSSI_HEATMAP_STOPS_RGB.map((rgb, i) => {
+    const pct = ((i / (RSSI_HEATMAP_STOPS_RGB.length - 1)) * 100).toFixed(1);
+    const [r, g, b] = rgb;
+    return `rgb(${r}, ${g}, ${b}) ${pct}%`;
+  }).join(', ');
+  return `linear-gradient(to right, ${stops})`;
+}
+
+/** dBm → jet RGB string. Weak signal = blue, strong = red. */
+export function dbmToHeatmapColor(dbm: number, min: number, max: number): string {
+  if (!Number.isFinite(dbm) || max <= min) return 'rgb(255, 255, 255)';
+  const t = Math.max(0, Math.min(1, (dbm - min) / (max - min)));
+  const scaled = t * (RSSI_HEATMAP_STOPS_RGB.length - 1);
+  const lo = Math.floor(scaled);
+  const hi = Math.min(RSSI_HEATMAP_STOPS_RGB.length - 1, lo + 1);
+  const frac = scaled - lo;
+  const c0 = RSSI_HEATMAP_STOPS_RGB[lo];
+  const c1 = RSSI_HEATMAP_STOPS_RGB[hi];
+  const r = Math.round(c0[0] + frac * (c1[0] - c0[0]));
+  const g = Math.round(c0[1] + frac * (c1[1] - c0[1]));
+  const b = Math.round(c0[2] + frac * (c1[2] - c0[2]));
+  return `rgb(${r}, ${g}, ${b})`;
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { Activity, LayoutGrid, Map, Radio, Settings, Sparkles } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth-store';
+
+/* ------------------------------------------------------------------ */
+/* 스크롤 진입 애니메이션 훅                                            */
+/* ------------------------------------------------------------------ */
+function useInView(options?: IntersectionObserverInit) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [inView, setInView] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setInView(true);
+        obs.disconnect();
+      }
+    }, { threshold: 0.1, rootMargin: '0px 0px -60px 0px', ...options });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+  return { ref, inView };
+}
+
+const SPRING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+
+function fadeUp(inView: boolean, delay = 0, dist = 44) {
+  return inView
+    ? {
+        opacity: 1,
+        transform: 'translateY(0)',
+        transition: `opacity 0.9s ${delay}ms ${SPRING}, transform 0.9s ${delay}ms ${SPRING}`,
+      }
+    : { opacity: 0, transform: `translateY(${dist}px)` };
+}
+
+/* ------------------------------------------------------------------ */
+/* 데이터                                                               */
+/* ------------------------------------------------------------------ */
+const NAV_ITEMS = [
+  { label: '대시보드', icon: LayoutGrid, active: false },
+  { label: '공간 편집', icon: Map, active: false },
+  { label: '시뮬레이션', icon: Radio, active: true },
+  { label: '실측/진단', icon: Activity, active: false },
+  { label: 'AP 배치 추천', icon: Sparkles, active: false },
+];
+
+const STEPS = [
+  {
+    num: '01',
+    emoji: '🗺️',
+    icon: Map,
+    title: '공간 편집',
+    desc: '매장 도면을 업로드하고 벽, 가구, 장애물을 설정합니다. 공간 구조를 정확히 반영할수록 시뮬레이션 결과가 정밀해집니다.',
+  },
+  {
+    num: '02',
+    emoji: '📡',
+    icon: Radio,
+    title: '시뮬레이션',
+    desc: '도면 위에 AP(공유기)를 자유롭게 배치하고 예상 Wi-Fi 커버리지를 열지도로 확인합니다. 위치를 바꿔가며 최적 배치를 찾아보세요.',
+  },
+  {
+    num: '03',
+    emoji: '📱',
+    icon: Activity,
+    title: '실측/진단',
+    desc: '모바일 앱으로 매장을 걸어다니며 실제 Wi-Fi 신호를 측정하고, 시뮬레이션 모델을 현실에 맞게 보정합니다. 예측 정확도가 크게 올라가요.',
+  },
+  {
+    num: '04',
+    emoji: '✨',
+    icon: Sparkles,
+    title: 'AP 배치 추천',
+    desc: '실측 데이터를 분석해 신호가 약한 구역을 찾고, 개선 효과가 가장 큰 AP 설치 위치를 추천합니다.',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* 텍스트 순환 컴포넌트                                                  */
+/* ------------------------------------------------------------------ */
+const CYCLE_ITEMS = [
+  '도면 위에 AP를 배치하고 커버리지를 예측하세요',
+  '모바일로 실측해 사각지대를 바로 확인하세요',
+  'AI가 분석한 최적 공유기 위치를 추천받으세요',
+  '실측 데이터로 시뮬레이션 정확도를 높이세요',
+];
+
+function TextCycler() {
+  const [index, setIndex] = useState(0);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setAnimating(true);
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % CYCLE_ITEMS.length);
+        setAnimating(false);
+      }, 400);
+    }, 2800);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="relative mt-6 h-14 overflow-hidden">
+      <p
+        className="absolute inset-0 flex items-center text-lg font-medium text-blue-600"
+        style={{
+          opacity: animating ? 0 : 1,
+          transform: animating ? 'translateY(-20px)' : 'translateY(0)',
+          transition: `opacity 0.4s ${SPRING}, transform 0.4s ${SPRING}`,
+        }}
+      >
+        {CYCLE_ITEMS[index]}
+      </p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 메인 컴포넌트                                                         */
+/* ------------------------------------------------------------------ */
+export default function LandingPage() {
+  const isAuthed = useAuthStore((s) => s.isAuthenticated());
+  if (isAuthed) return <Navigate to="/dashboard" replace />;
+
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-white text-slate-950">
+      {/* 유리 닦기 오버레이 */}
+      <div
+        className="pointer-events-none fixed inset-0 z-100 bg-white/70 backdrop-blur-sm"
+        style={{ animation: 'lp-glass-wipe 1s 0.1s cubic-bezier(0.76, 0, 0.24, 1) both' }}
+      />
+
+      {/* 헤더 */}
+      <header
+        className="fixed inset-x-0 top-0 z-50 border-b border-slate-100/80 bg-white/80 backdrop-blur-md"
+        style={{ animation: `lp-fade-down 0.7s ${SPRING} both` }}
+      >
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-blue-600 text-xs font-bold text-white">
+              Wi
+            </div>
+            <span className="font-semibold tracking-tight">Wi-Fi Space</span>
+          </div>
+          <nav className="flex items-center gap-6 text-sm">
+            <Link to="/auth/login" className="text-slate-500 transition hover:text-slate-900">
+              로그인
+            </Link>
+            <Link to="/auth/signup" className="text-slate-500 transition hover:text-slate-900">
+              회원가입
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      {/* ── 히어로 ─────────────────────────────────────── */}
+      <section className="mx-auto grid max-w-6xl grid-cols-1 items-center gap-16 px-6 pb-48 pt-40 md:grid-cols-2 md:pt-48">
+
+        {/* 왼쪽: 카피 */}
+        <div style={{ animation: `lp-fade-up 1s 0.2s ${SPRING} both` }}>
+          <div
+            className="mb-6 inline-flex items-center rounded-full border border-sky-100 px-4 py-1.5 text-sm text-sky-400"
+            style={{
+              backgroundImage: 'linear-gradient(110deg, #f0f9ff 40%, #e0f2fe 50%, #f0f9ff 60%)',
+              backgroundSize: '200% auto',
+              animation: 'lp-shimmer 2.5s linear infinite',
+            }}
+          >
+            Wi-Fi 커버리지 최적화 플랫폼
+          </div>
+          <h1 className="text-4xl font-bold leading-[1.2] tracking-tight sm:text-5xl">
+            우리 매장 Wi-Fi<br />상태를 확인하고<br />
+            <span className="text-blue-600">최적의 공유기 위치</span>를<br />
+            추천해드려요
+          </h1>
+          <p className="mt-6 max-w-md text-base leading-7 text-slate-500">
+            도면 위에 공유기를 배치하면 예상 신호 범위를 바로 확인할 수 있어요.
+            실제 측정 데이터와 비교해 가장 안정적인 배치를 완성하세요.
+          </p>
+          <TextCycler />
+          <div className="mt-10">
+            <Link
+              to="/auth/signup"
+              className="inline-block rounded-2xl bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-xl shadow-blue-600/20 transition hover:bg-blue-700 hover:shadow-blue-600/30 active:scale-[0.98]"
+            >
+              분석 시작하기
+            </Link>
+          </div>
+        </div>
+
+        {/* 오른쪽: 앱 미리보기 */}
+        <div
+          className="relative"
+          style={{ animation: `lp-slide-up 1.1s 0.35s ${SPRING} both` }}
+        >
+          {/* 배경 글로우 */}
+          <div className="absolute -inset-8 rounded-4xl bg-blue-100/70 blur-3xl" />
+
+          {/* 앱 창 */}
+          <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-200/80" style={{ animation: 'lp-float 5s ease-in-out infinite' }}>
+            {/* 앱 상단 바 */}
+            <div className="flex items-center justify-between border-b bg-slate-50 px-5 py-3">
+              <div className="flex items-center gap-2.5">
+                <div className="flex h-5 w-5 items-center justify-center rounded bg-blue-600 text-[8px] font-bold text-white">Wi</div>
+                <span className="text-xs font-semibold text-slate-700">Wi-Fi Space</span>
+              </div>
+              <div className="flex items-center gap-2 text-[10px]">
+                <span className="rounded-full border bg-white px-2.5 py-0.5 text-slate-500">1F · 카페 매장</span>
+                <span className="rounded-full bg-emerald-50 px-2.5 py-0.5 font-semibold text-emerald-600">분석 완료</span>
+              </div>
+            </div>
+
+            <div className="flex h-80">
+              {/* 미니 사이드바 */}
+              <nav className="flex w-32 flex-col gap-0.5 border-r bg-slate-50/60 p-2.5">
+                {NAV_ITEMS.map((item) => (
+                  <div
+                    key={item.label}
+                    className={`flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-[9px] font-medium transition ${
+                      item.active ? 'bg-blue-100 text-blue-700' : 'text-slate-400'
+                    }`}
+                  >
+                    <item.icon className="h-3 w-3 shrink-0" />
+                    {item.label}
+                  </div>
+                ))}
+                <div className="mt-auto flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-[9px] text-slate-300">
+                  <Settings className="h-3 w-3" />
+                  설정
+                </div>
+              </nav>
+
+              {/* 메인 화면 */}
+              <div className="flex flex-1 flex-col gap-2.5 p-3">
+                {/* 도면 + 히트맵 */}
+                <div className="relative flex-1 overflow-hidden rounded-2xl bg-slate-100">
+                  <div className="absolute left-8 top-5 h-24 w-28 rounded-2xl bg-blue-400/45 blur-xl" />
+                  <div className="absolute right-8 top-8 h-22 w-22 rounded-full bg-emerald-400/45 blur-xl" />
+                  <div className="absolute bottom-8 left-1/2 h-18 w-22 -translate-x-1/2 rounded-full bg-orange-400/35 blur-lg" />
+                  <div className="absolute inset-4 grid grid-cols-3 grid-rows-2 gap-1.5">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                      <div key={i} className="rounded-xl border border-white/70 bg-white/35" />
+                    ))}
+                  </div>
+                  <div className="absolute left-12 top-9 rounded-full bg-blue-600 px-2 py-0.5 text-[9px] font-bold text-white shadow-md">AP-1</div>
+                  <div className="absolute right-12 top-6 rounded-full bg-blue-600 px-2 py-0.5 text-[9px] font-bold text-white shadow-md">AP-2</div>
+                  <div className="absolute bottom-2.5 left-2.5 right-2.5 rounded-xl bg-white/90 px-3 py-2 backdrop-blur-sm">
+                    <div className="flex items-center justify-between text-[9px]">
+                      <span className="text-slate-500">커버리지</span>
+                      <span className="font-bold text-blue-600">78%</span>
+                    </div>
+                    <div className="mt-1 h-1 rounded-full bg-slate-200">
+                      <div className="h-1 w-[78%] rounded-full bg-linear-to-r from-blue-500 to-emerald-400" />
+                    </div>
+                  </div>
+                </div>
+
+                {/* 지표 */}
+                <div className="grid grid-cols-3 gap-2">
+                  {[
+                    { label: 'AP 수', value: '2개' },
+                    { label: '평균 RSSI', value: '-58 dBm' },
+                    { label: '주파수', value: '5 GHz' },
+                  ].map((m) => (
+                    <div key={m.label} className="rounded-xl bg-slate-50 p-2.5 text-center">
+                      <div className="text-[8px] text-slate-400">{m.label}</div>
+                      <div className="mt-0.5 text-[11px] font-bold text-slate-800">{m.value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── 사용 흐름 ────────────────────────────────────── */}
+      <StepsSection />
+
+      {/* ── 하단 CTA ─────────────────────────────────────── */}
+      <CtaSection />
+
+      <footer className="border-t border-slate-800 bg-slate-900 px-6 py-8 text-center text-sm text-slate-500">
+        Wi-Fi Space · 실내 Wi-Fi 커버리지 최적화
+      </footer>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 사용 흐름 섹션                                                        */
+/* ------------------------------------------------------------------ */
+function StepCard({ s, delay }: { s: typeof STEPS[number]; delay: number }) {
+  const { ref, inView } = useInView();
+  return (
+    <div ref={ref} style={fadeUp(inView, delay)}>
+      <div className="relative h-full rounded-3xl border border-slate-200 bg-white px-9 py-10 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-slate-200/80">
+        <div className="mb-10 flex items-start justify-between">
+          <div className="relative z-10 flex h-11 w-11 items-center justify-center rounded-full bg-white text-sm font-bold text-blue-600 shadow-sm ring-1 ring-slate-200">
+            {s.num}
+          </div>
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-50 text-3xl">
+            {s.emoji}
+          </div>
+        </div>
+        <h3 className="text-xl font-extrabold tracking-tight text-slate-950">{s.title}</h3>
+        <p className="mt-4 text-sm leading-7 text-slate-500">{s.desc}</p>
+      </div>
+    </div>
+  );
+}
+
+function StepsSection() {
+  const { ref, inView } = useInView();
+  return (
+    <section className="bg-slate-50 px-6 py-48">
+      <div className="mx-auto max-w-6xl">
+        <div ref={ref} style={fadeUp(inView, 0, 36)} className="mb-16 text-center">
+          <h2 className="text-4xl font-bold tracking-tight">이렇게 사용해요</h2>
+          <p className="mt-4 text-lg text-slate-500">
+            도면 업로드부터 실제 신호 보정까지 한 흐름으로 관리하세요.
+          </p>
+        </div>
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-x-0 top-10.5 hidden h-px bg-slate-200 lg:block" />
+          <div className="grid gap-5 sm:grid-cols-2 md:grid-cols-4">
+            {STEPS.map((s, i) => (
+              <StepCard key={s.num} s={s} delay={i * 80} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 하단 CTA 섹션                                                         */
+/* ------------------------------------------------------------------ */
+function CtaSection() {
+  const { ref, inView } = useInView();
+  return (
+    <section className="relative overflow-hidden bg-slate-900 px-6 pb-30 pt-40">
+      {/* 배경 글로우 */}
+      <div className="pointer-events-none absolute left-1/2 top-1/2 h-150 w-150 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-700/20 blur-[120px]" />
+      <div className="pointer-events-none absolute -left-32 bottom-0 h-80 w-80 rounded-full bg-blue-500/10 blur-3xl" />
+      <div className="pointer-events-none absolute -right-32 top-0 h-80 w-80 rounded-full bg-indigo-500/10 blur-3xl" />
+
+      {/* 신호 파동 링 */}
+      {[0, 0.8, 1.6].map((delay) => (
+        <div
+          key={delay}
+          className="pointer-events-none absolute left-1/2 top-1/2 h-96 w-96 rounded-full border border-blue-500/20"
+          style={{ animation: `lp-ping 3.6s ${delay}s ease-out infinite` }}
+        />
+      ))}
+
+      {/* 배경 점 패턴 */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.04]"
+        style={{
+          backgroundImage: 'radial-gradient(circle, #94a3b8 1px, transparent 1px)',
+          backgroundSize: '40px 40px',
+        }}
+      />
+
+      <div ref={ref} className="relative mx-auto w-full max-w-3xl text-center">
+        <p
+          style={fadeUp(inView, 0, 36)}
+          className="mb-15 text-sm font-semibold uppercase tracking-[0.2em] text-blue-400"
+        >
+          Wi-Fi Space
+        </p>
+        <h2
+          style={fadeUp(inView, 100, 52)}
+          className="text-5xl font-bold leading-tight tracking-tight text-white sm:text-6xl"
+        >
+          매장 Wi-Fi, 한번<br />직접 분석해보세요
+        </h2>
+        <p
+          style={fadeUp(inView, 220, 40)}
+          className="mx-auto mt-10 max-w-md text-lg leading-8 text-slate-400"
+        >
+          시뮬레이션부터 실측 보정까지,<br />공유기 최적 위치 후보를 바로 확인해보세요.
+        </p>
+        <div style={fadeUp(inView, 360, 32)} className="mt-20">
+          <Link
+            to="/auth/signup"
+            className="inline-block rounded-2xl bg-blue-600 px-15 py-4 text-base font-semibold text-white transition hover:bg-blue-500 active:scale-[0.98]"
+            style={{ animation: 'lp-btn-pulse 2.5s ease-in-out infinite' }}
+          >
+            분석 시작하기
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   Activity,
   AlertTriangle,
@@ -12,6 +13,7 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { RSSI_HEATMAP_GRADIENT_CSS } from '@/lib/rssi-colormap';
 import { HelpFab } from '@/components/HelpFab';
 import { MobileConnectModal } from '@/features/mobile/MobileConnectModal';
 import { Popover } from '@/components/ui/Popover';
@@ -54,6 +56,7 @@ const EMPTY_MEASUREMENT_SESSIONS: MeasurementSession[] = [];
 const EMPTY_MEASUREMENT_POINTS: ApiPoint[] = [];
 
 export default function MeasurementPage() {
+  const queryClient = useQueryClient();
   const floorId = useAppStore((s) => s.selectedFloorId);
 
   // 확정된 도면 (캔버스 배경).
@@ -86,8 +89,15 @@ export default function MeasurementPage() {
   const spaceType: SpaceType = currentFloor?.space_type ?? 'unknown';
 
   // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
-  const sessionsQuery = useFloorMeasurementSessions(floorId);
-  const sessions = sessionsQuery.data?.items ?? EMPTY_MEASUREMENT_SESSIONS;
+  // 모바일 측정 완료 후 웹에 세션이 늦게 반영되는 경우가 있어 주기적으로 목록 갱신.
+  const sessionsQuery = useFloorMeasurementSessions(floorId, { refetchInterval: 5_000 });
+  const allSessions = sessionsQuery.data?.items ?? EMPTY_MEASUREMENT_SESSIONS;
+  // 현재 도면 버전이 생성된 이후에 측정된 세션만 표시.
+  // 도면을 수정하고 재시뮬레이션하면 이전 버전의 측정 기록은 자동으로 숨겨진다.
+  const sessions = useMemo(() => {
+    if (!currentVersion?.created_at) return allSessions;
+    return allSessions.filter((s) => s.created_at >= currentVersion.created_at);
+  }, [allSessions, currentVersion?.created_at]);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const activeSession =
     sessions.find((s) => s.id === selectedSessionId) ?? sessions[0] ?? null;
@@ -164,6 +174,16 @@ export default function MeasurementPage() {
 
   const hasVersion = versions.length > 0;
   const hasMeasurement = points.length > 0;
+  const isLoadingMeasurement =
+    sessionsQuery.isFetching || (!!activeSession && pointsQuery.isFetching);
+
+  const prevMobileOpen = useRef(false);
+  useEffect(() => {
+    if (prevMobileOpen.current && !mobileOpen && floorId) {
+      void queryClient.invalidateQueries({ queryKey: ['measurement-sessions', floorId] });
+    }
+    prevMobileOpen.current = mobileOpen;
+  }, [mobileOpen, floorId, queryClient]);
 
   // §11 캘리브레이션 — 현재 측정 세션 + 최근 RF Run + 현재 버전을 입력으로 사용.
   // 측정 페이지에 둠: 진단 카드에서 차이를 발견한 직후 보정 가능.
@@ -175,11 +195,21 @@ export default function MeasurementPage() {
   // 백엔드 평가는 기존 데이터 호환을 위해 최소 5점 guard를 별도로 유지한다.
   const MIN_MEASUREMENTS_FOR_CALIBRATION = 8;
   const hasEnoughMeasurements = points.length >= MIN_MEASUREMENTS_FOR_CALIBRATION;
+  const radioMapBounds = useMemo(
+    () => extractRadioMapBounds(latestRfRun?.metrics_json),
+    [latestRfRun?.metrics_json],
+  );
+  const pointsInsideSim = useMemo(
+    () => countPointsInsideBounds(points, radioMapBounds),
+    [points, radioMapBounds],
+  );
+  const hasEnoughPointsInSim = pointsInsideSim >= MIN_MEASUREMENTS_FOR_CALIBRATION;
   const canCalibrate =
     !!activeSession?.id &&
     !!latestRfRunId &&
     !!currentVersion?.id &&
-    hasEnoughMeasurements;
+    hasEnoughMeasurements &&
+    hasEnoughPointsInSim;
   const evaluationSessionIds = useMemo(() => {
     const ids = new Set<string>();
     for (const session of sessions) {
@@ -200,14 +230,18 @@ export default function MeasurementPage() {
       ? 'insufficient_points'
       : !latestRfRunId
         ? 'no_simulation'
-        : 'ready';
+        : !hasEnoughPointsInSim
+          ? 'outside_sim_area'
+          : 'ready';
   const calibrationDisabledReason = !hasMeasurement
     ? null
     : !hasEnoughMeasurements
       ? `보정을 위해 측정점 ${MIN_MEASUREMENTS_FOR_CALIBRATION}개 이상이 필요합니다 (현재 ${points.length}개). 도면 곳곳을 더 측정해주세요.`
       : !latestRfRunId
         ? null
-        : null;
+        : !hasEnoughPointsInSim
+          ? `측정점 ${points.length}개 중 ${pointsInsideSim}개만 시뮬레이션 영역 안에 있습니다. 모바일 앱에서 도면 벽 안쪽의 시작 위치를 지정하고 건물 안을 따라 다시 측정해주세요.`
+          : null;
   const handleCalibrate = () => {
     if (!canCalibrate || !activeSession || !latestRfRunId || !currentVersion) return;
     evaluateCalibration.mutate(
@@ -354,7 +388,7 @@ export default function MeasurementPage() {
                   mode={mode}
                   estimatedHeatmap={displayedHeatmap}
                 />
-                {!hasMeasurement && <CanvasEmptyOverlay loading={pointsQuery.isFetching} />}
+                {!hasMeasurement && <CanvasEmptyOverlay loading={isLoadingMeasurement} />}
                 {/* dbm 모드 colorbar — 도면 좌상단. gradient + tick 값 수직 정렬로 "이 색=이 dBm" 직관. */}
                 {mode !== 'route' && displayedRange && (
                   <div className="pointer-events-none absolute left-3 top-3 z-10 w-70">
@@ -468,6 +502,40 @@ function apsFromRfRunRequest(requestJson: Record<string, unknown> | undefined): 
     out.push({ id, x_m: x, y_m: y, label: id.toUpperCase() });
   });
   return out;
+}
+
+/** RfRun.metrics_json.radio_map.bounds_m 추출. */
+function extractRadioMapBounds(
+  metrics: Record<string, unknown> | undefined,
+): { min_x: number; min_y: number; max_x: number; max_y: number } | null {
+  const radioMap = metrics?.['radio_map'];
+  if (!radioMap || typeof radioMap !== 'object') return null;
+  const bounds = (radioMap as Record<string, unknown>)['bounds_m'];
+  if (!bounds || typeof bounds !== 'object') return null;
+  const b = bounds as Record<string, unknown>;
+  const min_x = Number(b['min_x']);
+  const min_y = Number(b['min_y']);
+  const max_x = Number(b['max_x']);
+  const max_y = Number(b['max_y']);
+  if (![min_x, min_y, max_x, max_y].every(Number.isFinite)) return null;
+  if (max_x <= min_x || max_y <= min_y) return null;
+  return { min_x, min_y, max_x, max_y };
+}
+
+function countPointsInsideBounds(
+  points: ApiPoint[],
+  bounds: { min_x: number; min_y: number; max_x: number; max_y: number } | null,
+): number {
+  if (!bounds) return points.length;
+  return points.filter((p) => {
+    const { x, y } = p.floor_position;
+    return (
+      x >= bounds.min_x &&
+      x <= bounds.max_x &&
+      y >= bounds.min_y &&
+      y <= bounds.max_y
+    );
+  }).length;
 }
 
 /** RfMap.metrics_json.rss_dbm.mean 추출 (없으면 옛 avg_rssi_dbm fallback). */
@@ -673,7 +741,7 @@ function TabBar({
   );
 }
 
-/** dbm 모드일 땐 inferno 그라데이션 + 양 끝/중간 dBm 표시. quality 모드면 기존 3-tier. */
+/** dbm 모드일 땐 jet 그라데이션 + 양 끝/중간 dBm 표시. quality 모드면 기존 3-tier. */
 function Legend({
   colorMode,
   range,
@@ -690,10 +758,7 @@ function Legend({
         <span className="font-semibold text-foreground">실측 RSSI</span>
         <div
           className="h-2 w-32 rounded-sm border border-border/60"
-          style={{
-            backgroundImage:
-              'linear-gradient(to right, rgb(0,0,4), rgb(66,10,104), rgb(147,38,103), rgb(221,81,58), rgb(252,165,10), rgb(252,255,164))',
-          }}
+          style={{ backgroundImage: RSSI_HEATMAP_GRADIENT_CSS }}
         />
         <span className="font-mono tabular-nums text-[10px] text-foreground/70">
           {min.toFixed(0)} · {mid.toFixed(0)} · {max.toFixed(0)} dBm

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -97,7 +97,7 @@ export default function SimulationPage() {
     setPickedRunId(id);
   };
 
-  const createRfRun = useCreateRfRun();
+  const createRfRun = useCreateRfRun(floorId, { page_size: 20 });
   const rfRunPoll = useRfRun(activeRunId);
   const rfMapsQuery = useRfMaps(activeRunId, rfRunPoll.isSucceeded);
   const activeRunSceneVersionId = rfRunPoll.rfRun?.scene_version_id ?? null;
@@ -235,27 +235,27 @@ export default function SimulationPage() {
   const activeMapMetrics = rfMapsQuery.data?.[0]?.metrics_json;
   const history: SimulationHistoryItem[] = useMemo(
     () =>
-      pastRuns
-        .filter((r) => r.status === 'succeeded')
-        .map((r) => {
-          // rf_run.metrics_json 은 `{ radio_map: { rss_dbm, coverage_summary, ... }, ... }` 형태로
-          // 한 단계 nested. parseMetrics 는 top-level 키만 찾으므로 radio_map 도 같이 풀어 넘김.
-          // active 일 땐 RfMap.metrics_json (flat) 도 함께 — 그쪽이 더 풍부할 수 있음.
-          const radioMap = (r.metrics_json?.['radio_map'] ?? null) as
-            | Record<string, unknown>
-            | null;
-          const sources: Array<Record<string, unknown> | undefined> = [r.metrics_json];
-          if (radioMap) sources.push(radioMap);
-          if (r.id === activeRunId && activeMapMetrics) sources.push(activeMapMetrics);
-          const m = parseMetrics(...sources);
-          return {
-            id: r.id,
-            createdAt: r.created_at,
-            avgRssiDbm: m.avgRssiDbm,
-            coveragePercent: m.coveragePercent,
-            active: r.id === activeRunId,
-          };
-        }),
+      pastRuns.map((r) => {
+        const isTerminal = r.status === 'succeeded' || r.status === 'failed';
+        // rf_run.metrics_json 은 `{ radio_map: { rss_dbm, coverage_summary, ... }, ... }` 형태로
+        // 한 단계 nested. parseMetrics 는 top-level 키만 찾으므로 radio_map 도 같이 풀어 넘김.
+        // active 일 땐 RfMap.metrics_json (flat) 도 함께 — 그쪽이 더 풍부할 수 있음.
+        const radioMap = (r.metrics_json?.['radio_map'] ?? null) as
+          | Record<string, unknown>
+          | null;
+        const sources: Array<Record<string, unknown> | undefined> = [r.metrics_json];
+        if (radioMap) sources.push(radioMap);
+        if (r.id === activeRunId && activeMapMetrics) sources.push(activeMapMetrics);
+        const m = isTerminal ? parseMetrics(...sources) : { avgRssiDbm: null, coveragePercent: null };
+        return {
+          id: r.id,
+          createdAt: r.created_at,
+          status: r.status,
+          avgRssiDbm: m.avgRssiDbm,
+          coveragePercent: m.coveragePercent,
+          active: r.id === activeRunId,
+        };
+      }),
     [pastRuns, activeRunId, activeMapMetrics],
   );
 
@@ -685,7 +685,7 @@ function SimulationVisualization({ state }: { state: SimulationState }) {
         <Loader2 className="h-7 w-7 animate-spin text-blue-600" />
         <p className="text-sm font-medium text-slate-800">RF 시뮬레이션 진행 중</p>
         <p className="max-w-sm text-xs leading-relaxed text-slate-500">
-          서버에서 결과를 계산하는 동안 잠시만 기다려주세요. 최대 약 15분이 소요될 수 있습니다.
+          서버에서 결과를 계산하는 동안 잠시만 기다려주세요.
         </p>
       </div>
     );

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -29,8 +29,8 @@ export default function LoginPage() {
   const apiError = login.error as HttpError | null;
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
-      <div className="w-full max-w-sm rounded-xl border bg-card p-8 shadow-sm">
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4" style={{ animation: 'page-enter 0.4s cubic-bezier(0.16, 1, 0.3, 1) both' }}>
+      <div className="w-full max-w-sm rounded-xl border bg-card p-8 shadow-sm" style={{ animation: 'panel-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) both' }}>
         <div className="mb-6 flex flex-col items-center gap-2 text-center">
           <div className="flex items-center gap-2">
             <Wifi className="h-6 w-6 text-primary" />

--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -31,8 +31,8 @@ export default function SignupPage() {
   const apiError = signup.error as HttpError | null;
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
-      <div className="w-full max-w-sm rounded-xl border bg-card p-8 shadow-sm">
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4" style={{ animation: 'page-enter 0.4s cubic-bezier(0.16, 1, 0.3, 1) both' }}>
+      <div className="w-full max-w-sm rounded-xl border bg-card p-8 shadow-sm" style={{ animation: 'panel-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) both' }}>
         <div className="mb-6 flex flex-col items-center gap-2 text-center">
           <div className="flex items-center gap-2">
             <Wifi className="h-6 w-6 text-primary" />

--- a/frontend/src/routes/AppRouter.tsx
+++ b/frontend/src/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense } from 'react';
 import { ProtectedRoute } from './ProtectedRoute';
 import { AppLayout } from '@/layouts/AppLayout';
 
+const LandingPage = lazy(() => import('@/pages/LandingPage'));
 const LoginPage = lazy(() => import('@/pages/auth/LoginPage'));
 const SignupPage = lazy(() => import('@/pages/auth/SignupPage'));
 const DashboardPage = lazy(() => import('@/pages/DashboardPage'));
@@ -19,6 +20,14 @@ const Loading = () => (
 );
 
 const router = createBrowserRouter([
+  {
+    path: '/',
+    element: (
+      <Suspense fallback={<Loading />}>
+        <LandingPage />
+      </Suspense>
+    ),
+  },
   {
     path: '/auth/login',
     element: (
@@ -41,7 +50,6 @@ const router = createBrowserRouter([
       {
         element: <AppLayout />,
         children: [
-          { index: true, element: <Navigate to="/dashboard" replace /> },
           {
             path: 'dashboard',
             element: (


### PR DESCRIPTION
- **Colormap 통일**: frontend `rssi-colormap.ts` 신규 추가, backend GP heatmap·DbmColorBar·HeatmapColorLegend 모두 동일한 warm-thermal 팔레트로 교체 (기존 inferno 제거)
- **보정 에러 개선**: 측정점이 시뮬 영역 밖일 때 `outside_sim_area` gate 추가 및 상세 한국어 안내 메시지 표시 (영역 밖 점 수, 시뮬 좌표 범위 포함)
- **시뮬 목록 캐시**: RF run 생성/완료/실패 시 목록 쿼리 캐시를 즉시 갱신해 새로고침 없이 상태 반영
- **UI 한국어화**: CalibrationCard 지표 라벨, 토스트 메시지, 모달 헤더 전반 한국어 전환
- **LandingPage 추가**: 진입 화면 신규 구현 및 관련 CSS 애니메이션 추가
- 외에 짜잘짜잘한 간격이나 버튼 크기 등 조금 수정