### PR TITLE
[Refactor] AP 위치 추천 로직 개선: 설치 가능 영역/우선 평가 영역 분리 및 실측 보정식 기반 점수화 적용

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.ap_layout import ApLayout
+from app.models.ap_recommendation_run import ApRecommendationItem, ApRecommendationRun
 from app.models.asset import Asset
 from app.models.calibration_run import CalibrationRun
 from app.models.parameter_update import ParameterUpdate
@@ -52,6 +53,8 @@ __all__ = [
     "MeasurementSession",
     "MeasurementPoint",
     "ApLayout",
+    "ApRecommendationRun",
+    "ApRecommendationItem",
     "CalibrationRun",
     "ParameterUpdate",
 ]

--- a/backend/app/models/ap_recommendation_run.py
+++ b/backend/app/models/ap_recommendation_run.py
@@ -1,0 +1,110 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ApRecommendationRun(Base):
+    __tablename__ = "ap_recommendation_runs"
+    __table_args__ = (
+        Index("idx_ap_recommendation_runs_scene_version", "scene_version_id"),
+        Index("idx_ap_recommendation_runs_floor", "floor_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    project_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    floor_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("floors.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    scene_version_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("scene_versions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    calibration_run_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("calibration_runs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=text("'completed'")
+    )
+    request_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    input_areas_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    existing_aps_json: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    calibration_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    score_weights_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    candidates_evaluated: Mapped[int] = mapped_column(
+        Integer(), nullable=False, server_default=text("0")
+    )
+    eval_points_count: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+    weighted_eval_points_count: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    items = relationship(
+        "ApRecommendationItem",
+        back_populates="run",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        order_by="ApRecommendationItem.rank",
+    )
+
+
+class ApRecommendationItem(Base):
+    __tablename__ = "ap_recommendation_items"
+    __table_args__ = (
+        Index("idx_ap_recommendation_items_run", "run_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    run_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("ap_recommendation_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    rank: Mapped[int] = mapped_column(Integer(), nullable=False)
+    recommended_x: Mapped[Decimal] = mapped_column(Numeric(10, 3), nullable=False)
+    recommended_y: Mapped[Decimal] = mapped_column(Numeric(10, 3), nullable=False)
+    score: Mapped[Decimal] = mapped_column(Numeric(12, 4), nullable=False)
+    metrics_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    prediction_points_json: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    run = relationship("ApRecommendationRun", back_populates="items")

--- a/backend/app/routers/rf/ap_recommendation.py
+++ b/backend/app/routers/rf/ap_recommendation.py
@@ -1,13 +1,20 @@
 """AP 최적 위치 추천 라우터"""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.rf.ap_recommendation import ApRecommendationRequest, ApRecommendationResponse
+from app.schemas.pagination import PaginatedResponse
+from app.schemas.rf.ap_recommendation import (
+    ApRecommendationRequest,
+    ApRecommendationResponse,
+    ApRecommendationRunResponse,
+)
 from app.services.rf import ap_recommendation_service
 
 router = APIRouter(prefix="/ap-recommendation", tags=["ap-recommendation"])
@@ -24,3 +31,41 @@ def recommend_ap(
     current_user: User = Depends(get_current_user),
 ) -> ApRecommendationResponse:
     return ap_recommendation_service.recommend_ap_location(db, request, current_user)
+
+
+@router.get(
+    "",
+    response_model=PaginatedResponse[ApRecommendationRunResponse],
+    summary="도면 버전별 AP 추천 실행 이력 조회",
+)
+def list_ap_recommendation_runs(
+    scene_version_id: UUID = Query(...),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[ApRecommendationRunResponse]:
+    return ap_recommendation_service.list_recommendation_runs(
+        db,
+        scene_version_id=scene_version_id,
+        current_user=current_user,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get(
+    "/{run_id}",
+    response_model=ApRecommendationRunResponse,
+    summary="AP 추천 실행 이력 단건 조회",
+)
+def get_ap_recommendation_run(
+    run_id: UUID = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ApRecommendationRunResponse:
+    return ap_recommendation_service.get_recommendation_run(
+        db,
+        run_id=run_id,
+        current_user=current_user,
+    )

--- a/backend/app/routers/rf/calibration_runs.py
+++ b/backend/app/routers/rf/calibration_runs.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, verify_internal_api_key
 from app.db.session import get_db
 from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
 from app.schemas.rf.calibration_run import (
     CalibrationEvaluationRequest,
     CalibrationEvaluationResponse,
@@ -53,6 +54,27 @@ def evaluate_calibration_run(
 ) -> CalibrationEvaluationResponse:
     return calibration_run_service.evaluate_calibration_run(
         db, payload=payload, user=current_user
+    )
+
+
+@router.get(
+    "",
+    response_model=PaginatedResponse[CalibrationRunResponse],
+    summary="도면 버전별 보정 실행 이력 조회",
+)
+def list_calibration_runs(
+    scene_version_id: UUID = Query(...),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PaginatedResponse[CalibrationRunResponse]:
+    return calibration_run_service.list_calibration_runs(
+        db,
+        scene_version_id=scene_version_id,
+        user=current_user,
+        page=page,
+        page_size=page_size,
     )
 
 

--- a/backend/app/routers/rf/measurements.py
+++ b/backend/app/routers/rf/measurements.py
@@ -31,12 +31,14 @@ router = APIRouter(tags=["measurement"])
 def create_measurement_link(
     floor_id: str,
     recommended_measurement_purpose: str = Query("calibration"),
+    scene_version_id: str | None = Query(default=None),
     db: Session = Depends(get_db),
 ) -> MeasurementLinkCreateResponseDTO:
     return measurement_service.create_measurement_link(
         db,
         floor_id,
         recommended_measurement_purpose=recommended_measurement_purpose,
+        scene_version_id=scene_version_id,
     )
 
 

--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -1,33 +1,52 @@
-"""AP 최적 위치 추천 스키마"""
+"""Schemas for AP placement recommendation."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class ApRecommendationBBox(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x_min: float
+    x_max: float
+    y_min: float
+    y_max: float
+
+
+class ApRecommendationZone(ApRecommendationBBox):
+    label: str | None = None
+    weight: float = Field(default=1.0, ge=0.0)
 
 
 class ApRecommendationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     scene_version_id: UUID
-    # 사용자가 드래그한 탐색 영역 (미터 단위)
-    x_min: float
-    x_max: float
-    y_min: float
-    y_max: float
+
+    # Legacy single bbox. Optional so new clients can use candidate_bboxes only.
+    x_min: float | None = None
+    x_max: float | None = None
+    y_min: float | None = None
+    y_max: float | None = None
     target_bboxes: list[dict[str, float]] = Field(default_factory=list)
-    # 격자 간격 (기본 1m)
+
+    candidate_bboxes: list[ApRecommendationBBox] = Field(default_factory=list)
+    priority_zones: list[ApRecommendationZone] = Field(default_factory=list)
+    excluded_zones: list[ApRecommendationBBox] = Field(default_factory=list)
+
     step_m: float = Field(default=1.0, gt=0.0, le=5.0)
-    # 기존 AP 리스트 — 이미 배치된 AP의 간섭/보완 효과 반영
     existing_aps: list[dict[str, Any]] = Field(default_factory=list)
-    # 보정 파라미터 출처 (없으면 기본값)
     calibration_run_id: UUID | None = None
-    # 음영 기준선 (기본 -80 dBm)
+    recommendation_mode: Literal["add", "replace"] = "add"
+    coverage_threshold_dbm: float = -67.0
+    weak_zone_threshold_dbm: float = -67.0
+
+    # Deprecated legacy fields. Kept for request compatibility.
     shadow_threshold_dbm: float = Field(default=-80.0)
-    # 음영 패널티 점수
     shadow_penalty: float = Field(default=100.0)
-    # 반환할 추천 개수
     n_recommendations: int = Field(default=3, ge=1, le=10)
 
 
@@ -38,6 +57,26 @@ class ApRecommendationItem(BaseModel):
     recommended_x: float
     recommended_y: float
     score: float
+    coverage_score: float | None = None
+    coverage_ratio: float | None = None
+    weak_zone_improvement_score: float | None = None
+    weak_zone_improvement_db: float | None = None
+    bottom_10_percent_score: float | None = None
+    bottom_10_percent_rssi_dbm: float | None = None
+    average_rssi_score: float | None = None
+    average_rssi_dbm: float | None = None
+    baseline_improvement_score: float | None = None
+    baseline_improvement_db: float | None = None
+
+
+class ApRecommendationCalibrationInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    method: str
+    slope: float
+    intercept_db: float
+    residual_used: bool = False
+    calibration_run_id: UUID | None = None
 
 
 class ApRecommendationResponse(BaseModel):
@@ -46,3 +85,8 @@ class ApRecommendationResponse(BaseModel):
     recommendations: list[ApRecommendationItem]
     status: str = "success"
     candidates_evaluated: int
+    eval_points_count: int | None = None
+    weighted_eval_points_count: int | None = None
+    calibration_applied: bool = False
+    calibration: ApRecommendationCalibrationInfo | None = None
+    score_weights: dict[str, float] = Field(default_factory=dict)

--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ApRecommendationBBox(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     x_min: float
     x_max: float
@@ -18,11 +18,11 @@ class ApRecommendationBBox(BaseModel):
 
 class ApRecommendationZone(ApRecommendationBBox):
     label: str | None = None
-    weight: float = Field(default=1.0, ge=0.0)
+    weight: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class ApRecommendationRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     scene_version_id: UUID
 
@@ -34,13 +34,20 @@ class ApRecommendationRequest(BaseModel):
     target_bboxes: list[dict[str, float]] = Field(default_factory=list)
 
     candidate_bboxes: list[ApRecommendationBBox] = Field(default_factory=list)
+    evaluation_bboxes: list[ApRecommendationBBox] = Field(default_factory=list)
     priority_zones: list[ApRecommendationZone] = Field(default_factory=list)
     excluded_zones: list[ApRecommendationBBox] = Field(default_factory=list)
+    default_unzoned_weight: float = Field(default=0.2, ge=0.0, le=1.0)
 
     step_m: float = Field(default=1.0, gt=0.0, le=5.0)
     existing_aps: list[dict[str, Any]] = Field(default_factory=list)
     calibration_run_id: UUID | None = None
+    calibration_policy: Literal["transfer_only", "best_params_only", "combined"] = (
+        "transfer_only"
+    )
     recommendation_mode: Literal["add", "replace"] = "add"
+    replace_target_ap_id: str | None = None
+    candidate_tx_power_dbm: float = 20.0
     coverage_threshold_dbm: float = -67.0
     weak_zone_threshold_dbm: float = -67.0
 
@@ -73,8 +80,11 @@ class ApRecommendationCalibrationInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     method: str
+    policy: Literal["transfer_only", "best_params_only", "combined"] = "transfer_only"
     slope: float
     intercept_db: float
+    transfer_applied: bool = False
+    best_params_applied: bool = False
     residual_used: bool = False
     calibration_run_id: UUID | None = None
 

--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -1,6 +1,7 @@
 """Schemas for AP placement recommendation."""
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
@@ -103,6 +104,7 @@ class ApRecommendationCalibrationInfo(BaseModel):
 class ApRecommendationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    run_id: UUID | None = None
     recommendations: list[ApRecommendationItem]
     status: str = "success"
     candidates_evaluated: int
@@ -111,3 +113,25 @@ class ApRecommendationResponse(BaseModel):
     calibration_applied: bool = False
     calibration: ApRecommendationCalibrationInfo | None = None
     score_weights: dict[str, float] = Field(default_factory=dict)
+    created_at: datetime | None = None
+
+
+class ApRecommendationRunResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    project_id: UUID
+    floor_id: UUID
+    scene_version_id: UUID
+    calibration_run_id: UUID | None = None
+    status: str
+    request_json: dict[str, Any] = Field(default_factory=dict)
+    input_areas_json: dict[str, Any] = Field(default_factory=dict)
+    existing_aps_json: list[dict[str, Any]] = Field(default_factory=list)
+    calibration_json: dict[str, Any] = Field(default_factory=dict)
+    score_weights_json: dict[str, float] = Field(default_factory=dict)
+    candidates_evaluated: int
+    eval_points_count: int | None = None
+    weighted_eval_points_count: int | None = None
+    recommendations: list[ApRecommendationItem] = Field(default_factory=list)
+    created_at: datetime

--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -74,6 +74,17 @@ class ApRecommendationItem(BaseModel):
     average_rssi_dbm: float | None = None
     baseline_improvement_score: float | None = None
     baseline_improvement_db: float | None = None
+    prediction_points: list["ApRecommendationPredictionPoint"] = Field(default_factory=list)
+
+
+class ApRecommendationPredictionPoint(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    x: float
+    y: float
+    rssi_dbm: float
+    baseline_rssi_dbm: float | None = None
+    weight: float = 1.0
 
 
 class ApRecommendationCalibrationInfo(BaseModel):

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -1,26 +1,28 @@
-"""Grid-based AP 최적 위치 추천.
-
-입력받은 BBox 내를 step_m 간격으로 순회하며 고속 path-loss 모델로
-신호 품질 점수를 산정, 가장 높은 점수의 격자 좌표를 반환한다.
-
-Score 계산 규칙 (수신 포인트 하나당):
-  - pred RSSI < shadow_threshold_dbm → -shadow_penalty (음영 패널티)
-  - pred RSSI ≥ shadow_threshold_dbm → +pred_rssi (신호 세기 가점)
-"""
+"""Grid-based AP placement recommendation."""
 from __future__ import annotations
 
 import logging
 import math
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
 from app.core.geom import wkb_to_geojson
-from app.models.scene_version import SceneVersion
+from app.models.calibration_run import CalibrationRun
 from app.models.project import Project
+from app.models.scene_version import SceneVersion
 from app.models.user import User
-from app.schemas.rf.ap_recommendation import ApRecommendationItem, ApRecommendationRequest, ApRecommendationResponse
+from app.schemas.rf.ap_recommendation import (
+    ApRecommendationBBox,
+    ApRecommendationCalibrationInfo,
+    ApRecommendationItem,
+    ApRecommendationRequest,
+    ApRecommendationResponse,
+)
 from app.services.rf.calibration_worker.path_loss import (
     AccessPoint,
     CalibrationParams,
@@ -28,14 +30,69 @@ from app.services.rf.calibration_worker.path_loss import (
     WallSegment,
     predict_rssi_best_ap,
 )
-from app.services.rf.scene_obstacles import column_wall_segments_for_objects, normalize_rf_material
+from app.services.rf.scene_obstacles import (
+    column_wall_segments_for_objects,
+    normalize_rf_material,
+)
 
 logger = logging.getLogger(__name__)
 
-# 평가 수신 포인트 생성용 해상도 (미터) — 너무 촘촘하면 느림, 너무 성글면 부정확
 _EVAL_GRID_STEP_M = 1.0
-# 최소 후보점 수 확보 — 영역이 너무 작으면 step 자동 축소
 _MIN_CANDIDATES = 4
+_DEFAULT_COVERAGE_THRESHOLD_DBM = -67.0
+_DEFAULT_WEAK_ZONE_THRESHOLD_DBM = -67.0
+
+SCORE_WEIGHTS: dict[str, float] = {
+    "coverage": 0.30,
+    "weak_zone_improvement": 0.25,
+    "bottom_10_percent": 0.20,
+    "average_rssi": 0.15,
+    "baseline_improvement": 0.10,
+}
+
+
+@dataclass
+class WeightedEvalPoint:
+    x: float
+    y: float
+    weight: float = 1.0
+    zone_label: str | None = None
+    baseline_rssi_dbm: float | None = None
+
+
+@dataclass
+class PredictedEvalPoint:
+    x: float
+    y: float
+    weight: float
+    zone_label: str | None
+    baseline_rssi_dbm: float | None
+    candidate_rssi_dbm: float
+
+
+@dataclass
+class RssiTransfer:
+    slope: float = 1.0
+    intercept_db: float = 0.0
+    method: str = "identity"
+    calibration_run_id: str | None = None
+    residual_enabled: bool = False
+    residual_weight: float = 0.0
+
+
+@dataclass
+class CandidateMetrics:
+    coverage_score: float
+    coverage_ratio: float
+    weak_zone_improvement_score: float | None
+    weak_zone_improvement_db: float | None
+    bottom_10_percent_score: float
+    bottom_10_percent_rssi_dbm: float
+    average_rssi_score: float
+    average_rssi_dbm: float
+    baseline_improvement_score: float | None
+    baseline_improvement_db: float | None
+    final_score: float
 
 
 def recommend_ap_location(
@@ -43,8 +100,7 @@ def recommend_ap_location(
     request: ApRecommendationRequest,
     current_user: User,
 ) -> ApRecommendationResponse:
-    """BBox 내 Grid Search로 최적 AP 위치 반환."""
-    # 1) scene_version 권한 확인
+    """Recommend Top-N AP coordinates using weighted RSSI quality metrics."""
     sv = db.execute(
         select(SceneVersion)
         .join(Project, SceneVersion.project_id == Project.id)
@@ -56,81 +112,131 @@ def recommend_ap_location(
     if sv is None:
         raise AppError(ErrorCode.SCENE_VERSION_NOT_FOUND, "Scene version not found.", 404)
 
-    # 2) 벽 데이터 로드
     walls = _load_walls(db, str(sv.id))
-
-    # 3) 보정 파라미터 로드 (없으면 기본값)
     params = _load_calibration_params(db, str(sv.id), request.calibration_run_id)
-
-    # 4) 기존 AP 변환
+    rssi_transfer = _load_rssi_transfer(db, str(sv.id), request.calibration_run_id)
     existing_aps = _parse_existing_aps(request.existing_aps)
 
-    # 5) 탐색 후보 격자 생성
     candidates = _generate_candidates_for_request(request)
     if not candidates:
         raise AppError(
             ErrorCode.INVALID_REQUEST_BODY,
-            "BBox가 너무 작아 후보 격자를 생성할 수 없습니다. "
-            "영역을 넓히거나 step_m을 줄여주세요.",
+            "No AP candidates could be generated. Check candidate_bboxes and step_m.",
             400,
         )
 
-    # 6) 평가 수신 포인트 격자 생성 (도면 전체 기준)
-    eval_points = _generate_eval_points(db, str(sv.id))
-    if not eval_points:
-        # 벽/도면 정보 없으면 BBox 자체를 eval 격자로 사용
-        eval_points = _generate_candidates(
-            request.x_min, request.x_max,
-            request.y_min, request.y_max,
-            _EVAL_GRID_STEP_M,
+    raw_eval_points = _generate_eval_points(db, str(sv.id))
+    if not raw_eval_points:
+        raw_eval_points = [
+            Measurement(x=x, y=y, rssi_dbm=0.0)
+            for x, y in _generate_eval_fallback_points(request)
+        ]
+    weighted_points = _build_weighted_eval_points(
+        raw_eval_points,
+        priority_zones=request.priority_zones,
+        excluded_zones=request.excluded_zones,
+    )
+    if not weighted_points:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "All evaluation points were excluded. Adjust excluded_zones or floor geometry.",
+            400,
         )
 
-    logger.info(
-        "AP 추천 시작: scene=%s candidates=%d eval_points=%d existing_aps=%d",
-        sv.id, len(candidates), len(eval_points), len(existing_aps),
-    )
-
-    # 7) Grid Search — 상위 n_recommendations개 반환
-    top_results = _grid_search_topn(
-        candidates=candidates,
-        eval_points=eval_points,
+    _attach_baseline_rssi(
+        points=weighted_points,
         existing_aps=existing_aps,
         walls=walls,
         params=params,
-        shadow_threshold_dbm=request.shadow_threshold_dbm,
-        shadow_penalty=request.shadow_penalty,
-        n=request.n_recommendations,
+        transfer=rssi_transfer,
     )
 
     logger.info(
-        "AP 추천 완료: top%d, best=(%.2f, %.2f) score=%.1f",
-        len(top_results), top_results[0][0], top_results[0][1], top_results[0][2],
+        "AP recommendation start: scene=%s candidates=%d eval=%d weighted=%d existing_aps=%d calibration=%s",
+        sv.id,
+        len(candidates),
+        len(raw_eval_points),
+        len(weighted_points),
+        len(existing_aps),
+        rssi_transfer.method,
     )
+
+    top_results = _grid_search_topn(
+        candidates=candidates,
+        eval_points=weighted_points,
+        existing_aps=existing_aps,
+        walls=walls,
+        params=params,
+        transfer=rssi_transfer,
+        recommendation_mode=request.recommendation_mode,
+        coverage_threshold_dbm=request.coverage_threshold_dbm
+        or _DEFAULT_COVERAGE_THRESHOLD_DBM,
+        weak_zone_threshold_dbm=request.weak_zone_threshold_dbm
+        or _DEFAULT_WEAK_ZONE_THRESHOLD_DBM,
+        n=request.n_recommendations,
+    )
+
+    recommendations = [
+        _to_response_item(i + 1, x, y, metrics)
+        for i, (x, y, metrics) in enumerate(top_results)
+    ]
 
     return ApRecommendationResponse(
-        recommendations=[
-            ApRecommendationItem(
-                rank=i + 1,
-                recommended_x=round(x, 3),
-                recommended_y=round(y, 3),
-                score=round(score, 2),
-            )
-            for i, (x, y, score) in enumerate(top_results)
-        ],
+        recommendations=recommendations,
         candidates_evaluated=len(candidates),
+        eval_points_count=len(raw_eval_points),
+        weighted_eval_points_count=len(weighted_points),
+        calibration_applied=rssi_transfer.method != "identity",
+        calibration=ApRecommendationCalibrationInfo(
+            method=rssi_transfer.method,
+            slope=round(rssi_transfer.slope, 6),
+            intercept_db=round(rssi_transfer.intercept_db, 6),
+            residual_used=False,
+            calibration_run_id=UUID(rssi_transfer.calibration_run_id)
+            if rssi_transfer.calibration_run_id
+            else None,
+        ),
+        score_weights=SCORE_WEIGHTS,
     )
 
 
-# ────────────────────────────────────────────────────────────────────
-# 내부 헬퍼
-# ────────────────────────────────────────────────────────────────────
+def _to_response_item(
+    rank: int,
+    x: float,
+    y: float,
+    metrics: CandidateMetrics,
+) -> ApRecommendationItem:
+    return ApRecommendationItem(
+        rank=rank,
+        recommended_x=round(x, 3),
+        recommended_y=round(y, 3),
+        score=round(metrics.final_score, 4),
+        coverage_score=round(metrics.coverage_score, 4),
+        coverage_ratio=round(metrics.coverage_ratio, 4),
+        weak_zone_improvement_score=_round_optional(metrics.weak_zone_improvement_score),
+        weak_zone_improvement_db=_round_optional(metrics.weak_zone_improvement_db),
+        bottom_10_percent_score=round(metrics.bottom_10_percent_score, 4),
+        bottom_10_percent_rssi_dbm=round(metrics.bottom_10_percent_rssi_dbm, 2),
+        average_rssi_score=round(metrics.average_rssi_score, 4),
+        average_rssi_dbm=round(metrics.average_rssi_dbm, 2),
+        baseline_improvement_score=_round_optional(metrics.baseline_improvement_score),
+        baseline_improvement_db=_round_optional(metrics.baseline_improvement_db),
+    )
+
+
+def _round_optional(value: float | None, digits: int = 4) -> float | None:
+    if value is None:
+        return None
+    return round(value, digits)
+
 
 def _generate_candidates(
-    x_min: float, x_max: float,
-    y_min: float, y_max: float,
+    x_min: float,
+    x_max: float,
+    y_min: float,
+    y_max: float,
     step_m: float,
 ) -> list[tuple[float, float]]:
-    """BBox 내부를 step_m 간격으로 순회하는 격자 좌표 리스트."""
     if x_max <= x_min or y_max <= y_min:
         return []
     pts: list[tuple[float, float]] = []
@@ -147,26 +253,17 @@ def _generate_candidates(
 def _generate_candidates_for_request(
     request: ApRecommendationRequest,
 ) -> list[tuple[float, float]]:
-    """Generate candidate grid points inside all selected target boxes."""
-    raw_boxes = request.target_bboxes or [
-        {
-            "x_min": request.x_min,
-            "x_max": request.x_max,
-            "y_min": request.y_min,
-            "y_max": request.y_max,
-        }
-    ]
+    boxes = _candidate_boxes_for_request(request)
     seen: set[tuple[float, float]] = set()
     candidates: list[tuple[float, float]] = []
-    for box in raw_boxes:
-        try:
-            x_min = float(box["x_min"])
-            x_max = float(box["x_max"])
-            y_min = float(box["y_min"])
-            y_max = float(box["y_max"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        for point in _generate_candidates(x_min, x_max, y_min, y_max, request.step_m):
+    for box in boxes:
+        for point in _generate_candidates(
+            box.x_min,
+            box.x_max,
+            box.y_min,
+            box.y_max,
+            _candidate_step_for_box(box, request.step_m),
+        ):
             key = (round(point[0], 6), round(point[1], 6))
             if key in seen:
                 continue
@@ -175,13 +272,81 @@ def _generate_candidates_for_request(
     return candidates
 
 
-def _generate_eval_points(
-    db: Session, scene_version_id: str,
-) -> list[Measurement]:
-    """confirmed scene version 의 벽 bbox 기반으로 평가 격자를 만든다.
+def _candidate_boxes_for_request(
+    request: ApRecommendationRequest,
+) -> list[ApRecommendationBBox]:
+    if request.candidate_bboxes:
+        return request.candidate_bboxes
+    if request.target_bboxes:
+        out: list[ApRecommendationBBox] = []
+        for raw in request.target_bboxes:
+            try:
+                out.append(
+                    ApRecommendationBBox(
+                        x_min=float(raw["x_min"]),
+                        x_max=float(raw["x_max"]),
+                        y_min=float(raw["y_min"]),
+                        y_max=float(raw["y_max"]),
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+        return out
+    if (
+        request.x_min is not None
+        and request.x_max is not None
+        and request.y_min is not None
+        and request.y_max is not None
+    ):
+        return [
+            ApRecommendationBBox(
+                x_min=request.x_min,
+                x_max=request.x_max,
+                y_min=request.y_min,
+                y_max=request.y_max,
+            )
+        ]
+    return []
 
-    벽이 없으면 빈 리스트 반환 — 호출측이 BBox fallback 사용.
-    """
+
+def _candidate_step_for_box(box: ApRecommendationBBox, step_m: float) -> float:
+    width = box.x_max - box.x_min
+    height = box.y_max - box.y_min
+    if width <= 0 or height <= 0:
+        return step_m
+    if (math.floor(width / step_m) + 1) * (math.floor(height / step_m) + 1) >= _MIN_CANDIDATES:
+        return step_m
+    return max(0.1, min(width, height) / 2.0)
+
+
+def _generate_eval_fallback_points(
+    request: ApRecommendationRequest,
+) -> list[tuple[float, float]]:
+    boxes = _candidate_boxes_for_request(request)
+    if not boxes:
+        return []
+    points: list[tuple[float, float]] = []
+    seen: set[tuple[float, float]] = set()
+    for box in boxes:
+        for point in _generate_candidates(
+            box.x_min,
+            box.x_max,
+            box.y_min,
+            box.y_max,
+            _EVAL_GRID_STEP_M,
+        ):
+            key = (round(point[0], 6), round(point[1], 6))
+            if key in seen:
+                continue
+            seen.add(key)
+            points.append(point)
+    return points
+
+
+def _generate_eval_points(
+    db: Session,
+    scene_version_id: str,
+) -> list[Measurement]:
     from app.models.wall import Wall
 
     rows = db.execute(
@@ -197,8 +362,11 @@ def _generate_eval_points(
         if not gj or gj.get("type") != "LineString":
             continue
         for coord in (gj.get("coordinates") or []):
-            xs.append(float(coord[0]))
-            ys.append(float(coord[1]))
+            try:
+                xs.append(float(coord[0]))
+                ys.append(float(coord[1]))
+            except (TypeError, ValueError, IndexError):
+                continue
     if not xs:
         return []
 
@@ -216,9 +384,47 @@ def _generate_eval_points(
     return pts
 
 
+def _build_weighted_eval_points(
+    eval_points: list[Measurement],
+    *,
+    priority_zones: list[Any],
+    excluded_zones: list[Any],
+) -> list[WeightedEvalPoint]:
+    weighted: list[WeightedEvalPoint] = []
+    for point in eval_points:
+        if any(_point_in_bbox(point.x, point.y, zone) for zone in excluded_zones):
+            continue
+        weight = 1.0
+        label: str | None = None
+        for zone in priority_zones:
+            if _point_in_bbox(point.x, point.y, zone):
+                zone_weight = float(getattr(zone, "weight", 1.0))
+                if zone_weight >= weight or label is None:
+                    weight = zone_weight
+                    label = getattr(zone, "label", None)
+        if weight <= 0:
+            continue
+        weighted.append(
+            WeightedEvalPoint(
+                x=point.x,
+                y=point.y,
+                weight=weight,
+                zone_label=label,
+            )
+        )
+    return weighted
+
+
+def _point_in_bbox(x: float, y: float, box: Any) -> bool:
+    return (
+        float(box.x_min) <= x <= float(box.x_max)
+        and float(box.y_min) <= y <= float(box.y_max)
+    )
+
+
 def _load_walls(db: Session, scene_version_id: str) -> list[WallSegment]:
-    from app.models.wall import Wall
     from app.models.object import SceneObject
+    from app.models.wall import Wall
 
     rows = db.execute(
         select(Wall).where(Wall.scene_version_id == scene_version_id)
@@ -236,36 +442,40 @@ def _load_walls(db: Session, scene_version_id: str) -> list[WallSegment]:
             continue
         x1, y1 = float(coords[0][0]), float(coords[0][1])
         x2, y2 = float(coords[-1][0]), float(coords[-1][1])
-        out.append(WallSegment(
-            x1=x1, y1=y1, x2=x2, y2=y2,
-            thickness_m=float(w.thickness_m) if w.thickness_m is not None else 0.12,
-            material=normalize_rf_material(w.material_label),
-        ))
+        out.append(
+            WallSegment(
+                x1=x1,
+                y1=y1,
+                x2=x2,
+                y2=y2,
+                thickness_m=float(w.thickness_m) if w.thickness_m is not None else 0.12,
+                material=normalize_rf_material(w.material_label),
+            )
+        )
     for seg in column_wall_segments_for_objects(objects):
-        out.append(WallSegment(
-            x1=float(seg["x1"]),
-            y1=float(seg["y1"]),
-            x2=float(seg["x2"]),
-            y2=float(seg["y2"]),
-            thickness_m=float(seg["thickness_m"]),
-            material=str(seg["material"]) if seg["material"] else None,
-        ))
+        out.append(
+            WallSegment(
+                x1=float(seg["x1"]),
+                y1=float(seg["y1"]),
+                x2=float(seg["x2"]),
+                y2=float(seg["y2"]),
+                thickness_m=float(seg["thickness_m"]),
+                material=str(seg["material"]) if seg["material"] else None,
+            )
+        )
     return out
 
 
 def _load_calibration_params(
-    db: Session, scene_version_id: str, calibration_run_id=None
+    db: Session,
+    scene_version_id: str,
+    calibration_run_id=None,
 ) -> CalibrationParams:
-    """calibration_run_id 지정 시 해당 run의 best_params 사용.
-    없으면 scene_version 의 최신 completed calibration 자동 탐색.
-    둘 다 없으면 기본값 반환.
-    """
     from app.services.rf.calibration_worker.apply import get_latest_calibration
-    from app.models.calibration_run import CalibrationRun
 
     run = None
     if calibration_run_id is not None:
-        run = db.get(CalibrationRun, str(calibration_run_id))
+        run = _get_calibration_for_scene_or_400(db, scene_version_id, calibration_run_id)
     if run is None:
         run = get_latest_calibration(db, scene_version_id)
     if run is None or not run.metrics_json:
@@ -276,15 +486,104 @@ def _load_calibration_params(
         return CalibrationParams()
 
     return CalibrationParams(
-        tx_power_offset_db=float(best.get("tx_power_offset_db", 0.0)),
-        path_loss_exp=float(best.get("path_loss_exp", 3.0)),
-        floor_thickness_m=float(best.get("floor_thickness_m", 0.10)),
-        furniture_default_thickness_m=float(best.get("furniture_default_thickness_m", 0.05)),
+        tx_power_offset_db=_finite_float(best.get("tx_power_offset_db"), 0.0),
+        path_loss_exp=_finite_float(best.get("path_loss_exp"), 3.0),
+        floor_thickness_m=_finite_float(best.get("floor_thickness_m"), 0.10),
+        furniture_default_thickness_m=_finite_float(
+            best.get("furniture_default_thickness_m"),
+            0.05,
+        ),
         material_attenuation_scales={
-            str(k): float(v)
+            str(k): _finite_float(v, 1.0)
             for k, v in (best.get("material_attenuation_scales") or {}).items()
         },
     )
+
+
+def _load_rssi_transfer(
+    db: Session,
+    scene_version_id: str,
+    calibration_run_id=None,
+) -> RssiTransfer:
+    run = None
+    if calibration_run_id is not None:
+        run = _get_calibration_for_scene_or_400(db, scene_version_id, calibration_run_id)
+    else:
+        run = db.execute(
+            select(CalibrationRun)
+            .where(
+                CalibrationRun.scene_version_id == str(scene_version_id),
+                CalibrationRun.status == "completed",
+            )
+            .order_by(CalibrationRun.created_at.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+    if run is None or not run.metrics_json:
+        return RssiTransfer()
+
+    calibration = _find_calibration_metrics(run.metrics_json)
+    if not calibration:
+        return RssiTransfer()
+
+    slope = _finite_float(calibration.get("slope"), 1.0)
+    intercept = _finite_float(
+        calibration.get("intercept_db", calibration.get("intercept")),
+        0.0,
+    )
+    if not math.isfinite(slope) or not math.isfinite(intercept):
+        return RssiTransfer()
+    return RssiTransfer(
+        slope=slope,
+        intercept_db=intercept,
+        method=str(calibration.get("method") or "affine_rssi_transfer"),
+        calibration_run_id=str(run.id),
+        residual_enabled=False,
+        residual_weight=0.0,
+    )
+
+
+def _get_calibration_for_scene_or_400(
+    db: Session,
+    scene_version_id: str,
+    calibration_run_id: Any,
+) -> CalibrationRun | None:
+    run = db.get(CalibrationRun, str(calibration_run_id))
+    if run is None:
+        raise AppError(ErrorCode.INVALID_REQUEST_BODY, "Calibration run not found.", 400)
+    if str(run.scene_version_id) != str(scene_version_id):
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "Calibration run does not belong to this scene_version_id.",
+            400,
+        )
+    return run
+
+
+def _find_calibration_metrics(metrics_json: dict[str, Any]) -> dict[str, Any] | None:
+    evaluation = metrics_json.get("evaluation")
+    if isinstance(evaluation, dict):
+        calibration = evaluation.get("calibration")
+        if isinstance(calibration, dict):
+            return calibration
+    maps = metrics_json.get("maps")
+    if isinstance(maps, dict):
+        calibrated = maps.get("calibrated")
+        if isinstance(calibrated, dict):
+            calibration = calibrated.get("calibration")
+            if isinstance(calibration, dict):
+                return calibration
+    calibration = metrics_json.get("calibration")
+    if isinstance(calibration, dict):
+        return calibration
+    return None
+
+
+def _finite_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if math.isfinite(parsed) else default
 
 
 def _parse_existing_aps(raw: list[dict]) -> list[AccessPoint]:
@@ -294,42 +593,249 @@ def _parse_existing_aps(raw: list[dict]) -> list[AccessPoint]:
         y = ap.get("y_m") if ap.get("y_m") is not None else ap.get("y")
         if x is None or y is None:
             continue
-        aps.append(AccessPoint(
-            name=str(ap.get("id") or ap.get("name") or f"ap{i + 1}"),
-            x=float(x),
-            y=float(y),
-            tx_power_dbm=float(ap.get("tx_power_dbm") or ap.get("power_dbm") or 20.0),
-        ))
+        aps.append(
+            AccessPoint(
+                name=str(ap.get("id") or ap.get("name") or f"ap{i + 1}"),
+                x=_finite_float(x, 0.0),
+                y=_finite_float(y, 0.0),
+                tx_power_dbm=_finite_float(
+                    ap.get("tx_power_dbm", ap.get("power_dbm")),
+                    20.0,
+                ),
+            )
+        )
     return aps
+
+
+def _attach_baseline_rssi(
+    *,
+    points: list[WeightedEvalPoint],
+    existing_aps: list[AccessPoint],
+    walls: list[WallSegment],
+    params: CalibrationParams,
+    transfer: RssiTransfer,
+) -> None:
+    if not existing_aps:
+        return
+    for point in points:
+        raw = predict_rssi_best_ap(existing_aps, _as_measurement(point), walls, params)
+        point.baseline_rssi_dbm = apply_rssi_transfer(raw, transfer)
+
+
+def apply_rssi_transfer(raw_pred: float, transfer: RssiTransfer) -> float:
+    return transfer.slope * raw_pred + transfer.intercept_db
+
+
+def _as_measurement(point: WeightedEvalPoint) -> Measurement:
+    return Measurement(x=point.x, y=point.y, rssi_dbm=0.0)
 
 
 def _grid_search_topn(
     *,
     candidates: list[tuple[float, float]],
-    eval_points: list[Measurement],
+    eval_points: list[WeightedEvalPoint],
     existing_aps: list[AccessPoint],
     walls: list[WallSegment],
     params: CalibrationParams,
-    shadow_threshold_dbm: float,
-    shadow_penalty: float,
+    transfer: RssiTransfer,
+    recommendation_mode: str,
+    coverage_threshold_dbm: float,
+    weak_zone_threshold_dbm: float,
     n: int,
-) -> list[tuple[float, float, float]]:
-    """모든 후보 좌표에 대해 점수 계산 후 상위 n개 반환 (x, y, score)."""
-    scored: list[tuple[float, float, float]] = []
+) -> list[tuple[float, float, CandidateMetrics]]:
+    scored: list[tuple[float, float, CandidateMetrics]] = []
 
-    for (cx, cy) in candidates:
-        test_ap = AccessPoint(name="test", x=cx, y=cy)
-        all_aps = existing_aps + [test_ap]
+    for cx, cy in candidates:
+        test_ap = AccessPoint(name="candidate", x=cx, y=cy)
+        eval_aps = (
+            existing_aps + [test_ap]
+            if recommendation_mode == "add"
+            else [test_ap]
+        )
+        predicted: list[PredictedEvalPoint] = []
+        for point in eval_points:
+            raw = predict_rssi_best_ap(eval_aps, _as_measurement(point), walls, params)
+            calibrated = apply_rssi_transfer(raw, transfer)
+            predicted.append(
+                PredictedEvalPoint(
+                    x=point.x,
+                    y=point.y,
+                    weight=point.weight,
+                    zone_label=point.zone_label,
+                    baseline_rssi_dbm=point.baseline_rssi_dbm,
+                    candidate_rssi_dbm=calibrated,
+                )
+            )
+        metrics = compute_ap_recommendation_metrics(
+            predicted,
+            coverage_threshold_dbm=coverage_threshold_dbm,
+            weak_zone_threshold_dbm=weak_zone_threshold_dbm,
+        )
+        scored.append((cx, cy, metrics))
 
-        score = 0.0
-        for ep in eval_points:
-            pred = predict_rssi_best_ap(all_aps, ep, walls, params)
-            if pred < shadow_threshold_dbm:
-                score -= shadow_penalty
-            else:
-                score += pred
-
-        scored.append((cx, cy, score))
-
-    scored.sort(key=lambda t: t[2], reverse=True)
+    scored.sort(
+        key=lambda t: (
+            t[2].final_score,
+            t[2].coverage_score,
+            t[2].bottom_10_percent_score,
+            t[2].average_rssi_score,
+        ),
+        reverse=True,
+    )
     return scored[:n]
+
+
+def compute_ap_recommendation_metrics(
+    points: list[PredictedEvalPoint],
+    *,
+    coverage_threshold_dbm: float,
+    weak_zone_threshold_dbm: float,
+) -> CandidateMetrics:
+    total_weight = sum(max(0.0, p.weight) for p in points)
+    if total_weight <= 0:
+        return CandidateMetrics(
+            coverage_score=0.0,
+            coverage_ratio=0.0,
+            weak_zone_improvement_score=None,
+            weak_zone_improvement_db=None,
+            bottom_10_percent_score=0.0,
+            bottom_10_percent_rssi_dbm=-110.0,
+            average_rssi_score=0.0,
+            average_rssi_dbm=-110.0,
+            baseline_improvement_score=None,
+            baseline_improvement_db=None,
+            final_score=0.0,
+        )
+
+    coverage_ratio = (
+        sum(p.weight for p in points if p.candidate_rssi_dbm >= coverage_threshold_dbm)
+        / total_weight
+    )
+    average_rssi = _weighted_average(
+        [(p.candidate_rssi_dbm, p.weight) for p in points],
+        default=-110.0,
+    )
+    bottom_rssi = _weighted_bottom_percent_average(points, percent=0.10)
+
+    baseline_points = [p for p in points if p.baseline_rssi_dbm is not None]
+    weak_points = [
+        p for p in baseline_points
+        if p.baseline_rssi_dbm is not None
+        and p.baseline_rssi_dbm < weak_zone_threshold_dbm
+    ]
+    weak_improvement_db = None
+    weak_score = None
+    if weak_points:
+        weak_improvement_db = _weighted_average(
+            [
+                (p.candidate_rssi_dbm - float(p.baseline_rssi_dbm), p.weight)
+                for p in weak_points
+            ],
+            default=0.0,
+        )
+        weak_score = normalize_improvement(weak_improvement_db, 0.0, 15.0)
+
+    baseline_improvement_db = None
+    baseline_score = None
+    if baseline_points:
+        baseline_improvement_db = _weighted_average(
+            [
+                (p.candidate_rssi_dbm - float(p.baseline_rssi_dbm), p.weight)
+                for p in baseline_points
+            ],
+            default=0.0,
+        )
+        baseline_score = normalize_improvement(baseline_improvement_db, 0.0, 10.0)
+
+    coverage_score = coverage_ratio
+    bottom_score = normalize_rssi(bottom_rssi, -85.0, coverage_threshold_dbm)
+    avg_score = normalize_rssi(average_rssi, -85.0, -45.0)
+    metric_scores: dict[str, float | None] = {
+        "coverage": coverage_score,
+        "weak_zone_improvement": weak_score,
+        "bottom_10_percent": bottom_score,
+        "average_rssi": avg_score,
+        "baseline_improvement": baseline_score,
+    }
+    final_score = _weighted_metric_score(metric_scores)
+
+    return CandidateMetrics(
+        coverage_score=coverage_score,
+        coverage_ratio=coverage_ratio,
+        weak_zone_improvement_score=weak_score,
+        weak_zone_improvement_db=weak_improvement_db,
+        bottom_10_percent_score=bottom_score,
+        bottom_10_percent_rssi_dbm=bottom_rssi,
+        average_rssi_score=avg_score,
+        average_rssi_dbm=average_rssi,
+        baseline_improvement_score=baseline_score,
+        baseline_improvement_db=baseline_improvement_db,
+        final_score=final_score,
+    )
+
+
+def _weighted_metric_score(metric_scores: dict[str, float | None]) -> float:
+    numerator = 0.0
+    denominator = 0.0
+    for key, weight in SCORE_WEIGHTS.items():
+        value = metric_scores.get(key)
+        if value is None:
+            continue
+        numerator += weight * value
+        denominator += weight
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator
+
+
+def _weighted_average(values: list[tuple[float, float]], default: float) -> float:
+    denominator = sum(max(0.0, weight) for _, weight in values)
+    if denominator <= 0:
+        return default
+    return sum(value * max(0.0, weight) for value, weight in values) / denominator
+
+
+def _weighted_bottom_percent_average(
+    points: list[PredictedEvalPoint],
+    *,
+    percent: float,
+) -> float:
+    total_weight = sum(max(0.0, p.weight) for p in points)
+    if total_weight <= 0:
+        return -110.0
+    target_weight = max(total_weight * percent, 1e-9)
+    remaining = target_weight
+    numerator = 0.0
+    denominator = 0.0
+    for point in sorted(points, key=lambda p: p.candidate_rssi_dbm):
+        if remaining <= 0:
+            break
+        take = min(max(0.0, point.weight), remaining)
+        numerator += point.candidate_rssi_dbm * take
+        denominator += take
+        remaining -= take
+    if denominator <= 0:
+        return -110.0
+    return numerator / denominator
+
+
+def normalize_linear(value: float, min_value: float, max_value: float) -> float:
+    if max_value <= min_value:
+        return 0.0
+    return max(0.0, min(1.0, (value - min_value) / (max_value - min_value)))
+
+
+def normalize_rssi(
+    rssi_dbm: float,
+    min_dbm: float = -85.0,
+    max_dbm: float = -45.0,
+) -> float:
+    return normalize_linear(rssi_dbm, min_dbm, max_dbm)
+
+
+def normalize_improvement(
+    improvement_db: float,
+    min_db: float = 0.0,
+    max_db: float = 15.0,
+) -> float:
+    return normalize_linear(improvement_db, min_db, max_db)

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -3,19 +3,25 @@ from __future__ import annotations
 
 import logging
 import math
+from decimal import Decimal
 from dataclasses import dataclass
 from typing import Any, Literal
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
 from app.core.geom import wkb_to_geojson
+from app.models.ap_recommendation_run import (
+    ApRecommendationItem as ApRecommendationItemRow,
+    ApRecommendationRun,
+)
 from app.models.calibration_run import CalibrationRun
 from app.models.project import Project
 from app.models.scene_version import SceneVersion
 from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
 from app.schemas.rf.ap_recommendation import (
     ApRecommendationBBox,
     ApRecommendationCalibrationInfo,
@@ -23,6 +29,7 @@ from app.schemas.rf.ap_recommendation import (
     ApRecommendationPredictionPoint,
     ApRecommendationRequest,
     ApRecommendationResponse,
+    ApRecommendationRunResponse,
 )
 from app.services.rf.calibration_worker.path_loss import (
     AccessPoint,
@@ -198,7 +205,7 @@ def recommend_ap_location(
         for i, (x, y, metrics, predicted) in enumerate(top_results)
     ]
 
-    return ApRecommendationResponse(
+    response = ApRecommendationResponse(
         recommendations=recommendations,
         candidates_evaluated=len(candidates),
         eval_points_count=len(raw_eval_points),
@@ -218,6 +225,214 @@ def recommend_ap_location(
         ),
         score_weights=SCORE_WEIGHTS,
     )
+    run = _persist_recommendation_run(
+        db=db,
+        scene_version=sv,
+        request=request,
+        response=response,
+        calibration_run=selected_calibration_run,
+    )
+    response.run_id = UUID(str(run.id))
+    response.created_at = run.created_at
+    return response
+
+
+def list_recommendation_runs(
+    db: Session,
+    *,
+    scene_version_id: UUID,
+    current_user: User,
+    page: int = 1,
+    page_size: int = 20,
+) -> PaginatedResponse[ApRecommendationRunResponse]:
+    sv = db.execute(
+        select(SceneVersion)
+        .join(Project, SceneVersion.project_id == Project.id)
+        .where(
+            SceneVersion.id == str(scene_version_id),
+            Project.owner_user_id == current_user.id,
+        )
+    ).scalar_one_or_none()
+    if sv is None:
+        raise AppError(ErrorCode.SCENE_VERSION_NOT_FOUND, "Scene version not found.", 404)
+
+    stmt = select(ApRecommendationRun).where(
+        ApRecommendationRun.scene_version_id == str(scene_version_id)
+    )
+    total = db.execute(
+        select(func.count(ApRecommendationRun.id)).where(
+            ApRecommendationRun.scene_version_id == str(scene_version_id)
+        )
+    ).scalar() or 0
+    rows = (
+        db.execute(
+            stmt.order_by(ApRecommendationRun.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        .scalars()
+        .all()
+    )
+    return PaginatedResponse[ApRecommendationRunResponse](
+        items=[_run_to_response(row) for row in rows],
+        page=page,
+        page_size=page_size,
+        total=int(total),
+    )
+
+
+def get_recommendation_run(
+    db: Session,
+    *,
+    run_id: UUID,
+    current_user: User,
+) -> ApRecommendationRunResponse:
+    row = (
+        db.execute(
+            select(ApRecommendationRun)
+            .join(Project, ApRecommendationRun.project_id == Project.id)
+            .where(
+                ApRecommendationRun.id == str(run_id),
+                Project.owner_user_id == current_user.id,
+            )
+        )
+        .scalar_one_or_none()
+    )
+    if row is None:
+        raise AppError(
+            ErrorCode.INVALID_REQUEST_BODY,
+            "AP recommendation run not found.",
+            404,
+        )
+    return _run_to_response(row)
+
+
+def _persist_recommendation_run(
+    *,
+    db: Session,
+    scene_version: SceneVersion,
+    request: ApRecommendationRequest,
+    response: ApRecommendationResponse,
+    calibration_run: CalibrationRun | None,
+) -> ApRecommendationRun:
+    calibration = (
+        response.calibration.model_dump(mode="json")
+        if response.calibration is not None
+        else {}
+    )
+    run = ApRecommendationRun(
+        project_id=scene_version.project_id,
+        floor_id=scene_version.floor_id,
+        scene_version_id=scene_version.id,
+        calibration_run_id=calibration_run.id if calibration_run is not None else None,
+        status=response.status,
+        request_json=request.model_dump(mode="json"),
+        input_areas_json={
+            "candidate_bboxes": [b.model_dump(mode="json") for b in request.candidate_bboxes],
+            "evaluation_bboxes": [b.model_dump(mode="json") for b in request.evaluation_bboxes],
+            "priority_zones": [z.model_dump(mode="json") for z in request.priority_zones],
+            "excluded_zones": [b.model_dump(mode="json") for b in request.excluded_zones],
+            "default_unzoned_weight": request.default_unzoned_weight,
+        },
+        existing_aps_json=list(request.existing_aps),
+        calibration_json=calibration,
+        score_weights_json=dict(response.score_weights),
+        candidates_evaluated=response.candidates_evaluated,
+        eval_points_count=response.eval_points_count,
+        weighted_eval_points_count=response.weighted_eval_points_count,
+    )
+    db.add(run)
+    db.flush()
+
+    for item in response.recommendations:
+        db.add(
+            ApRecommendationItemRow(
+                run_id=run.id,
+                rank=item.rank,
+                recommended_x=Decimal(str(item.recommended_x)),
+                recommended_y=Decimal(str(item.recommended_y)),
+                score=Decimal(str(item.score)),
+                metrics_json=_item_metrics_json(item),
+                prediction_points_json=[
+                    p.model_dump(mode="json") for p in item.prediction_points
+                ],
+            )
+        )
+
+    db.commit()
+    db.refresh(run)
+    return run
+
+
+def _item_metrics_json(item: ApRecommendationItem) -> dict[str, Any]:
+    data = item.model_dump(mode="json", exclude={"prediction_points"})
+    data.pop("rank", None)
+    data.pop("recommended_x", None)
+    data.pop("recommended_y", None)
+    data.pop("score", None)
+    return data
+
+
+def _run_to_response(row: ApRecommendationRun) -> ApRecommendationRunResponse:
+    return ApRecommendationRunResponse(
+        id=row.id,
+        project_id=row.project_id,
+        floor_id=row.floor_id,
+        scene_version_id=row.scene_version_id,
+        calibration_run_id=row.calibration_run_id,
+        status=row.status,
+        request_json=row.request_json or {},
+        input_areas_json=row.input_areas_json or {},
+        existing_aps_json=row.existing_aps_json or [],
+        calibration_json=row.calibration_json or {},
+        score_weights_json=row.score_weights_json or {},
+        candidates_evaluated=row.candidates_evaluated,
+        eval_points_count=row.eval_points_count,
+        weighted_eval_points_count=row.weighted_eval_points_count,
+        recommendations=[_item_row_to_schema(item) for item in row.items],
+        created_at=row.created_at,
+    )
+
+
+def _item_row_to_schema(row: ApRecommendationItemRow) -> ApRecommendationItem:
+    metrics = row.metrics_json or {}
+    return ApRecommendationItem(
+        rank=row.rank,
+        recommended_x=float(row.recommended_x),
+        recommended_y=float(row.recommended_y),
+        score=float(row.score),
+        coverage_score=_float_or_none(metrics.get("coverage_score")),
+        coverage_ratio=_float_or_none(metrics.get("coverage_ratio")),
+        weak_zone_improvement_score=_float_or_none(
+            metrics.get("weak_zone_improvement_score")
+        ),
+        weak_zone_improvement_db=_float_or_none(metrics.get("weak_zone_improvement_db")),
+        bottom_10_percent_score=_float_or_none(metrics.get("bottom_10_percent_score")),
+        bottom_10_percent_rssi_dbm=_float_or_none(
+            metrics.get("bottom_10_percent_rssi_dbm")
+        ),
+        average_rssi_score=_float_or_none(metrics.get("average_rssi_score")),
+        average_rssi_dbm=_float_or_none(metrics.get("average_rssi_dbm")),
+        baseline_improvement_score=_float_or_none(
+            metrics.get("baseline_improvement_score")
+        ),
+        baseline_improvement_db=_float_or_none(metrics.get("baseline_improvement_db")),
+        prediction_points=[
+            ApRecommendationPredictionPoint(**p)
+            for p in (row.prediction_points_json or [])
+            if isinstance(p, dict)
+        ],
+    )
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _to_response_item(

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from sqlalchemy import select
@@ -41,6 +41,9 @@ _EVAL_GRID_STEP_M = 1.0
 _MIN_CANDIDATES = 4
 _DEFAULT_COVERAGE_THRESHOLD_DBM = -67.0
 _DEFAULT_WEAK_ZONE_THRESHOLD_DBM = -67.0
+_DEFAULT_UNZONED_WEIGHT = 0.2
+
+CalibrationPolicy = Literal["transfer_only", "best_params_only", "combined"]
 
 SCORE_WEIGHTS: dict[str, float] = {
     "coverage": 0.30,
@@ -76,6 +79,7 @@ class RssiTransfer:
     intercept_db: float = 0.0
     method: str = "identity"
     calibration_run_id: str | None = None
+    transfer_applied: bool = False
     residual_enabled: bool = False
     residual_weight: float = 0.0
 
@@ -113,8 +117,17 @@ def recommend_ap_location(
         raise AppError(ErrorCode.SCENE_VERSION_NOT_FOUND, "Scene version not found.", 404)
 
     walls = _load_walls(db, str(sv.id))
-    params = _load_calibration_params(db, str(sv.id), request.calibration_run_id)
-    rssi_transfer = _load_rssi_transfer(db, str(sv.id), request.calibration_run_id)
+    selected_calibration_run = _select_calibration_run(
+        db,
+        str(sv.id),
+        request.calibration_run_id,
+    )
+    params = _params_from_run(selected_calibration_run, request.calibration_policy)
+    best_params_applied = _best_params_applied(
+        selected_calibration_run,
+        request.calibration_policy,
+    )
+    rssi_transfer = _transfer_from_run(selected_calibration_run, request.calibration_policy)
     existing_aps = _parse_existing_aps(request.existing_aps)
 
     candidates = _generate_candidates_for_request(request)
@@ -135,6 +148,7 @@ def recommend_ap_location(
         raw_eval_points,
         priority_zones=request.priority_zones,
         excluded_zones=request.excluded_zones,
+        default_unzoned_weight=request.default_unzoned_weight,
     )
     if not weighted_points:
         raise AppError(
@@ -169,6 +183,8 @@ def recommend_ap_location(
         params=params,
         transfer=rssi_transfer,
         recommendation_mode=request.recommendation_mode,
+        replace_target_ap_id=request.replace_target_ap_id,
+        candidate_tx_power_dbm=request.candidate_tx_power_dbm,
         coverage_threshold_dbm=request.coverage_threshold_dbm
         or _DEFAULT_COVERAGE_THRESHOLD_DBM,
         weak_zone_threshold_dbm=request.weak_zone_threshold_dbm
@@ -186,14 +202,17 @@ def recommend_ap_location(
         candidates_evaluated=len(candidates),
         eval_points_count=len(raw_eval_points),
         weighted_eval_points_count=len(weighted_points),
-        calibration_applied=rssi_transfer.method != "identity",
+        calibration_applied=rssi_transfer.transfer_applied or best_params_applied,
         calibration=ApRecommendationCalibrationInfo(
             method=rssi_transfer.method,
+            policy=request.calibration_policy,
             slope=round(rssi_transfer.slope, 6),
             intercept_db=round(rssi_transfer.intercept_db, 6),
+            transfer_applied=rssi_transfer.transfer_applied,
+            best_params_applied=best_params_applied,
             residual_used=False,
-            calibration_run_id=UUID(rssi_transfer.calibration_run_id)
-            if rssi_transfer.calibration_run_id
+            calibration_run_id=UUID(str(selected_calibration_run.id))
+            if selected_calibration_run is not None
             else None,
         ),
         score_weights=SCORE_WEIGHTS,
@@ -277,6 +296,12 @@ def _candidate_boxes_for_request(
 ) -> list[ApRecommendationBBox]:
     if request.candidate_bboxes:
         return request.candidate_bboxes
+    return _legacy_boxes_for_request(request)
+
+
+def _legacy_boxes_for_request(
+    request: ApRecommendationRequest,
+) -> list[ApRecommendationBBox]:
     if request.target_bboxes:
         out: list[ApRecommendationBBox] = []
         for raw in request.target_bboxes:
@@ -322,7 +347,7 @@ def _candidate_step_for_box(box: ApRecommendationBBox, step_m: float) -> float:
 def _generate_eval_fallback_points(
     request: ApRecommendationRequest,
 ) -> list[tuple[float, float]]:
-    boxes = _candidate_boxes_for_request(request)
+    boxes = _evaluation_boxes_for_request(request)
     if not boxes:
         return []
     points: list[tuple[float, float]] = []
@@ -341,6 +366,24 @@ def _generate_eval_fallback_points(
             seen.add(key)
             points.append(point)
     return points
+
+
+def _evaluation_boxes_for_request(
+    request: ApRecommendationRequest,
+) -> list[ApRecommendationBBox]:
+    """Fallback evaluation areas, ordered by scoring intent.
+
+    Candidate boxes are installable AP areas, so they are only used as the last
+    legacy fallback when the request gives no explicit evaluation scope.
+    """
+    if request.priority_zones:
+        return request.priority_zones
+    if request.evaluation_bboxes:
+        return request.evaluation_bboxes
+    legacy = _legacy_boxes_for_request(request)
+    if legacy:
+        return legacy
+    return request.candidate_bboxes
 
 
 def _generate_eval_points(
@@ -389,17 +432,26 @@ def _build_weighted_eval_points(
     *,
     priority_zones: list[Any],
     excluded_zones: list[Any],
+    default_unzoned_weight: float = _DEFAULT_UNZONED_WEIGHT,
 ) -> list[WeightedEvalPoint]:
     weighted: list[WeightedEvalPoint] = []
+    has_priority_zones = len(priority_zones) > 0
+    default_weight = (
+        max(0.0, min(1.0, default_unzoned_weight))
+        if math.isfinite(default_unzoned_weight)
+        else _DEFAULT_UNZONED_WEIGHT
+    )
     for point in eval_points:
         if any(_point_in_bbox(point.x, point.y, zone) for zone in excluded_zones):
             continue
-        weight = 1.0
+        weight = default_weight if has_priority_zones else 1.0
         label: str | None = None
         for zone in priority_zones:
             if _point_in_bbox(point.x, point.y, zone):
-                zone_weight = float(getattr(zone, "weight", 1.0))
-                if zone_weight >= weight or label is None:
+                zone_weight = _finite_float(getattr(zone, "weight", 1.0), 1.0)
+                zone_weight = max(0.0, min(1.0, zone_weight))
+                # Overlap rule: the strongest priority wins; ties keep first match.
+                if zone_weight > weight or label is None:
                     weight = zone_weight
                     label = getattr(zone, "label", None)
         if weight <= 0:
@@ -466,25 +518,33 @@ def _load_walls(db: Session, scene_version_id: str) -> list[WallSegment]:
     return out
 
 
-def _load_calibration_params(
+def _select_calibration_run(
     db: Session,
     scene_version_id: str,
     calibration_run_id=None,
-) -> CalibrationParams:
-    from app.services.rf.calibration_worker.apply import get_latest_calibration
-
-    run = None
+) -> CalibrationRun | None:
     if calibration_run_id is not None:
-        run = _get_calibration_for_scene_or_400(db, scene_version_id, calibration_run_id)
-    if run is None:
-        run = get_latest_calibration(db, scene_version_id)
-    if run is None or not run.metrics_json:
-        return CalibrationParams()
+        return _get_calibration_for_scene_or_400(db, scene_version_id, calibration_run_id)
+    return db.execute(
+        select(CalibrationRun)
+        .where(
+            CalibrationRun.scene_version_id == str(scene_version_id),
+            CalibrationRun.status == "completed",
+        )
+        .order_by(CalibrationRun.created_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
 
-    best = (run.metrics_json or {}).get("best_params") or {}
+
+def _params_from_run(
+    run: CalibrationRun | None,
+    policy: CalibrationPolicy,
+) -> CalibrationParams:
+    if policy not in ("best_params_only", "combined"):
+        return CalibrationParams()
+    best = _find_best_params(run.metrics_json if run is not None else None)
     if not best:
         return CalibrationParams()
-
     return CalibrationParams(
         tx_power_offset_db=_finite_float(best.get("tx_power_offset_db"), 0.0),
         path_loss_exp=_finite_float(best.get("path_loss_exp"), 3.0),
@@ -500,28 +560,25 @@ def _load_calibration_params(
     )
 
 
-def _load_rssi_transfer(
-    db: Session,
-    scene_version_id: str,
-    calibration_run_id=None,
+def _best_params_applied(
+    run: CalibrationRun | None,
+    policy: CalibrationPolicy,
+) -> bool:
+    return policy in ("best_params_only", "combined") and bool(
+        _find_best_params(run.metrics_json if run is not None else None)
+    )
+
+
+def _transfer_from_run(
+    run: CalibrationRun | None,
+    policy: CalibrationPolicy,
 ) -> RssiTransfer:
-    run = None
-    if calibration_run_id is not None:
-        run = _get_calibration_for_scene_or_400(db, scene_version_id, calibration_run_id)
-    else:
-        run = db.execute(
-            select(CalibrationRun)
-            .where(
-                CalibrationRun.scene_version_id == str(scene_version_id),
-                CalibrationRun.status == "completed",
-            )
-            .order_by(CalibrationRun.created_at.desc())
-            .limit(1)
-        ).scalar_one_or_none()
+    if policy not in ("transfer_only", "combined"):
+        return RssiTransfer()
     if run is None or not run.metrics_json:
         return RssiTransfer()
 
-    calibration = _find_calibration_metrics(run.metrics_json)
+    calibration = _find_rssi_transfer_metrics(run.metrics_json)
     if not calibration:
         return RssiTransfer()
 
@@ -532,11 +589,16 @@ def _load_rssi_transfer(
     )
     if not math.isfinite(slope) or not math.isfinite(intercept):
         return RssiTransfer()
+    transfer_applied = not (
+        math.isclose(slope, 1.0, abs_tol=1e-9)
+        and math.isclose(intercept, 0.0, abs_tol=1e-9)
+    )
     return RssiTransfer(
         slope=slope,
         intercept_db=intercept,
         method=str(calibration.get("method") or "affine_rssi_transfer"),
         calibration_run_id=str(run.id),
+        transfer_applied=transfer_applied,
         residual_enabled=False,
         residual_weight=0.0,
     )
@@ -559,7 +621,25 @@ def _get_calibration_for_scene_or_400(
     return run
 
 
-def _find_calibration_metrics(metrics_json: dict[str, Any]) -> dict[str, Any] | None:
+def _find_best_params(metrics_json: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(metrics_json, dict):
+        return None
+    best = metrics_json.get("best_params")
+    if isinstance(best, dict):
+        return best
+    # Forward-compatible shape for future physical calibration records. Study-room
+    # spaces may benefit from internal wall effective attenuation scale, but AP
+    # recommendation does not tune path_loss_exp here to avoid overfitting.
+    physical = metrics_json.get("physical_params")
+    if isinstance(physical, dict):
+        return physical
+    return None
+
+
+def _find_rssi_transfer_metrics(metrics_json: dict[str, Any]) -> dict[str, Any] | None:
+    transfer = metrics_json.get("rssi_transfer")
+    if isinstance(transfer, dict):
+        return transfer
     evaluation = metrics_json.get("evaluation")
     if isinstance(evaluation, dict):
         calibration = evaluation.get("calibration")
@@ -639,6 +719,8 @@ def _grid_search_topn(
     params: CalibrationParams,
     transfer: RssiTransfer,
     recommendation_mode: str,
+    replace_target_ap_id: str | None,
+    candidate_tx_power_dbm: float,
     coverage_threshold_dbm: float,
     weak_zone_threshold_dbm: float,
     n: int,
@@ -646,11 +728,17 @@ def _grid_search_topn(
     scored: list[tuple[float, float, CandidateMetrics]] = []
 
     for cx, cy in candidates:
-        test_ap = AccessPoint(name="candidate", x=cx, y=cy)
-        eval_aps = (
-            existing_aps + [test_ap]
-            if recommendation_mode == "add"
-            else [test_ap]
+        test_ap = AccessPoint(
+            name=replace_target_ap_id or "candidate",
+            x=cx,
+            y=cy,
+            tx_power_dbm=_finite_float(candidate_tx_power_dbm, 20.0),
+        )
+        eval_aps = _aps_for_candidate(
+            existing_aps=existing_aps,
+            candidate_ap=test_ap,
+            recommendation_mode=recommendation_mode,
+            replace_target_ap_id=replace_target_ap_id,
         )
         predicted: list[PredictedEvalPoint] = []
         for point in eval_points:
@@ -683,6 +771,28 @@ def _grid_search_topn(
         reverse=True,
     )
     return scored[:n]
+
+
+def _aps_for_candidate(
+    *,
+    existing_aps: list[AccessPoint],
+    candidate_ap: AccessPoint,
+    recommendation_mode: str,
+    replace_target_ap_id: str | None,
+) -> list[AccessPoint]:
+    if recommendation_mode == "add":
+        return existing_aps + [candidate_ap]
+    # replace without a target is the legacy "evaluate candidate AP only" mode.
+    if not replace_target_ap_id:
+        return [candidate_ap]
+    kept = [ap for ap in existing_aps if ap.name != replace_target_ap_id]
+    if len(kept) == len(existing_aps):
+        logger.warning(
+            "AP replacement target %s not found; evaluating candidate only.",
+            replace_target_ap_id,
+        )
+        return [candidate_ap]
+    return kept + [candidate_ap]
 
 
 def compute_ap_recommendation_metrics(

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -20,6 +20,7 @@ from app.schemas.rf.ap_recommendation import (
     ApRecommendationBBox,
     ApRecommendationCalibrationInfo,
     ApRecommendationItem,
+    ApRecommendationPredictionPoint,
     ApRecommendationRequest,
     ApRecommendationResponse,
 )
@@ -193,8 +194,8 @@ def recommend_ap_location(
     )
 
     recommendations = [
-        _to_response_item(i + 1, x, y, metrics)
-        for i, (x, y, metrics) in enumerate(top_results)
+        _to_response_item(i + 1, x, y, metrics, predicted)
+        for i, (x, y, metrics, predicted) in enumerate(top_results)
     ]
 
     return ApRecommendationResponse(
@@ -224,6 +225,7 @@ def _to_response_item(
     x: float,
     y: float,
     metrics: CandidateMetrics,
+    prediction_points: list[PredictedEvalPoint],
 ) -> ApRecommendationItem:
     return ApRecommendationItem(
         rank=rank,
@@ -240,6 +242,16 @@ def _to_response_item(
         average_rssi_dbm=round(metrics.average_rssi_dbm, 2),
         baseline_improvement_score=_round_optional(metrics.baseline_improvement_score),
         baseline_improvement_db=_round_optional(metrics.baseline_improvement_db),
+        prediction_points=[
+            ApRecommendationPredictionPoint(
+                x=round(p.x, 3),
+                y=round(p.y, 3),
+                rssi_dbm=round(p.candidate_rssi_dbm, 2),
+                baseline_rssi_dbm=_round_optional(p.baseline_rssi_dbm, 2),
+                weight=round(p.weight, 3),
+            )
+            for p in prediction_points
+        ],
     )
 
 
@@ -724,8 +736,8 @@ def _grid_search_topn(
     coverage_threshold_dbm: float,
     weak_zone_threshold_dbm: float,
     n: int,
-) -> list[tuple[float, float, CandidateMetrics]]:
-    scored: list[tuple[float, float, CandidateMetrics]] = []
+) -> list[tuple[float, float, CandidateMetrics, list[PredictedEvalPoint]]]:
+    scored: list[tuple[float, float, CandidateMetrics, list[PredictedEvalPoint]]] = []
 
     for cx, cy in candidates:
         test_ap = AccessPoint(
@@ -759,7 +771,7 @@ def _grid_search_topn(
             coverage_threshold_dbm=coverage_threshold_dbm,
             weak_zone_threshold_dbm=weak_zone_threshold_dbm,
         )
-        scored.append((cx, cy, metrics))
+        scored.append((cx, cy, metrics, predicted))
 
     scored.sort(
         key=lambda t: (

--- a/backend/app/services/rf/calibration_run_service.py
+++ b/backend/app/services/rf/calibration_run_service.py
@@ -8,7 +8,7 @@ import random
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError, ErrorCode
@@ -21,6 +21,7 @@ from app.models.project import Project
 from app.models.rf_run import RfRun
 from app.models.scene_version import SceneVersion
 from app.models.user import User
+from app.schemas.pagination import PaginatedResponse
 from app.schemas.rf.calibration_run import (
     CalibrationEvaluationRequest,
     CalibrationEvaluationResponse,
@@ -947,6 +948,41 @@ def get_calibration_run(
     db: Session, run_id: UUID, user: User
 ) -> CalibrationRunResponse:
     return _to_response(_get_owned_calibration_run(db, run_id, user))
+
+
+def list_calibration_runs(
+    db: Session,
+    *,
+    scene_version_id: UUID,
+    user: User,
+    page: int = 1,
+    page_size: int = 20,
+) -> PaginatedResponse[CalibrationRunResponse]:
+    sv = _get_owned_scene_version(db, scene_version_id, user)
+    total = db.execute(
+        select(func.count(CalibrationRun.id)).where(
+            CalibrationRun.scene_version_id == str(sv.id)
+        )
+    ).scalar() or 0
+    rows = (
+        db.execute(
+            select(CalibrationRun)
+            .where(
+                CalibrationRun.scene_version_id == str(sv.id)
+            )
+            .order_by(CalibrationRun.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        .scalars()
+        .all()
+    )
+    return PaginatedResponse[CalibrationRunResponse](
+        items=[_to_response(r) for r in rows],
+        page=page,
+        page_size=page_size,
+        total=int(total),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/rf/measurement_service.py
+++ b/backend/app/services/rf/measurement_service.py
@@ -129,32 +129,41 @@ def _latest_floorplan_asset(db: Session, floor_id: str) -> Asset | None:
 
 
 def _resolve_scene_and_asset(
-    db: Session, floor_id: str
+    db: Session, floor_id: str, scene_version_id: str | None = None
 ) -> tuple[str | None, str | None]:
     """Pick the scene_version + asset that this measurement link should anchor to.
 
-    Preference: latest **confirmed** scene_version for the floor (and its
-    source_asset_id); fall back to the latest floorplan_image asset on the
-    floor when no confirmed scene version exists yet. Draft (is_confirmed=False)
-    versions are ignored — measurement links must anchor to a stable, user-
-    approved scene so that downstream coordinates stay consistent.
+    When a scene_version_id is provided, the measurement link is anchored to
+    exactly that version. Otherwise, use the latest confirmed scene for the
+    floor. Do not pair a scene with the floor's latest unrelated asset.
     """
-    scene = db.execute(
-        select(SceneVersion)
-        .where(
-            SceneVersion.floor_id == floor_id,
-            SceneVersion.is_confirmed.is_(True),
-        )
-        .order_by(SceneVersion.version_no.desc())
-        .limit(1)
-    ).scalar_one_or_none()
+    if scene_version_id:
+        _validate_uuid(scene_version_id, "scene_version_id")
+        scene = db.execute(
+            select(SceneVersion).where(
+                SceneVersion.id == scene_version_id,
+                SceneVersion.floor_id == floor_id,
+            )
+        ).scalar_one_or_none()
+        if scene is None:
+            raise AppError(
+                ErrorCode.SCENE_VERSION_NOT_FOUND,
+                f"Scene version {scene_version_id} not found for floor {floor_id}.",
+                404,
+            )
+    else:
+        scene = db.execute(
+            select(SceneVersion)
+            .where(
+                SceneVersion.floor_id == floor_id,
+                SceneVersion.is_confirmed.is_(True),
+            )
+            .order_by(SceneVersion.version_no.desc())
+            .limit(1)
+        ).scalar_one_or_none()
 
     if scene is not None:
-        asset_id = scene.source_asset_id
-        if asset_id is None:
-            fallback = _latest_floorplan_asset(db, floor_id)
-            asset_id = fallback.id if fallback else None
-        return scene.id, asset_id
+        return scene.id, scene.source_asset_id
 
     fallback = _latest_floorplan_asset(db, floor_id)
     return None, fallback.id if fallback else None
@@ -207,33 +216,29 @@ def _floorplan_info_from_asset(
     )
 
 
-def _bounds_from_scene_walls(db: Session, floor_id: str) -> FloorBoundsDTO | None:
-    """Confirmed scene 의 벽/개구부 좌표로 bbox 계산.
+def _bounds_from_scene_walls(
+    db: Session, scene_version_id: str | None
+) -> FloorBoundsDTO | None:
+    """Scene version 의 벽/개구부 좌표로 bbox 계산.
 
     프론트 MeasurementCanvas 의 viewBox 도 같은 (walls + openings) 기준으로 잡힘.
     히트맵 PNG 가 도면 위에 정확히 깔리려면 같은 좌표계 bounds 가 필요.
-    confirmed scene 이 없거나 벽이 0개면 None — 호출측에서 다음 fallback 사용.
+    scene 이 없거나 벽/개구부 좌표가 없으면 None — 호출측에서 다음 fallback 사용.
     """
     from app.core.geom import wkb_to_geojson
     from app.models.opening import Opening
     from app.models.wall import Wall
 
-    scene = db.execute(
-        select(SceneVersion)
-        .where(
-            SceneVersion.floor_id == floor_id,
-            SceneVersion.is_confirmed.is_(True),
-        )
-        .order_by(SceneVersion.version_no.desc())
-        .limit(1)
-    ).scalar_one_or_none()
+    if not scene_version_id:
+        return None
+    scene = db.get(SceneVersion, scene_version_id)
     if scene is None:
         return None
 
     minx = miny = float("inf")
     maxx = maxy = float("-inf")
     for w in db.execute(
-        select(Wall).where(Wall.scene_version_id == scene.id)
+        select(Wall).where(Wall.scene_version_id == scene_version_id)
     ).scalars().all():
         gj = wkb_to_geojson(w.centerline_geom)
         if not gj or gj.get("type") != "LineString":
@@ -244,7 +249,7 @@ def _bounds_from_scene_walls(db: Session, floor_id: str) -> FloorBoundsDTO | Non
             if x > maxx: maxx = x
             if y > maxy: maxy = y
     for o in db.execute(
-        select(Opening).where(Opening.scene_version_id == scene.id)
+        select(Opening).where(Opening.scene_version_id == scene_version_id)
     ).scalars().all():
         gj = wkb_to_geojson(o.line_geom)
         if not gj or gj.get("type") != "LineString":
@@ -275,7 +280,11 @@ def _bounds_from_floorplan(floorplan: FloorplanInfoDTO) -> FloorBoundsDTO:
 
 
 def create_measurement_link(
-    db: Session, floor_id: str, *, recommended_measurement_purpose: str = "calibration"
+    db: Session,
+    floor_id: str,
+    *,
+    recommended_measurement_purpose: str = "calibration",
+    scene_version_id: str | None = None,
 ) -> MeasurementLinkCreateResponseDTO:
     _validate_uuid(floor_id, "floor_id")
     purpose = (
@@ -292,7 +301,9 @@ def create_measurement_link(
             404,
         )
 
-    scene_version_id, asset_id = _resolve_scene_and_asset(db, floor.id)
+    resolved_scene_version_id, asset_id = _resolve_scene_and_asset(
+        db, floor.id, scene_version_id
+    )
 
     token = _generate_token()
     now = datetime.now(timezone.utc)
@@ -302,7 +313,7 @@ def create_measurement_link(
         token=token,
         project_id=floor.project_id,
         floor_id=floor.id,
-        scene_version_id=scene_version_id,
+        scene_version_id=resolved_scene_version_id,
         asset_id=asset_id,
         purpose=purpose,
         status="active",
@@ -390,7 +401,7 @@ def get_measurement_link_context(
     floorplan = _floorplan_info_from_asset(
         db, link.asset_id, link_token=token, base_url=base_url,
     )
-    bounds = _bounds_from_scene_walls(db, str(link.floor_id)) or _bounds_from_floorplan(floorplan)
+    bounds = _bounds_from_scene_walls(db, link.scene_version_id) or _bounds_from_floorplan(floorplan)
 
     return MeasurementLinkContextResponseDTO(
         token=link.token,
@@ -711,10 +722,10 @@ def list_sessions_by_floor(
     )
 
 
-def _try_load_sim_grid_for_floor(
-    db: Session, floor_id: str,
+def _try_load_sim_grid_for_scene(
+    db: Session, floor_id: str, scene_version_id: str | None,
 ) -> tuple["np.ndarray", "np.ndarray", "np.ndarray"] | None:
-    """floor 의 최근 succeeded RfRun 의 radio_map values_dbm + xs/ys 추출.
+    """scene_version 기준 최근 succeeded RfRun 의 radio_map values_dbm + xs/ys 추출.
 
     Returns:
         (grid, xs, ys) — residual kriging 의 prior 로 사용.
@@ -723,13 +734,16 @@ def _try_load_sim_grid_for_floor(
     import numpy as np
     from app.models.rf_run import RfRun
 
-    # 가장 최근 done/completed/succeeded — 백엔드 status 표기 다양.
+    # scene_version_id 가 있는 세션은 반드시 같은 도면의 sim prior 만 사용.
+    filters = [
+        RfRun.floor_id == floor_id,
+        RfRun.status.in_(["done", "completed", "succeeded"]),
+    ]
+    if scene_version_id:
+        filters.append(RfRun.scene_version_id == scene_version_id)
     rf_run = db.execute(
         select(RfRun)
-        .where(
-            RfRun.floor_id == floor_id,
-            RfRun.status.in_(["done", "completed", "succeeded"]),
-        )
+        .where(*filters)
         .order_by(RfRun.created_at.desc())
         .limit(1)
     ).scalar_one_or_none()
@@ -822,10 +836,9 @@ def estimate_session_coverage(
 
     # bounds — confirmed scene 의 벽/개구부 bbox 우선 (프론트 캔버스가 이 좌표계로 도면을 그림).
     # 도면 이미지 픽셀 bounds 는 scene 좌표계와 어긋날 수 있어 후순위.
-    bounds_dto = _bounds_from_scene_walls(db, str(session_row.floor_id))
+    bounds_dto = _bounds_from_scene_walls(db, session_row.scene_version_id)
     if bounds_dto is None:
-        asset = _latest_floorplan_asset(db, str(session_row.floor_id))
-        floorplan = _floorplan_info_from_asset(db, asset.id if asset else None)
+        floorplan = _floorplan_info_from_asset(db, session_row.asset_id)
         bounds_dto = _bounds_from_floorplan(floorplan)
     if bounds_dto.max_x <= 0 or bounds_dto.max_y <= 0:
         # fallback: 측정점 bbox + 1m 마진
@@ -846,7 +859,9 @@ def estimate_session_coverage(
     estimate = None
     want_residual = method in ("residual_kriging", "auto")
     if want_residual:
-        sim_grid_data = _try_load_sim_grid_for_floor(db, str(session_row.floor_id))
+        sim_grid_data = _try_load_sim_grid_for_scene(
+            db, str(session_row.floor_id), session_row.scene_version_id
+        )
         if sim_grid_data is not None:
             sim_grid, sim_xs, sim_ys = sim_grid_data
             try:

--- a/backend/app/tests/test_ap_recommendation_service.py
+++ b/backend/app/tests/test_ap_recommendation_service.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+backend_dir = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(backend_dir))
+
+from app.models.calibration_run import CalibrationRun
+from app.schemas.rf.ap_recommendation import (
+    ApRecommendationBBox,
+    ApRecommendationRequest,
+    ApRecommendationZone,
+)
+from app.services.rf.ap_recommendation_service import (
+    RssiTransfer,
+    _aps_for_candidate,
+    _best_params_applied,
+    _build_weighted_eval_points,
+    _generate_candidates_for_request,
+    _generate_eval_fallback_points,
+    _params_from_run,
+    _transfer_from_run,
+)
+from app.services.rf.calibration_worker.path_loss import AccessPoint, CalibrationParams, Measurement
+
+
+def _request(**overrides) -> ApRecommendationRequest:
+    data = {"scene_version_id": uuid4(), **overrides}
+    return ApRecommendationRequest(**data)
+
+
+def _run(metrics_json: dict) -> CalibrationRun:
+    return CalibrationRun(
+        id=str(uuid4()),
+        project_id=str(uuid4()),
+        floor_id=str(uuid4()),
+        scene_version_id=str(uuid4()),
+        status="completed",
+        metrics_json=metrics_json,
+    )
+
+
+def test_no_priority_zones_weight_all_non_excluded_points_one():
+    points = [
+        Measurement(x=0.0, y=0.0, rssi_dbm=0.0),
+        Measurement(x=1.0, y=1.0, rssi_dbm=0.0),
+    ]
+
+    weighted = _build_weighted_eval_points(
+        points,
+        priority_zones=[],
+        excluded_zones=[],
+    )
+
+    assert [p.weight for p in weighted] == [1.0, 1.0]
+
+
+def test_priority_zones_leave_outside_points_at_default_weight():
+    points = [
+        Measurement(x=0.5, y=0.5, rssi_dbm=0.0),
+        Measurement(x=2.0, y=2.0, rssi_dbm=0.0),
+    ]
+    zones = [ApRecommendationZone(x_min=0, x_max=1, y_min=0, y_max=1, weight=1.0)]
+
+    weighted = _build_weighted_eval_points(
+        points,
+        priority_zones=zones,
+        excluded_zones=[],
+        default_unzoned_weight=0.2,
+    )
+
+    assert [p.weight for p in weighted] == [1.0, 0.2]
+
+
+def test_excluded_zones_remove_eval_points():
+    points = [
+        Measurement(x=0.5, y=0.5, rssi_dbm=0.0),
+        Measurement(x=2.0, y=2.0, rssi_dbm=0.0),
+    ]
+    excluded = [ApRecommendationBBox(x_min=0, x_max=1, y_min=0, y_max=1)]
+
+    weighted = _build_weighted_eval_points(
+        points,
+        priority_zones=[],
+        excluded_zones=excluded,
+    )
+
+    assert [(p.x, p.y) for p in weighted] == [(2.0, 2.0)]
+
+
+def test_candidate_bboxes_generate_candidates_but_priority_zones_drive_eval_fallback():
+    request = _request(
+        candidate_bboxes=[ApRecommendationBBox(x_min=10, x_max=11, y_min=10, y_max=11)],
+        priority_zones=[ApRecommendationZone(x_min=0, x_max=1, y_min=0, y_max=1, weight=1.0)],
+        step_m=1.0,
+    )
+
+    assert _generate_candidates_for_request(request) == [
+        (10.0, 10.0),
+        (10.0, 11.0),
+        (11.0, 10.0),
+        (11.0, 11.0),
+    ]
+    assert _generate_eval_fallback_points(request) == [
+        (0.0, 0.0),
+        (0.0, 1.0),
+        (1.0, 0.0),
+        (1.0, 1.0),
+    ]
+
+
+def test_eval_fallback_uses_evaluation_bboxes_before_candidate_bboxes():
+    request = _request(
+        candidate_bboxes=[ApRecommendationBBox(x_min=10, x_max=11, y_min=10, y_max=11)],
+        evaluation_bboxes=[ApRecommendationBBox(x_min=2, x_max=3, y_min=3, y_max=4)],
+    )
+
+    assert _generate_eval_fallback_points(request) == [
+        (2.0, 3.0),
+        (2.0, 4.0),
+        (3.0, 3.0),
+        (3.0, 4.0),
+    ]
+
+
+def test_transfer_only_policy_applies_transfer_not_best_params():
+    run = _run(
+        {
+            "best_params": {"path_loss_exp": 4.2, "tx_power_offset_db": 9.0},
+            "rssi_transfer": {"slope": 0.72, "intercept_db": -18.4},
+        }
+    )
+
+    params = _params_from_run(run, "transfer_only")
+    transfer = _transfer_from_run(run, "transfer_only")
+
+    assert params == CalibrationParams()
+    assert transfer.slope == pytest.approx(0.72)
+    assert transfer.intercept_db == pytest.approx(-18.4)
+    assert transfer.transfer_applied is True
+    assert _best_params_applied(run, "transfer_only") is False
+
+
+def test_best_params_only_policy_applies_best_params_with_identity_transfer():
+    run = _run(
+        {
+            "best_params": {"path_loss_exp": 4.2, "tx_power_offset_db": 9.0},
+            "rssi_transfer": {"slope": 0.72, "intercept_db": -18.4},
+        }
+    )
+
+    params = _params_from_run(run, "best_params_only")
+    transfer = _transfer_from_run(run, "best_params_only")
+
+    assert params.path_loss_exp == pytest.approx(4.2)
+    assert params.tx_power_offset_db == pytest.approx(9.0)
+    assert transfer == RssiTransfer()
+    assert _best_params_applied(run, "best_params_only") is True
+
+
+def test_combined_policy_applies_best_params_and_transfer_from_same_run():
+    run = _run(
+        {
+            "best_params": {"path_loss_exp": 3.6, "tx_power_offset_db": -1.5},
+            "rssi_transfer": {"slope": 0.8, "intercept_db": -10.0},
+            "residual": {"method": "idw", "weight": 0.6, "use_for_recommendation": True},
+        }
+    )
+
+    params = _params_from_run(run, "combined")
+    transfer = _transfer_from_run(run, "combined")
+
+    assert params.path_loss_exp == pytest.approx(3.6)
+    assert params.tx_power_offset_db == pytest.approx(-1.5)
+    assert transfer.slope == pytest.approx(0.8)
+    assert transfer.intercept_db == pytest.approx(-10.0)
+    assert transfer.calibration_run_id == str(run.id)
+    assert transfer.residual_enabled is False
+    assert _best_params_applied(run, "combined") is True
+
+
+def test_add_and_replace_modes_are_explicit():
+    existing = [
+        AccessPoint(name="ap1", x=0.0, y=0.0),
+        AccessPoint(name="ap2", x=5.0, y=5.0),
+    ]
+    candidate = AccessPoint(name="candidate", x=1.0, y=1.0)
+
+    add = _aps_for_candidate(
+        existing_aps=existing,
+        candidate_ap=candidate,
+        recommendation_mode="add",
+        replace_target_ap_id=None,
+    )
+    replace_all = _aps_for_candidate(
+        existing_aps=existing,
+        candidate_ap=candidate,
+        recommendation_mode="replace",
+        replace_target_ap_id=None,
+    )
+    replace_target = _aps_for_candidate(
+        existing_aps=existing,
+        candidate_ap=AccessPoint(name="ap1", x=1.0, y=1.0),
+        recommendation_mode="replace",
+        replace_target_ap_id="ap1",
+    )
+
+    assert [ap.name for ap in add] == ["ap1", "ap2", "candidate"]
+    assert [ap.name for ap in replace_all] == ["candidate"]
+    assert [ap.name for ap in replace_target] == ["ap2", "ap1"]

--- a/backend/migrations/versions/20260604_0013_ap_recommendation_history.py
+++ b/backend/migrations/versions/20260604_0013_ap_recommendation_history.py
@@ -1,0 +1,167 @@
+"""store AP recommendation run history
+
+Revision ID: 20260604_0013
+Revises: 20260531_0012
+Create Date: 2026-06-04 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260604_0013"
+down_revision: Union[str, Sequence[str], None] = "20260531_0012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ap_recommendation_runs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "floor_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("floors.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "scene_version_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("scene_versions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "calibration_run_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("calibration_runs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'completed'"),
+        ),
+        sa.Column(
+            "request_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "input_areas_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "existing_aps_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "calibration_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "score_weights_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "candidates_evaluated",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("eval_points_count", sa.Integer(), nullable=True),
+        sa.Column("weighted_eval_points_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "idx_ap_recommendation_runs_scene_version",
+        "ap_recommendation_runs",
+        ["scene_version_id"],
+    )
+    op.create_index(
+        "idx_ap_recommendation_runs_floor",
+        "ap_recommendation_runs",
+        ["floor_id"],
+    )
+
+    op.create_table(
+        "ap_recommendation_items",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "run_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("ap_recommendation_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("rank", sa.Integer(), nullable=False),
+        sa.Column("recommended_x", sa.Numeric(10, 3), nullable=False),
+        sa.Column("recommended_y", sa.Numeric(10, 3), nullable=False),
+        sa.Column("score", sa.Numeric(12, 4), nullable=False),
+        sa.Column(
+            "metrics_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "prediction_points_json",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "idx_ap_recommendation_items_run",
+        "ap_recommendation_items",
+        ["run_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ap_recommendation_items_run", table_name="ap_recommendation_items")
+    op.drop_table("ap_recommendation_items")
+    op.drop_index("idx_ap_recommendation_runs_floor", table_name="ap_recommendation_runs")
+    op.drop_index(
+        "idx_ap_recommendation_runs_scene_version",
+        table_name="ap_recommendation_runs",
+    )
+    op.drop_table("ap_recommendation_runs")

--- a/frontend/src/api/ap-recommendation.ts
+++ b/frontend/src/api/ap-recommendation.ts
@@ -1,11 +1,27 @@
 import { api } from './client';
+import type { Paginated, UUID } from '@/types/common';
 import type {
   ApRecommendationRequest,
   ApRecommendationResponse,
+  ApRecommendationRun,
 } from '@/types/ap-recommendation';
 
 export const apRecommendationApi = {
   /** POST /ap-recommendation — Grid Search 기반 AP 최적 위치 추천. */
   recommend: (body: ApRecommendationRequest) =>
     api.post<ApRecommendationResponse>('/ap-recommendation', body).then((r) => r.data),
+
+  listRuns: (sceneVersionId: UUID, params?: { page?: number; page_size?: number }) =>
+    api
+      .get<Paginated<ApRecommendationRun>>('/ap-recommendation', {
+        params: {
+          scene_version_id: sceneVersionId,
+          page: params?.page,
+          page_size: params?.page_size,
+        },
+      })
+      .then((r) => r.data),
+
+  getRun: (runId: UUID) =>
+    api.get<ApRecommendationRun>(`/ap-recommendation/${runId}`).then((r) => r.data),
 };

--- a/frontend/src/api/calibration-run.ts
+++ b/frontend/src/api/calibration-run.ts
@@ -1,5 +1,5 @@
 import { api } from './client';
-import type { UUID } from '@/types/common';
+import type { Paginated, UUID } from '@/types/common';
 import type {
   CalibrationRun,
   CalibrationRunCreateRequest,
@@ -15,6 +15,17 @@ export const calibrationRunApi = {
 
   evaluate: (body: CalibrationEvaluationRequest) =>
     api.post<CalibrationEvaluationResponse>('/calibration-runs/evaluate', body).then((r) => r.data),
+
+  list: (sceneVersionId: UUID, params?: { page?: number; page_size?: number }) =>
+    api
+      .get<Paginated<CalibrationRun>>('/calibration-runs', {
+        params: {
+          scene_version_id: sceneVersionId,
+          page: params?.page,
+          page_size: params?.page_size,
+        },
+      })
+      .then((r) => r.data),
 
   // §11.2 GET /calibration-runs/{id} — 결과/상태 조회.
   get: (id: UUID) =>

--- a/frontend/src/api/measurement-link.ts
+++ b/frontend/src/api/measurement-link.ts
@@ -4,10 +4,17 @@ import type { MeasurementLinkCreated } from '@/types/measurement-link';
 
 export const measurementLinkApi = {
   // §10.0 POST /floors/{floor_id}/measurement-links — 측정용 QR 토큰 생성
-  create: (floorId: UUID, recommendedPurpose = 'calibration') =>
+  create: (
+    floorId: UUID,
+    recommendedPurpose = 'calibration',
+    sceneVersionId?: UUID | null,
+  ) =>
     api
       .post<MeasurementLinkCreated>(`/floors/${floorId}/measurement-links`, null, {
-        params: { recommended_measurement_purpose: recommendedPurpose },
+        params: {
+          recommended_measurement_purpose: recommendedPurpose,
+          scene_version_id: sceneVersionId ?? undefined,
+        },
       })
       .then((r) => r.data),
 };

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
 import { parseGeometry, type Coord } from '@/features/editor/geometry-utils';
-import { loadCachedViewBox } from '@/features/editor/viewbox-cache';
 import {
   deriveImageExtent,
   useImageNaturalDimensions,
@@ -8,6 +7,7 @@ import {
 import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import type { DraftObject, DraftOpening, DraftWall, SceneVersion } from '@/types/scene';
 import { cn } from '@/lib/utils';
+import { dbmToHeatmapColor } from '@/lib/rssi-colormap';
 import {
   clampCoord,
   clampMeterBBox,
@@ -38,25 +38,19 @@ const AREA_STYLE: Record<
   { label: string; fill: string; stroke: string; badge: string }
 > = {
   candidate: {
-    label: '설치 가능 영역',
+    label: '설치 가능한 곳',
     fill: 'rgb(37 99 235 / 0.18)',
     stroke: 'rgb(37 99 235)',
     badge: 'oklch(0.55 0.22 254)',
   },
   priority: {
-    label: '우선 평가 영역',
+    label: '집중구간',
     fill: 'rgb(22 163 74 / 0.18)',
     stroke: 'rgb(22 163 74)',
     badge: 'oklch(0.62 0.18 145)',
   },
-  lowPriority: {
-    label: '낮은 우선순위 영역',
-    fill: 'rgb(234 179 8 / 0.20)',
-    stroke: 'rgb(202 138 4)',
-    badge: 'oklch(0.69 0.17 82)',
-  },
   excluded: {
-    label: '제외 영역',
+    label: '계산에서 제외',
     fill: 'rgb(239 68 68 / 0.16)',
     stroke: 'rgb(220 38 38)',
     badge: 'oklch(0.62 0.21 25)',
@@ -76,6 +70,13 @@ interface Props {
   onAreasChange: (areas: ApRecommendationArea[]) => void;
   recommendations: ApRecommendationResult[];
   selectedRecommendationRank: number | null;
+  heatmapMode?: 'prediction' | 'measurement';
+  measurementHeatmap?: {
+    url?: string | null;
+    bounds: { min_x: number; min_y: number; max_x: number; max_y: number };
+    rssiRange?: { min: number; max: number };
+    source?: 'measurement' | 'simulation';
+  } | null;
   disabled?: boolean;
 }
 
@@ -129,6 +130,8 @@ export function ApRecommendationCanvas({
   onAreasChange,
   recommendations,
   selectedRecommendationRank,
+  heatmapMode = 'prediction',
+  measurementHeatmap,
   disabled = false,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
@@ -145,11 +148,9 @@ export function ApRecommendationCanvas({
   );
 
   const vb = useMemo(() => {
-    const cached = loadCachedViewBox(sceneVersion?.floor_id ?? null);
-    if (cached) return cached;
     if (imageExtent) return computeViewBox(sceneVersion, imageExtent);
     return computeViewBox(sceneVersion, null);
-  }, [sceneVersion?.floor_id, sceneVersion, imageExtent]);
+  }, [sceneVersion, imageExtent]);
 
   const sceneBounds = useMemo(
     () => computeSceneBounds(sceneVersion, imageExtent),
@@ -217,11 +218,19 @@ export function ApRecommendationCanvas({
     ...area,
     bbox: clampMeterBBox(area.bbox, sceneBounds),
   }));
+  const selectedRecommendation = useMemo(
+    () => recommendations.find((rec) => rec.rank === selectedRecommendationRank) ?? null,
+    [recommendations, selectedRecommendationRank],
+  );
+  const predictionCells = useMemo(
+    () => buildPredictionCells(selectedRecommendation?.prediction_points ?? []),
+    [selectedRecommendation],
+  );
   const showDragPreview =
     dragRect && (dragRect.w >= DRAG_THRESHOLD_M || dragRect.h >= DRAG_THRESHOLD_M);
   const labelFontM = canvasLabelFontM(vb.w);
   const selectionBadgeH = labelFontM * 1.55;
-  const selectionBadgeW = labelFontM * 11.6;
+  const selectionBadgeW = labelFontM * 8.4;
   const removeButtonR = labelFontM * 0.7;
 
   const removeSelectedArea = (id: string) => {
@@ -267,6 +276,39 @@ export function ApRecommendationCanvas({
               opacity={0.35}
               pointerEvents="none"
               crossOrigin="anonymous"
+            />
+          )}
+
+          {heatmapMode === 'prediction' && predictionCells && (
+            <g opacity={0.62} pointerEvents="none">
+              {predictionCells.points.map((point, idx) => (
+                <rect
+                  key={`ap-rec-pred-${idx}`}
+                  x={point.x - predictionCells.cellW / 2}
+                  y={point.y - predictionCells.cellH / 2}
+                  width={predictionCells.cellW}
+                  height={predictionCells.cellH}
+                  fill={dbmToHeatmapColor(
+                    point.rssi_dbm,
+                    predictionCells.range.min,
+                    predictionCells.range.max,
+                  )}
+                />
+              ))}
+            </g>
+          )}
+
+          {heatmapMode === 'measurement' && measurementHeatmap?.url && (
+            <image
+              href={measurementHeatmap.url}
+              xlinkHref={measurementHeatmap.url}
+              x={measurementHeatmap.bounds.min_x}
+              y={measurementHeatmap.bounds.min_y}
+              width={measurementHeatmap.bounds.max_x - measurementHeatmap.bounds.min_x}
+              height={measurementHeatmap.bounds.max_y - measurementHeatmap.bounds.min_y}
+              preserveAspectRatio="none"
+              opacity={0.62}
+              pointerEvents="none"
             />
           )}
 
@@ -558,4 +600,36 @@ function RecommendationMarker({
       </text>
     </g>
   );
+}
+
+function buildPredictionCells(points: ApRecommendationResult['prediction_points']) {
+  const valid = points.filter(
+    (point) =>
+      Number.isFinite(point.x) &&
+      Number.isFinite(point.y) &&
+      Number.isFinite(point.rssi_dbm),
+  );
+  if (valid.length === 0) return null;
+  const xs = [...new Set(valid.map((point) => point.x))].sort((a, b) => a - b);
+  const ys = [...new Set(valid.map((point) => point.y))].sort((a, b) => a - b);
+  const cellW = minPositiveDelta(xs) ?? 1;
+  const cellH = minPositiveDelta(ys) ?? cellW;
+  const values = valid.map((point) => point.rssi_dbm);
+  const min = Math.min(-90, Math.min(...values));
+  const max = Math.max(-30, Math.max(...values));
+  return {
+    points: valid,
+    cellW,
+    cellH,
+    range: { min, max },
+  };
+}
+
+function minPositiveDelta(values: number[]): number | null {
+  let best = Infinity;
+  for (let i = 1; i < values.length; i += 1) {
+    const delta = values[i] - values[i - 1];
+    if (delta > 1e-6 && delta < best) best = delta;
+  }
+  return Number.isFinite(best) ? best : null;
 }

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -16,8 +16,9 @@ import {
   isValidSelectionBBox,
   meterBBoxFromRect,
   normalizeRect,
-  validSelectionBBoxes,
-  type MeterBBox,
+  validRecommendationAreas,
+  type ApRecommendationArea,
+  type ApRecommendationAreaType,
 } from './recommendation-utils';
 
 export interface CanvasExistingAp {
@@ -32,6 +33,36 @@ const DRAG_THRESHOLD_M = 0.15;
 /** viewBox 너비 비율 — 도면 스케일과 무관하게 화면에서 읽기 쉬운 라벨 크기 */
 const CANVAS_LABEL_VB_RATIO = 0.018;
 
+const AREA_STYLE: Record<
+  ApRecommendationAreaType,
+  { label: string; fill: string; stroke: string; badge: string }
+> = {
+  candidate: {
+    label: '설치 가능 영역',
+    fill: 'rgb(37 99 235 / 0.18)',
+    stroke: 'rgb(37 99 235)',
+    badge: 'oklch(0.55 0.22 254)',
+  },
+  priority: {
+    label: '우선 평가 영역',
+    fill: 'rgb(22 163 74 / 0.18)',
+    stroke: 'rgb(22 163 74)',
+    badge: 'oklch(0.62 0.18 145)',
+  },
+  lowPriority: {
+    label: '낮은 우선순위 영역',
+    fill: 'rgb(234 179 8 / 0.20)',
+    stroke: 'rgb(202 138 4)',
+    badge: 'oklch(0.69 0.17 82)',
+  },
+  excluded: {
+    label: '제외 영역',
+    fill: 'rgb(239 68 68 / 0.16)',
+    stroke: 'rgb(220 38 38)',
+    badge: 'oklch(0.62 0.21 25)',
+  },
+};
+
 function canvasLabelFontM(viewBoxW: number): number {
   return viewBoxW * CANVAS_LABEL_VB_RATIO;
 }
@@ -40,8 +71,9 @@ interface Props {
   sceneVersion: SceneVersion | null | undefined;
   backgroundImageUrl?: string | null;
   existingAps: CanvasExistingAp[];
-  selectionBBoxes: MeterBBox[];
-  onSelectionChange: (bboxes: MeterBBox[]) => void;
+  selectedAreas: ApRecommendationArea[];
+  activeAreaType: ApRecommendationAreaType;
+  onAreasChange: (areas: ApRecommendationArea[]) => void;
   recommendations: ApRecommendationResult[];
   selectedRecommendationRank: number | null;
   disabled?: boolean;
@@ -92,8 +124,9 @@ function computeViewBox(
 export function ApRecommendationCanvas({
   sceneVersion,
   backgroundImageUrl,
-  selectionBBoxes,
-  onSelectionChange,
+  selectedAreas,
+  activeAreaType,
+  onAreasChange,
   recommendations,
   selectedRecommendationRank,
   disabled = false,
@@ -162,30 +195,37 @@ export function ApRecommendationCanvas({
     const rect = clampRectToBounds(normalizeRect(drag.start, drag.current), sceneBounds);
     setDrag(null);
     if (rect.w < DRAG_THRESHOLD_M || rect.h < DRAG_THRESHOLD_M) {
-      onSelectionChange([]);
       return;
     }
     const bbox = clampMeterBBox(meterBBoxFromRect(rect), sceneBounds);
     if (isValidSelectionBBox(bbox)) {
-      onSelectionChange([...selectionBBoxes, bbox]);
+      onAreasChange([
+        ...selectedAreas,
+        {
+          id: `${activeAreaType}-${Date.now()}-${selectedAreas.length}`,
+          type: activeAreaType,
+          bbox,
+        },
+      ]);
     }
   };
 
   const dragRect = drag
     ? clampRectToBounds(normalizeRect(drag.start, drag.current), sceneBounds)
     : null;
-  const clampedSelectionBBoxes = validSelectionBBoxes(selectionBBoxes).map((bbox) =>
-    clampMeterBBox(bbox, sceneBounds),
-  );
+  const clampedAreas = validRecommendationAreas(selectedAreas).map((area) => ({
+    ...area,
+    bbox: clampMeterBBox(area.bbox, sceneBounds),
+  }));
   const showDragPreview =
     dragRect && (dragRect.w >= DRAG_THRESHOLD_M || dragRect.h >= DRAG_THRESHOLD_M);
   const labelFontM = canvasLabelFontM(vb.w);
   const selectionBadgeH = labelFontM * 1.55;
-  const selectionBadgeW = labelFontM * 8.2;
+  const selectionBadgeW = labelFontM * 11.6;
   const removeButtonR = labelFontM * 0.7;
 
-  const removeSelectionBBox = (index: number) => {
-    onSelectionChange(selectionBBoxes.filter((_, idx) => idx !== index));
+  const removeSelectedArea = (id: string) => {
+    onAreasChange(selectedAreas.filter((area) => area.id !== id));
   };
 
   return (
@@ -252,68 +292,72 @@ export function ApRecommendationCanvas({
 
         {/* 선택 영역 — clamp된 좌표, clipPath 밖(배지가 상단에서 잘리지 않도록) */}
         <g>
-          {clampedSelectionBBoxes.map((bbox, idx) => (
-            <g key={`${bbox.x_min}-${bbox.y_min}-${bbox.x_max}-${bbox.y_max}-${idx}`}>
-              <rect
-                x={bbox.x_min}
-                y={bbox.y_min}
-                width={bbox.x_max - bbox.x_min}
-                height={bbox.y_max - bbox.y_min}
-                fill="rgb(37 99 235 / 0.22)"
-                stroke="rgb(37 99 235)"
-                strokeWidth="1.5"
-                vectorEffect="non-scaling-stroke"
-              />
-              <rect
-                x={bbox.x_min}
-                y={bbox.y_min - selectionBadgeH}
-                width={selectionBadgeW}
-                height={selectionBadgeH}
-                fill="oklch(0.55 0.22 254)"
-              />
-              <text
-                x={bbox.x_min + labelFontM * 0.45}
-                y={bbox.y_min - selectionBadgeH * 0.38}
-                fontSize={labelFontM * 0.92}
-                fontWeight="600"
-                fill="white"
-                pointerEvents="none"
-                style={{ userSelect: 'none' }}
-              >
-                우선 개선 영역
-              </text>
-              <g
-                className="cursor-pointer"
-                onPointerDown={(e) => {
-                  e.stopPropagation();
-                  removeSelectionBBox(idx);
-                }}
-              >
-                <circle
-                  cx={bbox.x_max}
-                  cy={bbox.y_min}
-                  r={removeButtonR}
-                  fill="oklch(0.62 0.21 25)"
-                  stroke="white"
+          {clampedAreas.map((area) => {
+            const bbox = area.bbox;
+            const style = AREA_STYLE[area.type];
+            return (
+              <g key={area.id}>
+                <rect
+                  x={bbox.x_min}
+                  y={bbox.y_min}
+                  width={bbox.x_max - bbox.x_min}
+                  height={bbox.y_max - bbox.y_min}
+                  fill={style.fill}
+                  stroke={style.stroke}
                   strokeWidth="1.5"
                   vectorEffect="non-scaling-stroke"
                 />
+                <rect
+                  x={bbox.x_min}
+                  y={bbox.y_min - selectionBadgeH}
+                  width={selectionBadgeW}
+                  height={selectionBadgeH}
+                  fill={style.badge}
+                />
                 <text
-                  x={bbox.x_max}
-                  y={bbox.y_min}
-                  textAnchor="middle"
-                  dominantBaseline="middle"
-                  fontSize={labelFontM}
-                  fontWeight="700"
+                  x={bbox.x_min + labelFontM * 0.45}
+                  y={bbox.y_min - selectionBadgeH * 0.38}
+                  fontSize={labelFontM * 0.92}
+                  fontWeight="600"
                   fill="white"
                   pointerEvents="none"
                   style={{ userSelect: 'none' }}
                 >
-                  ×
+                  {style.label}
                 </text>
+                <g
+                  className="cursor-pointer"
+                  onPointerDown={(e) => {
+                    e.stopPropagation();
+                    removeSelectedArea(area.id);
+                  }}
+                >
+                  <circle
+                    cx={bbox.x_max}
+                    cy={bbox.y_min}
+                    r={removeButtonR}
+                    fill="oklch(0.62 0.21 25)"
+                    stroke="white"
+                    strokeWidth="1.5"
+                    vectorEffect="non-scaling-stroke"
+                  />
+                  <text
+                    x={bbox.x_max}
+                    y={bbox.y_min}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize={labelFontM}
+                    fontWeight="700"
+                    fill="white"
+                    pointerEvents="none"
+                    style={{ userSelect: 'none' }}
+                  >
+                    ×
+                  </text>
+                </g>
               </g>
-            </g>
-          ))}
+            );
+          })}
 
           {showDragPreview && dragRect && (
             <rect
@@ -321,8 +365,8 @@ export function ApRecommendationCanvas({
               y={dragRect.y}
               width={dragRect.w}
               height={dragRect.h}
-              fill="rgb(37 99 235 / 0.18)"
-              stroke="rgb(37 99 235)"
+              fill={AREA_STYLE[activeAreaType].fill}
+              stroke={AREA_STYLE[activeAreaType].stroke}
               strokeWidth="1.5"
               strokeDasharray="4 3"
               vectorEffect="non-scaling-stroke"

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -33,7 +33,6 @@ export interface MeterBBox {
 export type ApRecommendationAreaType =
   | 'candidate'
   | 'priority'
-  | 'lowPriority'
   | 'excluded';
 
 export interface ApRecommendationArea {
@@ -102,11 +101,11 @@ export function buildApRecommendationPayload(params: {
       ? areas.filter((area) => area.type === 'candidate').map((area) => area.bbox)
       : legacyBboxes;
   const priorityZones = areas
-    .filter((area) => area.type === 'priority' || area.type === 'lowPriority')
+    .filter((area) => area.type === 'priority')
     .map((area) => ({
       ...area.bbox,
-      label: area.type === 'priority' ? '우선 평가 영역' : '낮은 우선순위 영역',
-      weight: area.type === 'priority' ? 1.0 : 0.2,
+      label: '집중구간',
+      weight: 1.0,
     }));
   const excludedZones = areas
     .filter((area) => area.type === 'excluded')
@@ -114,7 +113,7 @@ export function buildApRecommendationPayload(params: {
   const evaluationBBoxes =
     areas.length > 0
       ? areas
-          .filter((area) => area.type === 'priority' || area.type === 'lowPriority')
+          .filter((area) => area.type === 'priority')
           .map((area) => area.bbox)
       : [];
   const legacyUnion = unionMeterBBoxes(legacyBboxes);
@@ -164,6 +163,7 @@ export function normalizeRecommendations(
     average_rssi_dbm: item.average_rssi_dbm,
     baseline_improvement_score: item.baseline_improvement_score,
     baseline_improvement_db: item.baseline_improvement_db,
+    prediction_points: item.prediction_points ?? [],
   }));
 }
 
@@ -407,7 +407,7 @@ export function getRecommendationReason(
 
   if (rec.rank === 1) {
     parts.push(
-      '우선 개선 영역·도면 평가 지점에서 음영 구역을 줄이고 예측 신호가 가장 잘 닿는 위치입니다.',
+      '집중구간과 도면 평가 지점에서 음영 구역을 줄이고 예측 신호가 가장 잘 닿는 위치입니다.',
     );
     if (bbox && isNearBboxEdge(rec, bbox)) {
       parts.push('선택 영역 가장자리 근처입니다.');

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -87,6 +87,7 @@ export function buildApRecommendationPayload(params: {
     x_max: union.x_max,
     y_min: union.y_min,
     y_max: union.y_max,
+    candidate_bboxes: bboxes,
     target_bboxes: bboxes,
     existing_aps: mapToExistingAps(params.existingAps, params.txPowerDbm),
   };
@@ -103,6 +104,16 @@ export function normalizeRecommendations(
     recommended_y: item.recommended_y,
     score: item.score,
     candidates_evaluated: response.candidates_evaluated,
+    coverage_score: item.coverage_score,
+    coverage_ratio: item.coverage_ratio,
+    weak_zone_improvement_score: item.weak_zone_improvement_score,
+    weak_zone_improvement_db: item.weak_zone_improvement_db,
+    bottom_10_percent_score: item.bottom_10_percent_score,
+    bottom_10_percent_rssi_dbm: item.bottom_10_percent_rssi_dbm,
+    average_rssi_score: item.average_rssi_score,
+    average_rssi_dbm: item.average_rssi_dbm,
+    baseline_improvement_score: item.baseline_improvement_score,
+    baseline_improvement_db: item.baseline_improvement_db,
   }));
 }
 

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -3,6 +3,7 @@ import type {
   ApRecommendationRequest,
   ApRecommendationResponse,
   ApRecommendationResult,
+  ApRecommendationRun,
 } from '@/types/ap-recommendation';
 import type { UUID } from '@/types/common';
 import { parseGeometry } from '@/features/editor/geometry-utils';
@@ -165,6 +166,38 @@ export function normalizeRecommendations(
     baseline_improvement_db: item.baseline_improvement_db,
     prediction_points: item.prediction_points ?? [],
   }));
+}
+
+export function normalizeRecommendationRun(
+  run: ApRecommendationRun | null | undefined,
+): ApRecommendationResult[] {
+  if (!run) return [];
+  return normalizeRecommendations({
+    run_id: run.id,
+    recommendations: run.recommendations,
+    status: run.status,
+    candidates_evaluated: run.candidates_evaluated,
+    eval_points_count: run.eval_points_count,
+    weighted_eval_points_count: run.weighted_eval_points_count,
+    calibration_applied: !!run.calibration_run_id,
+    calibration: isApRecommendationCalibrationInfo(run.calibration_json)
+      ? run.calibration_json
+      : null,
+    score_weights: run.score_weights_json,
+    created_at: run.created_at,
+  });
+}
+
+function isApRecommendationCalibrationInfo(
+  value: unknown,
+): value is NonNullable<ApRecommendationResponse['calibration']> {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.method === 'string' &&
+    typeof record.slope === 'number' &&
+    typeof record.intercept_db === 'number'
+  );
 }
 
 /** 캔버스 AP → API existing_aps. tx_power_dbm 없으면 필드 생략(백엔드 default 20). */

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -30,6 +30,18 @@ export interface MeterBBox {
   y_max: number;
 }
 
+export type ApRecommendationAreaType =
+  | 'candidate'
+  | 'priority'
+  | 'lowPriority'
+  | 'excluded';
+
+export interface ApRecommendationArea {
+  id: string;
+  type: ApRecommendationAreaType;
+  bbox: MeterBBox;
+}
+
 const MIN_SELECTION_M = 0.2;
 
 /** normalizeRect 결과 → MeterBBox. */
@@ -58,6 +70,12 @@ export function validSelectionBBoxes(bboxes: MeterBBox[] | null | undefined): Me
   return (bboxes ?? []).filter(isValidSelectionBBox);
 }
 
+export function validRecommendationAreas(
+  areas: ApRecommendationArea[] | null | undefined,
+): ApRecommendationArea[] {
+  return (areas ?? []).filter((area) => isValidSelectionBBox(area.bbox));
+}
+
 export function unionMeterBBoxes(bboxes: MeterBBox[]): MeterBBox | null {
   const valid = validSelectionBBoxes(bboxes);
   if (valid.length === 0) return null;
@@ -72,25 +90,57 @@ export function unionMeterBBoxes(bboxes: MeterBBox[]): MeterBBox | null {
 /** POST /ap-recommendation 요청 본문 조립 (백엔드 default 필드는 생략). */
 export function buildApRecommendationPayload(params: {
   sceneVersionId: UUID;
-  bboxes: MeterBBox[];
+  bboxes?: MeterBBox[];
+  areas?: ApRecommendationArea[];
   existingAps: { id: string; x_m: number; y_m: number }[];
   txPowerDbm?: number;
 }): ApRecommendationRequest {
-  const bboxes = validSelectionBBoxes(params.bboxes);
-  const union = unionMeterBBoxes(bboxes);
-  if (!union) {
-    throw new Error('At least one valid target bbox is required.');
+  const areas = validRecommendationAreas(params.areas);
+  const legacyBboxes = validSelectionBBoxes(params.bboxes);
+  const candidateBBoxes =
+    areas.length > 0
+      ? areas.filter((area) => area.type === 'candidate').map((area) => area.bbox)
+      : legacyBboxes;
+  const priorityZones = areas
+    .filter((area) => area.type === 'priority' || area.type === 'lowPriority')
+    .map((area) => ({
+      ...area.bbox,
+      label: area.type === 'priority' ? '우선 평가 영역' : '낮은 우선순위 영역',
+      weight: area.type === 'priority' ? 1.0 : 0.2,
+    }));
+  const excludedZones = areas
+    .filter((area) => area.type === 'excluded')
+    .map((area) => area.bbox);
+  const evaluationBBoxes =
+    areas.length > 0
+      ? areas
+          .filter((area) => area.type === 'priority' || area.type === 'lowPriority')
+          .map((area) => area.bbox)
+      : [];
+  const legacyUnion = unionMeterBBoxes(legacyBboxes);
+
+  if (candidateBBoxes.length === 0) {
+    throw new Error('At least one installable candidate area is required.');
   }
-  return {
+  const request: ApRecommendationRequest = {
     scene_version_id: params.sceneVersionId,
-    x_min: union.x_min,
-    x_max: union.x_max,
-    y_min: union.y_min,
-    y_max: union.y_max,
-    candidate_bboxes: bboxes,
-    target_bboxes: bboxes,
+    candidate_bboxes: candidateBBoxes,
+    evaluation_bboxes: evaluationBBoxes,
+    priority_zones: priorityZones,
+    excluded_zones: excludedZones,
+    default_unzoned_weight: 0.2,
+    calibration_policy: 'transfer_only',
+    candidate_tx_power_dbm: params.txPowerDbm,
     existing_aps: mapToExistingAps(params.existingAps, params.txPowerDbm),
   };
+  if (legacyUnion) {
+    request.x_min = legacyUnion.x_min;
+    request.x_max = legacyUnion.x_max;
+    request.y_min = legacyUnion.y_min;
+    request.y_max = legacyUnion.y_max;
+    request.target_bboxes = legacyBboxes;
+  }
+  return request;
 }
 
 /** 응답 → UI 표시용 배열로 normalize. */

--- a/frontend/src/features/calibration/CalibrationCard.tsx
+++ b/frontend/src/features/calibration/CalibrationCard.tsx
@@ -12,7 +12,7 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { dbmToHeatmapColor } from '@/lib/rssi-colormap';
+import { RSSI_HEATMAP_GRADIENT_CSS, dbmToHeatmapColor } from '@/lib/rssi-colormap';
 import type {
   CalibrationEvaluationResponse,
   CalibrationRun,
@@ -966,10 +966,7 @@ function RssiScaleBar({ min, max }: { min: number; max: number }) {
     <div className="mt-2">
       <div
         className="h-2 rounded-full"
-        style={{
-          background:
-            'linear-gradient(90deg, rgb(12,7,134), rgb(75,3,161), rgb(125,3,168), rgb(203,71,119), rgb(248,149,64), rgb(240,249,33))',
-        }}
+        style={{ background: RSSI_HEATMAP_GRADIENT_CSS }}
       />
       <div className="mt-1 flex justify-between text-[10px] text-muted-foreground">
         <span>{min} dBm</span>

--- a/frontend/src/features/measurement/MeasurementCanvas.tsx
+++ b/frontend/src/features/measurement/MeasurementCanvas.tsx
@@ -12,6 +12,7 @@ import type {
   SceneVersion,
 } from '@/types/scene';
 import { cn } from '@/lib/utils';
+import { dbmToHeatmapColor } from '@/lib/rssi-colormap';
 
 export type MeasurementPointQuality = 'good' | 'warning' | 'poor';
 
@@ -133,38 +134,6 @@ const QUALITY_HEATMAP_RGBA: Record<MeasurementPointQuality, string> = {
   warning: 'rgba(250, 204, 21, 0.45)',
   poor: 'rgba(248, 113, 113, 0.6)',
 };
-
-// matplotlib inferno cmap stops — Sionna heatmap 과 동일 visual language.
-// HeatmapColorLegend.tsx 와 동기화 유지.
-const INFERNO_STOPS = [
-  [0, 0, 4],
-  [22, 11, 57],
-  [66, 10, 104],
-  [106, 23, 110],
-  [147, 38, 103],
-  [188, 55, 84],
-  [221, 81, 58],
-  [243, 120, 25],
-  [252, 165, 10],
-  [246, 215, 70],
-  [252, 255, 164],
-] as const;
-
-/** dBm 값 → inferno cmap RGB. min/max 범위로 정규화 후 stops 사이 선형 보간. */
-function dbmToInfernoColor(dbm: number, min: number, max: number): string {
-  if (!Number.isFinite(dbm) || max <= min) return 'rgb(255, 255, 255)';
-  const t = Math.max(0, Math.min(1, (dbm - min) / (max - min)));
-  const scaled = t * (INFERNO_STOPS.length - 1);
-  const lo = Math.floor(scaled);
-  const hi = Math.min(INFERNO_STOPS.length - 1, lo + 1);
-  const frac = scaled - lo;
-  const c0 = INFERNO_STOPS[lo];
-  const c1 = INFERNO_STOPS[hi];
-  const r = Math.round(c0[0] + frac * (c1[0] - c0[0]));
-  const g = Math.round(c0[1] + frac * (c1[1] - c0[1]));
-  const b = Math.round(c0[2] + frac * (c1[2] - c0[2]));
-  return `rgb(${r}, ${g}, ${b})`;
-}
 
 /**
  * 실측/진단 캔버스. 확정 버전 도형 위에 측정 경로(line + 색상 dot) 와/또는
@@ -364,7 +333,7 @@ export function MeasurementCanvas({
                     y={bounds.min_y + rowIdx * cellH}
                     width={cellW}
                     height={cellH}
-                    fill={dbmToInfernoColor(value, range.min, range.max)}
+                    fill={dbmToHeatmapColor(value, range.min, range.max)}
                   />
                 );
               }),
@@ -432,7 +401,7 @@ export function MeasurementCanvas({
           sortedPoints.map((p) => {
             const fill =
               effectiveColorMode === 'dbm'
-                ? dbmToInfernoColor(
+                ? dbmToHeatmapColor(
                     pointRssiByOrder?.get(p.id) ?? Number.NaN,
                     dbmMin,
                     dbmMax,

--- a/frontend/src/features/mobile/MobileConnectModal.tsx
+++ b/frontend/src/features/mobile/MobileConnectModal.tsx
@@ -4,16 +4,19 @@ import { QRCodeSVG } from 'qrcode.react';
 import { useAppStore } from '@/stores/app-store';
 import { useCreateMeasurementLink } from '@/hooks/use-measurement-link';
 import { toast } from '@/stores/toast-store';
+import type { UUID } from '@/types/common';
 
 interface Props {
   open: boolean;
   onClose: () => void;
+  sceneVersionId?: UUID | null;
   recommendedPurpose?: 'calibration' | 'reference' | 'validation' | 'unknown';
 }
 
 export function MobileConnectModal({
   open,
   onClose,
+  sceneVersionId,
   recommendedPurpose = 'calibration',
 }: Props) {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -26,9 +29,9 @@ export function MobileConnectModal({
     if (!open) return;
     if (!floorId) return;
     if (createLink.isPending || link) return;
-    createLink.mutate({ floorId, recommendedPurpose });
+    createLink.mutate({ floorId, recommendedPurpose, sceneVersionId });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, floorId, recommendedPurpose]);
+  }, [open, floorId, sceneVersionId, recommendedPurpose]);
 
   // 닫힐 때 상태 초기화 (다음 열릴 때 새 QR 발급)
   useEffect(() => {
@@ -85,10 +88,12 @@ export function MobileConnectModal({
             expiresAt={link.expires_at}
             deepLink={link.deep_link}
             recommendedPurpose={recommendedPurpose}
-            onRefresh={() => createLink.mutate({ floorId, recommendedPurpose })}
+            onRefresh={() => createLink.mutate({ floorId, recommendedPurpose, sceneVersionId })}
           />
         ) : createLink.isError ? (
-          <ErrorState onRetry={() => createLink.mutate({ floorId, recommendedPurpose })} />
+          <ErrorState
+            onRetry={() => createLink.mutate({ floorId, recommendedPurpose, sceneVersionId })}
+          />
         ) : null}
       </div>
     </div>

--- a/frontend/src/hooks/use-ap-recommendation-session.ts
+++ b/frontend/src/hooks/use-ap-recommendation-session.ts
@@ -4,87 +4,80 @@ import {
   useApRecommendationStore,
   type ApRecommendationSession,
 } from '@/stores/ap-recommendation-store';
-import type { MeterBBox } from '@/features/ap-recommendation/recommendation-utils';
+import type { ApRecommendationArea } from '@/features/ap-recommendation/recommendation-utils';
 import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import type { UUID } from '@/types/common';
 
-function isPersistedSession(
-  session: ApRecommendationSession | undefined,
-  sceneVersionId: UUID | null,
-): session is ApRecommendationSession {
-  if (!session || session.savedRank == null) return false;
-  if (
-    sceneVersionId &&
-    session.sceneVersionId &&
-    session.sceneVersionId !== sceneVersionId
-  ) {
-    return false;
-  }
-  return true;
+function getStoredSession(sceneVersionId: UUID | null): ApRecommendationSession | null {
+  if (!sceneVersionId) return null;
+  return useApRecommendationStore.getState().byScene[sceneVersionId] ?? null;
 }
 
-/**
- * AP 배치 추천 UI 세션.
- * - 페이지 내 편집: useState (추천만 받고 저장 안 한 상태는 유지하지 않음)
- * - 「이 위치 선택」 저장 성공 후에만 localStorage persist
- */
 export function useApRecommendationSession(
-  floorId: UUID | null,
+  _floorId: UUID | null,
   sceneVersionId: UUID | null,
 ) {
-  const patchFloor = useApRecommendationStore((s) => s.patchFloor);
-  const clearFloor = useApRecommendationStore((s) => s.clearFloor);
+  const patchScene = useApRecommendationStore((s) => s.patchScene);
+  const clearScene = useApRecommendationStore((s) => s.clearScene);
 
-  const [selectionBBox, setSelectionBBox] = useState<MeterBBox | null>(null);
+  const [areas, setAreas] = useState<ApRecommendationArea[]>([]);
   const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
   const [selectedRank, setSelectedRank] = useState<number | null>(null);
   const [savedRank, setSavedRank] = useState<number | null>(null);
+  const [compareWithMeasurement, setCompareWithMeasurement] = useState(false);
 
   useEffect(() => {
-    const stored = floorId
-      ? useApRecommendationStore.getState().byFloor[floorId]
-      : undefined;
+    const stored = getStoredSession(sceneVersionId);
 
-    if (isPersistedSession(stored, sceneVersionId)) {
-      setSelectionBBox(stored.selectionBBox);
+    if (stored) {
+      setAreas(stored.areas);
       setRecommendations(stored.recommendations);
       setSelectedRank(stored.selectedRank);
       setSavedRank(stored.savedRank);
+      setCompareWithMeasurement(stored.compareWithMeasurement);
       return;
     }
 
-    setSelectionBBox(EMPTY_AP_RECOMMENDATION_SESSION.selectionBBox);
+    setAreas(EMPTY_AP_RECOMMENDATION_SESSION.areas);
     setRecommendations(EMPTY_AP_RECOMMENDATION_SESSION.recommendations);
     setSelectedRank(EMPTY_AP_RECOMMENDATION_SESSION.selectedRank);
     setSavedRank(EMPTY_AP_RECOMMENDATION_SESSION.savedRank);
-  }, [floorId, sceneVersionId]);
+    setCompareWithMeasurement(EMPTY_AP_RECOMMENDATION_SESSION.compareWithMeasurement);
+  }, [sceneVersionId]);
 
-  const persistSavedSession = useCallback(
-    (session: ApRecommendationSession) => {
-      if (!floorId || session.savedRank == null) return;
-      patchFloor(floorId, session);
+  const persistSession = useCallback(
+    (patch: Partial<ApRecommendationSession>) => {
+      if (!sceneVersionId) return;
+      patchScene(sceneVersionId, {
+        sceneVersionId,
+        updatedAt: new Date().toISOString(),
+        ...patch,
+      });
     },
-    [floorId, patchFloor],
+    [patchScene, sceneVersionId],
   );
 
   const resetSession = useCallback(() => {
-    if (floorId) clearFloor(floorId);
-    setSelectionBBox(null);
+    if (sceneVersionId) clearScene(sceneVersionId);
+    setAreas([]);
     setRecommendations([]);
     setSelectedRank(null);
     setSavedRank(null);
-  }, [floorId, clearFloor]);
+    setCompareWithMeasurement(false);
+  }, [clearScene, sceneVersionId]);
 
   return {
-    selectionBBox,
+    areas,
     recommendations,
     selectedRank,
     savedRank,
-    setSelectionBBox,
+    compareWithMeasurement,
+    setAreas,
     setRecommendations,
     setSelectedRank,
     setSavedRank,
-    persistSavedSession,
+    setCompareWithMeasurement,
+    persistSession,
     resetSession,
   };
 }

--- a/frontend/src/hooks/use-ap-recommendation.ts
+++ b/frontend/src/hooks/use-ap-recommendation.ts
@@ -1,13 +1,23 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apRecommendationApi } from '@/api/ap-recommendation';
 import type { HttpError } from '@/api/client';
 import { toast } from '@/stores/toast-store';
+import type { UUID } from '@/types/common';
 import type { ApRecommendationRequest } from '@/types/ap-recommendation';
 
 /** POST /ap-recommendation — AP 최적 배치 추천. */
 export function useApRecommendation() {
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: ApRecommendationRequest) => apRecommendationApi.recommend(body),
+    onSuccess: (result, body) => {
+      qc.invalidateQueries({
+        queryKey: ['ap-recommendation-runs', body.scene_version_id],
+      });
+      if (result.run_id) {
+        qc.invalidateQueries({ queryKey: ['ap-recommendation-run', result.run_id] });
+      }
+    },
     onError: (err) => {
       const e = err as HttpError | null;
       toast.error(
@@ -15,5 +25,27 @@ export function useApRecommendation() {
         e?.message ?? '잠시 후 다시 시도해주세요.',
       );
     },
+  });
+}
+
+export function useApRecommendationRuns(sceneVersionId: UUID | null, pageSize = 20) {
+  return useQuery({
+    queryKey: ['ap-recommendation-runs', sceneVersionId, pageSize] as const,
+    queryFn: () =>
+      apRecommendationApi.listRuns(sceneVersionId as UUID, {
+        page: 1,
+        page_size: pageSize,
+      }),
+    enabled: !!sceneVersionId,
+    retry: false,
+  });
+}
+
+export function useApRecommendationRun(runId: UUID | null) {
+  return useQuery({
+    queryKey: ['ap-recommendation-run', runId] as const,
+    queryFn: () => apRecommendationApi.getRun(runId as UUID),
+    enabled: !!runId,
+    retry: false,
   });
 }

--- a/frontend/src/hooks/use-calibration-run.ts
+++ b/frontend/src/hooks/use-calibration-run.ts
@@ -33,8 +33,11 @@ export function useEvaluateCalibrationRun() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: CalibrationEvaluationRequest) => calibrationRunApi.evaluate(body),
-    onSuccess: (result) => {
+    onSuccess: (result, body) => {
       qc.invalidateQueries({ queryKey: ['calibration-run'] });
+      qc.invalidateQueries({
+        queryKey: ['calibration-runs', body.scene_version_id],
+      });
       toast.success('보정 평가 완료', '검증 지표와 보정맵을 확인할 수 있습니다.');
       return result;
     },
@@ -42,6 +45,19 @@ export function useEvaluateCalibrationRun() {
       const e = err as HttpError | null;
       toast.error('보정 실행 실패', e?.message ?? '측정점과 시뮬레이션 결과를 확인해주세요.');
     },
+  });
+}
+
+export function useCalibrationRuns(sceneVersionId: UUID | null, pageSize = 10) {
+  return useQuery({
+    queryKey: ['calibration-runs', sceneVersionId, pageSize] as const,
+    queryFn: () =>
+      calibrationRunApi.list(sceneVersionId as UUID, {
+        page: 1,
+        page_size: pageSize,
+      }),
+    enabled: !!sceneVersionId,
+    retry: false,
   });
 }
 

--- a/frontend/src/hooks/use-local-floorplan-image.ts
+++ b/frontend/src/hooks/use-local-floorplan-image.ts
@@ -45,12 +45,13 @@ function readEntry(key: string): string | null {
 function readForAssetOrFloor(
   floorId: string | null,
   sourceAssetId: string | null | undefined,
+  allowFloorFallback: boolean,
 ): string | null {
   if (sourceAssetId) {
     const v = readEntry(assetKey(sourceAssetId));
     if (v) return v;
   }
-  if (floorId) {
+  if (allowFloorFallback && floorId) {
     const v = readEntry(floorKey(floorId));
     if (v) return v;
   }
@@ -61,6 +62,7 @@ export interface UseLocalFloorplanImageOpts {
   floorId: string | null;
   /** SceneVersion / SceneDraft 의 source_asset_id — 있으면 이 자산별 키를 우선 읽음. */
   sourceAssetId?: string | null;
+  allowFloorFallback?: boolean;
 }
 
 /**
@@ -76,14 +78,15 @@ export function useLocalFloorplanImage(
       ? floorIdOrOpts
       : { floorId: floorIdOrOpts ?? null };
   const { floorId, sourceAssetId } = opts;
+  const allowFloorFallback = opts.allowFloorFallback ?? !sourceAssetId;
 
   const [dataUrl, setDataUrl] = useState<string | null>(() =>
-    readForAssetOrFloor(floorId, sourceAssetId),
+    readForAssetOrFloor(floorId, sourceAssetId, allowFloorFallback),
   );
 
   useEffect(() => {
-    setDataUrl(readForAssetOrFloor(floorId, sourceAssetId));
-  }, [floorId, sourceAssetId]);
+    setDataUrl(readForAssetOrFloor(floorId, sourceAssetId, allowFloorFallback));
+  }, [floorId, sourceAssetId, allowFloorFallback]);
 
   // 다른 탭/스코프에서 변경되거나 같은 페이지의 save/link 호출 후 동기화.
   useEffect(() => {
@@ -95,7 +98,7 @@ export function useLocalFloorplanImage(
         const matchesAsset = !!sourceAssetId && detail?.assetId === sourceAssetId;
         if (!matchesFloor && !matchesAsset) return;
       }
-      setDataUrl(readForAssetOrFloor(floorId, sourceAssetId));
+      setDataUrl(readForAssetOrFloor(floorId, sourceAssetId, allowFloorFallback));
     };
     window.addEventListener('storage', onChange);
     window.addEventListener('floorplan-image-changed', onChange);
@@ -103,7 +106,7 @@ export function useLocalFloorplanImage(
       window.removeEventListener('storage', onChange);
       window.removeEventListener('floorplan-image-changed', onChange);
     };
-  }, [floorId, sourceAssetId]);
+  }, [floorId, sourceAssetId, allowFloorFallback]);
 
   return dataUrl;
 }

--- a/frontend/src/hooks/use-measurement-link.ts
+++ b/frontend/src/hooks/use-measurement-link.ts
@@ -13,10 +13,12 @@ export function useCreateMeasurementLink() {
     mutationFn: ({
       floorId,
       recommendedPurpose = 'calibration',
+      sceneVersionId,
     }: {
       floorId: UUID;
       recommendedPurpose?: 'calibration' | 'reference' | 'validation' | 'unknown';
-    }) => measurementLinkApi.create(floorId, recommendedPurpose),
+      sceneVersionId?: UUID | null;
+    }) => measurementLinkApi.create(floorId, recommendedPurpose, sceneVersionId),
     onError: (err) => {
       const e = err as HttpError | null;
       toast.error(

--- a/frontend/src/lib/rssi-colormap.ts
+++ b/frontend/src/lib/rssi-colormap.ts
@@ -1,22 +1,19 @@
 /**
- * RSSI heatmap colormap — warm thermal (Wikipedia-style).
- * Weak → deep navy → blue → teal → green → yellow (peak warmth) → orange → red.
- * Strong signal appears as bright yellow/amber rather than dark red.
+ * RSSI heatmap colormap — matplotlib/OpenCV jet style.
+ * Weak → blue, medium → cyan/green/yellow, strong → red.
  */
 
 /** RGB tuples at t = 0 (weakest) … 1 (strongest) */
 export const RSSI_HEATMAP_STOPS_RGB: ReadonlyArray<readonly [number, number, number]> = [
-  [30,  80, 235],  // bright blue       (very weak)
-  [0,  140, 255],  // royal blue
-  [0,  210, 255],  // sky blue / cyan
-  [0,  240, 190],  // teal
-  [30, 240,  70],  // green
-  [160, 240,   0], // yellow-green
-  [255, 235,   0], // bright yellow
-  [255, 160,   0], // amber
-  [255,  55,   0], // orange-red
-  [235,   0,   0], // bright red
-  [195,   0,   0], // medium red        (very strong)
+  [0, 0, 128],
+  [0, 0, 255],
+  [0, 128, 255],
+  [0, 255, 255],
+  [128, 255, 128],
+  [255, 255, 0],
+  [255, 128, 0],
+  [255, 0, 0],
+  [128, 0, 0],
 ];
 
 export const RSSI_HEATMAP_GRADIENT_CSS = buildHeatmapGradientCss();

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -14,7 +14,7 @@ import { HelpFab } from '@/components/HelpFab';
 import { cn } from '@/lib/utils';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
-import { useAssetDownloadUrl, useFloorAssets } from '@/hooks/use-assets';
+import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { DraftSceneCanvas } from '@/features/editor/DraftSceneCanvas';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
@@ -88,14 +88,14 @@ export default function DashboardPage() {
     : null;
   // Asset.storage_url 이 s3:// URI 라서 직접 못 쓰고, /download-url 로 presigned 받음.
   const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
-  const fallbackAsset = (floorAssetsQuery.data ?? [])
-    .slice()
-    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
-  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const effectiveAssetId = sourceAssetId;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
   // sourceAssetId 우선 — 히스토리 버전 클릭 시 그 자산 이미지로 정확히 복원.
-  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const localImage = useLocalFloorplanImage({
+    floorId,
+    sourceAssetId,
+    allowFloorFallback: false,
+  });
   // 절대 http(s) 자산 URL 만 <image> 에서 직접 로드. local 모드 `/assets/{id}/raw`
   // 상대경로는 origin/인증 문제로 못 써서 localStorage 캐시로 fallback.
   const assetUrl = assetUrlQuery.data?.url ?? null;

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -169,6 +169,7 @@ export default function EditorPage() {
   // 2순위: 층의 floorplan 자산 중 가장 최근 것 (fallback).
   // Asset.storage_url 이 s3:// URI 라서 직접 못 쓰고, /download-url 로 presigned 받음.
   const sourceAssetId = baseScene?.source_asset_id ?? null;
+  const allowUnversionedImageFallback = !!activeDraftSummary;
   const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
   const fallbackAsset = useMemo(() => {
     const list = floorAssetsQuery.data ?? [];
@@ -176,12 +177,17 @@ export default function EditorPage() {
     // created_at 내림차순 정렬 후 첫 항목.
     return [...list].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
   }, [floorAssetsQuery.data]);
-  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const effectiveAssetId =
+    sourceAssetId ?? (allowUnversionedImageFallback ? fallbackAsset?.id : null) ?? null;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
   // 3순위: 사용자가 업로드한 파일을 base64 로 캐시해둔 로컬 이미지 (백엔드 미지원 우회).
   // sourceAssetId 알면 자산별 키 우선, 없으면 floor 키 fallback — 히스토리 버전 클릭 시
   // 그 당시 업로드 이미지가 별도 키로 보존돼 있어 정확히 복원됨.
-  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const localImage = useLocalFloorplanImage({
+    floorId,
+    sourceAssetId,
+    allowFloorFallback: allowUnversionedImageFallback,
+  });
   // 업로드 직후엔 floor 키에만 임시 저장돼있음 → draft.source_asset_id 알게 되는 순간
   // asset 키로 복사해 보존 (덮어쓰진 않음). 새 업로드가 floor 키를 덮어써도 이전 자산은
   // 자기 자산 키에 그대로 남음.

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Activity,
   AlertTriangle,
@@ -34,13 +35,14 @@ import {
 } from '@/hooks/use-measurement-session';
 import { useFloorRfRuns, useRfMaps } from '@/hooks/use-rf-run';
 import { useApLayouts } from '@/hooks/use-ap-layouts';
-import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
+import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import { useEvaluateCalibrationRun } from '@/hooks/use-calibration-run';
 import { CalibrationCard } from '@/features/calibration/CalibrationCard';
 import type { CalibrationEvaluationResponse, SpaceType } from '@/types/calibration-run';
 import { parseGeometry } from '@/features/editor/geometry-utils';
+import { RSSI_HEATMAP_GRADIENT_CSS } from '@/lib/rssi-colormap';
 import {
   MeasurementCanvas,
   type MeasurementPoint as CanvasPoint,
@@ -54,25 +56,61 @@ const EMPTY_MEASUREMENT_POINTS: ApiPoint[] = [];
 
 export default function MeasurementPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedSceneVersionId = searchParams.get('sceneVersionId');
+  const requestedSessionId = searchParams.get('sessionId');
+  const requestedRfRunId = searchParams.get('rfRunId');
 
   // 확정된 도면 (캔버스 배경).
   const versionsQuery = useFloorVersions(floorId);
   const versions = versionsQuery.data ?? [];
   const currentVersion = versions.find((v) => v.is_current) ?? versions[0] ?? null;
-  const versionDetailQuery = useSceneVersion(currentVersion?.id ?? null);
+  const sessionsQuery = useFloorMeasurementSessions(floorId);
+  const sessions = sessionsQuery.data?.items ?? EMPTY_MEASUREMENT_SESSIONS;
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [selectedSceneVersionId, setSelectedSceneVersionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedSessionId(requestedSessionId);
+    setSelectedSceneVersionId(requestedSceneVersionId);
+  }, [requestedSessionId, requestedSceneVersionId]);
+
+  const selectedSession = useMemo(
+    () => sessions.find((s) => s.id === selectedSessionId) ?? null,
+    [sessions, selectedSessionId],
+  );
+  const fallbackSceneVersionId =
+    selectedSceneVersionId ??
+    currentVersion?.id ??
+    sessions.find((s) => !!s.scene_version_id)?.scene_version_id ??
+    null;
+  const viewingSceneVersionId = selectedSession?.scene_version_id ?? fallbackSceneVersionId;
+  const sessionsForViewingVersion = useMemo(() => {
+    if (!viewingSceneVersionId) return [];
+    return sessions.filter((s) => s.scene_version_id === viewingSceneVersionId);
+  }, [sessions, viewingSceneVersionId]);
+  const selectedSessionBelongsToViewingVersion =
+    !!selectedSession?.scene_version_id &&
+    selectedSession.scene_version_id === viewingSceneVersionId;
+  const activeSession =
+    selectedSessionBelongsToViewingVersion
+      ? selectedSession
+      : sessionsForViewingVersion[0] ?? null;
+  const activeSceneVersionId = viewingSceneVersionId;
+  const versionDetailQuery = useSceneVersion(activeSceneVersionId);
   const sceneVersion = versionDetailQuery.data ?? null;
 
   // 배경 원본 도면 이미지 — 공간편집/시뮬과 동일한 방식.
   const versionAsDraft = sceneVersion ? versionToDraftShape(sceneVersion) : null;
   const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
-  const fallbackAsset = (floorAssetsQuery.data ?? [])
-    .slice()
-    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
-  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const effectiveAssetId = sourceAssetId;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
   // sourceAssetId 우선 — 히스토리 버전 클릭 시 그 자산 이미지로 정확히 복원.
-  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const localImage = useLocalFloorplanImage({
+    floorId,
+    sourceAssetId,
+    allowFloorFallback: false,
+  });
   const assetUrl = assetUrlQuery.data?.url ?? null;
   const usableAssetUrl =
     assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;
@@ -98,17 +136,6 @@ export default function MeasurementPage() {
   const spaceType: SpaceType = spaceTypeOverride ?? currentFloor?.space_type ?? 'unknown';
 
   // 측정 세션. 기본은 최근 세션 자동 선택, 사용자가 '이력 보기' 로 다른 세션 선택 가능.
-  const sessionsQuery = useFloorMeasurementSessions(floorId);
-  const sessions = sessionsQuery.data?.items ?? EMPTY_MEASUREMENT_SESSIONS;
-  const sessionsForCurrentVersion = useMemo(() => {
-    if (!currentVersion?.id) return sessions;
-    return sessions.filter((s) => s.scene_version_id === currentVersion.id);
-  }, [sessions, currentVersion?.id]);
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
-  const activeSession =
-    sessionsForCurrentVersion.find((s) => s.id === selectedSessionId) ??
-    sessionsForCurrentVersion[0] ??
-    null;
   const pointsQuery = useMeasurementPoints(activeSession?.id ?? null);
   const points = pointsQuery.data?.items ?? EMPTY_MEASUREMENT_POINTS;
 
@@ -123,8 +150,13 @@ export default function MeasurementPage() {
   }, [points]);
 
   // 가장 최근 succeeded RF Run → AP layouts + RF Map metrics.
-  const rfRunsQuery = useFloorRfRuns(floorId, { status: 'succeeded', page_size: 5 });
-  const latestRfRun = rfRunsQuery.data?.items?.[0] ?? null;
+  const rfRunsQuery = useFloorRfRuns(floorId, { status: 'succeeded', page_size: 50 });
+  const latestRfRun =
+    rfRunsQuery.data?.items?.find(
+      (r) => r.id === requestedRfRunId && r.scene_version_id === activeSceneVersionId,
+    ) ??
+    rfRunsQuery.data?.items?.find((r) => r.scene_version_id === activeSceneVersionId) ??
+    null;
   const latestRfRunId = latestRfRun?.id ?? null;
   const apLayoutsQuery = useApLayouts(latestRfRunId);
   // AP 마커 우선순위: ap_layouts 테이블 > rf_run.request_json.access_points fallback.
@@ -196,11 +228,12 @@ export default function MeasurementPage() {
   const canCalibrate =
     !!activeSession?.id &&
     !!latestRfRunId &&
-    !!currentVersion?.id &&
+    !!activeSceneVersionId &&
     hasEnoughMeasurements;
   const evaluationSessionIds = useMemo(() => {
     const ids = new Set<string>();
-    for (const session of sessionsForCurrentVersion) {
+    for (const session of sessions) {
+      if (activeSceneVersionId && session.scene_version_id !== activeSceneVersionId) continue;
       if (
         session.measurement_purpose === 'calibration' ||
         session.measurement_purpose === 'reference' ||
@@ -211,7 +244,7 @@ export default function MeasurementPage() {
     }
     if (activeSession?.id) ids.add(activeSession.id);
     return [...ids];
-  }, [activeSession, sessionsForCurrentVersion]);
+  }, [activeSession, activeSceneVersionId, sessions]);
   const calibrationDisabledReason = !hasMeasurement
     ? '먼저 측정을 진행해주세요.'
     : !hasEnoughMeasurements
@@ -221,12 +254,12 @@ export default function MeasurementPage() {
     ? '비교할 시뮬레이션 결과가 없습니다. 시뮬레이션 페이지에서 실행해주세요.'
     : null;
   const handleCalibrate = () => {
-    if (!canCalibrate || !activeSession || !latestRfRunId || !currentVersion) return;
+    if (!canCalibrate || !activeSession || !latestRfRunId || !activeSceneVersionId) return;
     evaluateCalibration.mutate(
       {
         floor_id: activeSession.floor_id,
         rf_run_id: latestRfRunId,
-        scene_version_id: currentVersion.id,
+        scene_version_id: activeSceneVersionId,
         measurement_session_ids: evaluationSessionIds.length > 0 ? evaluationSessionIds : [activeSession.id],
         method: 'affine_rssi_transfer',
         split: { strategy: 'purpose_or_random', holdout_ratio: 0.3, seed: 42 },
@@ -247,12 +280,17 @@ export default function MeasurementPage() {
 
   const lastAutoCalibrationKey = useRef<string | null>(null);
   useEffect(() => {
+    setCalibrationEvaluation(null);
+    lastAutoCalibrationKey.current = null;
+  }, [activeSession?.id, activeSceneVersionId, latestRfRunId]);
+
+  useEffect(() => {
     if (mode !== 'both') return;
-    if (!canCalibrate || !activeSession || !latestRfRunId || !currentVersion) return;
+    if (!canCalibrate || !activeSession || !latestRfRunId || !activeSceneVersionId) return;
     const sessionIds = evaluationSessionIds.length > 0 ? evaluationSessionIds : [activeSession.id];
     const key = [
       activeSession.floor_id,
-      currentVersion.id,
+      activeSceneVersionId,
       latestRfRunId,
       sessionIds.join(','),
       points.length,
@@ -263,7 +301,7 @@ export default function MeasurementPage() {
       {
         floor_id: activeSession.floor_id,
         rf_run_id: latestRfRunId,
-        scene_version_id: currentVersion.id,
+        scene_version_id: activeSceneVersionId,
         measurement_session_ids: sessionIds,
         method: 'affine_rssi_transfer',
         split: { strategy: 'purpose_or_random', holdout_ratio: 0.3, seed: 42 },
@@ -285,7 +323,7 @@ export default function MeasurementPage() {
     canCalibrate,
     activeSession,
     latestRfRunId,
-    currentVersion,
+    activeSceneVersionId,
     evaluationSessionIds,
     points.length,
     evaluateCalibration,
@@ -311,15 +349,31 @@ export default function MeasurementPage() {
       ? calibratedMainHeatmap.rssiRange
       : pointColorRange;
 
+  const handleSelectSession = (sessionId: string) => {
+    const session = sessions.find((s) => s.id === sessionId) ?? null;
+    setSelectedSessionId(sessionId);
+    setSelectedSceneVersionId(session?.scene_version_id ?? null);
+
+    const next = new URLSearchParams(searchParams);
+    next.set('sessionId', sessionId);
+    if (session?.scene_version_id) {
+      next.set('sceneVersionId', session.scene_version_id);
+    } else {
+      next.delete('sceneVersionId');
+    }
+    next.delete('rfRunId');
+    setSearchParams(next, { replace: true });
+  };
 
   return (
     <div className="relative flex h-full flex-col gap-5 p-6">
       <PageHeader
-        sessions={sessionsForCurrentVersion}
+        sessions={sessions}
         activeSession={activeSession}
+        currentVersionId={currentVersion?.id ?? null}
         floorId={floorId ?? null}
         projectId={projectIdForFloors}
-        onSelectSession={(id) => setSelectedSessionId(id)}
+        onSelectSession={handleSelectSession}
         onStartMeasurement={() => {
           setMobilePurpose('calibration');
           setMobileOpen(true);
@@ -417,6 +471,7 @@ export default function MeasurementPage() {
       <MobileConnectModal
         open={mobileOpen}
         onClose={() => setMobileOpen(false)}
+        sceneVersionId={activeSceneVersionId}
         recommendedPurpose={mobilePurpose}
       />
       <ActionGuideModal open={actionGuideOpen} onClose={() => setActionGuideOpen(false)} />
@@ -514,6 +569,7 @@ function computeMeasuredAvg(points: ApiPoint[]): number | null {
 function PageHeader({
   sessions,
   activeSession,
+  currentVersionId,
   floorId,
   projectId,
   onSelectSession,
@@ -521,6 +577,7 @@ function PageHeader({
 }: {
   sessions: MeasurementSession[];
   activeSession: MeasurementSession | null;
+  currentVersionId: string | null;
   floorId: string | null;
   projectId: string | null;
   onSelectSession: (id: string) => void;
@@ -564,6 +621,7 @@ function PageHeader({
               </p>
               {sessions.map((s) => {
                 const isActive = activeSession?.id === s.id;
+                const isCurrentVersion = !!currentVersionId && s.scene_version_id === currentVersionId;
                 return (
                   <button
                     key={s.id}
@@ -581,7 +639,10 @@ function PageHeader({
                       <span className="font-medium text-foreground">
                         {formatRelative(s.created_at)}
                       </span>
-                      <SessionStatusBadge status={s.status} />
+                      <span className="flex items-center gap-1">
+                        <VersionScopeBadge current={isCurrentVersion} />
+                        <SessionStatusBadge status={s.status} />
+                      </span>
                     </span>
                     <span className="text-[10px] text-muted-foreground">
                       {s.measurement_type} · 도면 {s.scene_version_id?.slice(0, 8) ?? '미지정'} · {s.id.slice(0, 8)}…
@@ -616,6 +677,19 @@ function SessionStatusBadge({ status }: { status: string }) {
     status === 'completed' ? '완료' : status === 'in_progress' ? '진행 중' : status;
   return (
     <span className={cn('rounded px-1.5 py-0.5 text-[10px] font-medium', style)}>{label}</span>
+  );
+}
+
+function VersionScopeBadge({ current }: { current: boolean }) {
+  return (
+    <span
+      className={cn(
+        'rounded px-1.5 py-0.5 text-[10px] font-medium',
+        current ? 'bg-blue-50 text-blue-700' : 'bg-slate-100 text-slate-600',
+      )}
+    >
+      {current ? '현재 도면' : '다른 도면'}
+    </span>
   );
 }
 
@@ -700,10 +774,7 @@ function Legend({
         <span className="font-semibold text-foreground">실측 RSSI</span>
         <div
           className="h-2 w-32 rounded-sm border border-border/60"
-          style={{
-            backgroundImage:
-              'linear-gradient(to right, rgb(0,0,4), rgb(66,10,104), rgb(147,38,103), rgb(221,81,58), rgb(252,165,10), rgb(252,255,164))',
-          }}
+          style={{ backgroundImage: RSSI_HEATMAP_GRADIENT_CSS }}
         />
         <span className="font-mono tabular-nums text-[10px] text-foreground/70">
           {min.toFixed(0)} · {mid.toFixed(0)} · {max.toFixed(0)} dBm

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -38,9 +38,13 @@ import { useApLayouts } from '@/hooks/use-ap-layouts';
 import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
-import { useEvaluateCalibrationRun } from '@/hooks/use-calibration-run';
+import { useCalibrationRuns, useEvaluateCalibrationRun } from '@/hooks/use-calibration-run';
 import { CalibrationCard } from '@/features/calibration/CalibrationCard';
-import type { CalibrationEvaluationResponse, SpaceType } from '@/types/calibration-run';
+import type {
+  CalibrationEvaluationResponse,
+  CalibrationRun,
+  SpaceType,
+} from '@/types/calibration-run';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import { RSSI_HEATMAP_GRADIENT_CSS } from '@/lib/rssi-colormap';
 import {
@@ -247,6 +251,7 @@ export default function MeasurementPage() {
   // §11 캘리브레이션 — 현재 측정 세션 + 최근 RF Run + 현재 버전을 입력으로 사용.
   // 측정 페이지에 둠: 진단 카드에서 차이를 발견한 직후 보정 가능.
   const evaluateCalibration = useEvaluateCalibrationRun();
+  const calibrationRunsQuery = useCalibrationRuns(activeSceneVersionId, 5);
   const [calibrationEvaluation, setCalibrationEvaluation] =
     useState<CalibrationEvaluationResponse | null>(null);
   // Affine RSSI transfer + residual IDW는 적은 측정점으로도 계산은 가능하지만,
@@ -501,6 +506,10 @@ export default function MeasurementPage() {
               parameterUpdates={[]}
               evaluation={calibrationEvaluation}
               backgroundImageUrl={backgroundImageUrl}
+            />
+            <CalibrationHistoryCard
+              runs={calibrationRunsQuery.data?.items ?? []}
+              loading={calibrationRunsQuery.isLoading}
             />
             <CauseAnalysisCard
               hasData={hasMeasurement}
@@ -898,6 +907,100 @@ function CanvasEmptyOverlay({ loading }: { loading: boolean }) {
 // ============================================
 // 우측 진단 카드
 // ============================================
+
+function CalibrationHistoryCard({
+  runs,
+  loading,
+}: {
+  runs: CalibrationRun[];
+  loading: boolean;
+}) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+          <TrendingUp className="h-4 w-4 text-primary" />
+          보정 이력
+        </h3>
+        <span className="text-[11px] text-muted-foreground">{runs.length}개</span>
+      </div>
+      {loading ? (
+        <p className="mt-3 text-xs text-muted-foreground">보정 이력을 불러오는 중...</p>
+      ) : runs.length === 0 ? (
+        <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+          이 도면에서 저장된 보정 결과가 아직 없습니다.
+        </p>
+      ) : (
+        <div className="mt-3 space-y-2">
+          {runs.map((run) => {
+            const summary = calibrationRunSummary(run);
+            return (
+              <div key={run.id} className="rounded-lg border bg-background px-3 py-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs font-semibold text-foreground">
+                    {formatRelative(run.created_at)}
+                  </p>
+                  <SessionStatusBadge status={run.status} />
+                </div>
+                <div className="mt-2 grid grid-cols-2 gap-2 text-[11px]">
+                  <MetricMini label="기울기" value={formatMetric(summary.slope, '')} />
+                  <MetricMini label="보정값" value={formatMetric(summary.interceptDb, ' dB')} />
+                  <MetricMini label="보정 전 MAE" value={formatMetric(summary.baselineMae, ' dB')} />
+                  <MetricMini label="보정 후 MAE" value={formatMetric(summary.calibratedMae, ' dB')} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetricMini({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-muted/40 px-2 py-1">
+      <p className="text-[10px] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 font-semibold tabular-nums text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function calibrationRunSummary(run: CalibrationRun): {
+  slope: number | null;
+  interceptDb: number | null;
+  baselineMae: number | null;
+  calibratedMae: number | null;
+} {
+  const metrics = run.error_metrics_json ?? {};
+  const evaluation = objectValue(metrics.evaluation);
+  const calibration = objectValue(evaluation?.calibration);
+  const response = objectValue(metrics.evaluation_response);
+  const responseEvaluation = objectValue(response?.evaluation);
+  const responseCalibration = objectValue(responseEvaluation?.calibration);
+  return {
+    slope: numberValue(calibration?.slope) ?? numberValue(responseCalibration?.slope),
+    interceptDb:
+      numberValue(calibration?.intercept_db) ??
+      numberValue(calibration?.intercept) ??
+      numberValue(responseCalibration?.intercept_db),
+    baselineMae: numberValue(metrics.baseline_mae_db),
+    calibratedMae: numberValue(metrics.calibrated_mae_db),
+  };
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function numberValue(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatMetric(value: number | null, suffix: string): string {
+  return value == null ? '값 없음' : `${value.toFixed(2)}${suffix}`;
+}
 
 function DiagnosticCard({
   points,

--- a/frontend/src/pages/MeasurementPage.tsx
+++ b/frontend/src/pages/MeasurementPage.tsx
@@ -53,6 +53,13 @@ import {
 
 const EMPTY_MEASUREMENT_SESSIONS: MeasurementSession[] = [];
 const EMPTY_MEASUREMENT_POINTS: ApiPoint[] = [];
+const MEASUREMENT_VIEW_STORAGE_KEY = 'wifang.measurement-view';
+
+interface StoredMeasurementView {
+  sessionId: string | null;
+  sceneVersionId: string | null;
+  mode: MeasurementViewMode;
+}
 
 export default function MeasurementPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -79,18 +86,28 @@ export default function MeasurementPage() {
     () => sessions.find((s) => s.id === selectedSessionId) ?? null,
     [sessions, selectedSessionId],
   );
+  const latestMeasuredSession = useMemo(
+    () =>
+      sessions.find((s) => s.status === 'completed') ??
+      sessions.find((s) => s.status === 'in_progress') ??
+      sessions[0] ??
+      null,
+    [sessions],
+  );
   const fallbackSceneVersionId =
     selectedSceneVersionId ??
+    latestMeasuredSession?.scene_version_id ??
     currentVersion?.id ??
-    sessions.find((s) => !!s.scene_version_id)?.scene_version_id ??
     null;
-  const viewingSceneVersionId = selectedSession?.scene_version_id ?? fallbackSceneVersionId;
+  const viewingSceneVersionId =
+    selectedSceneVersionId ?? selectedSession?.scene_version_id ?? fallbackSceneVersionId;
   const sessionsForViewingVersion = useMemo(() => {
     if (!viewingSceneVersionId) return [];
     return sessions.filter((s) => s.scene_version_id === viewingSceneVersionId);
   }, [sessions, viewingSceneVersionId]);
   const selectedSessionBelongsToViewingVersion =
-    !!selectedSession?.scene_version_id &&
+    !!selectedSession &&
+    !!viewingSceneVersionId &&
     selectedSession.scene_version_id === viewingSceneVersionId;
   const activeSession =
     selectedSessionBelongsToViewingVersion
@@ -186,6 +203,18 @@ export default function MeasurementPage() {
   const coverageResidualQuery = useEstimatedCoverage(activeSession?.id ?? null, { method: 'residual_kriging' });
 
   const [mode, setMode] = useState<MeasurementViewMode>('route');
+
+  useEffect(() => {
+    if (!floorId) return;
+    const stored = readStoredMeasurementView(floorId);
+    if (!stored) return;
+
+    if (!requestedSessionId && !requestedSceneVersionId) {
+      setSelectedSessionId(stored.sessionId);
+      setSelectedSceneVersionId(stored.sceneVersionId);
+    }
+    setMode(stored.mode);
+  }, [floorId, requestedSceneVersionId, requestedSessionId]);
 
   const activeCoverage = useMemo(() => {
     // mode 에 맞는 데이터 우선, 없으면 다른 method 데이터로 일시 fallback —
@@ -353,6 +382,11 @@ export default function MeasurementPage() {
     const session = sessions.find((s) => s.id === sessionId) ?? null;
     setSelectedSessionId(sessionId);
     setSelectedSceneVersionId(session?.scene_version_id ?? null);
+    persistMeasurementView(floorId, {
+      sessionId,
+      sceneVersionId: session?.scene_version_id ?? null,
+      mode,
+    });
 
     const next = new URLSearchParams(searchParams);
     next.set('sessionId', sessionId);
@@ -363,6 +397,15 @@ export default function MeasurementPage() {
     }
     next.delete('rfRunId');
     setSearchParams(next, { replace: true });
+  };
+
+  const handleModeChange = (nextMode: MeasurementViewMode) => {
+    setMode(nextMode);
+    persistMeasurementView(floorId, {
+      sessionId: activeSession?.id ?? selectedSessionId,
+      sceneVersionId: activeSceneVersionId,
+      mode: nextMode,
+    });
   };
 
   return (
@@ -393,7 +436,7 @@ export default function MeasurementPage() {
       ) : (
         <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
           <section className="flex min-h-0 flex-col gap-3">
-            <TabBar mode={mode} onChange={setMode} />
+            <TabBar mode={mode} onChange={handleModeChange} />
             <div className="relative min-h-0 flex-1 overflow-hidden rounded-2xl border bg-background shadow-sm">
               {/* route 모드 범례/측정 방식 뱃지는 캔버스 위에 올려 도면 크기를 시뮬레이션과 맞춘다. */}
               <div className="pointer-events-none absolute left-3 top-3 z-10 flex flex-wrap items-center gap-2">
@@ -757,7 +800,7 @@ function TabBar({
   );
 }
 
-/** dbm 모드일 땐 inferno 그라데이션 + 양 끝/중간 dBm 표시. quality 모드면 기존 3-tier. */
+/** dbm 모드일 땐 jet 무지개 그라데이션 + 양 끝/중간 dBm 표시. quality 모드면 기존 3-tier. */
 function Legend({
   colorMode,
   range,
@@ -1083,6 +1126,55 @@ function DetectedApsCard({ aps }: { aps: DetectedAp[] }) {
       </ul>
     </div>
   );
+}
+
+function readStoredMeasurementView(floorId: string): StoredMeasurementView | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(MEASUREMENT_VIEW_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      byFloor?: Record<string, Partial<StoredMeasurementView>>;
+    };
+    const value = parsed.byFloor?.[floorId];
+    if (!value) return null;
+    const mode =
+      value.mode === 'heatmap' || value.mode === 'both' || value.mode === 'route'
+        ? value.mode
+        : 'route';
+    return {
+      sessionId: value.sessionId ?? null,
+      sceneVersionId: value.sceneVersionId ?? null,
+      mode,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function persistMeasurementView(
+  floorId: string | null,
+  view: StoredMeasurementView,
+): void {
+  if (!floorId || typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(MEASUREMENT_VIEW_STORAGE_KEY);
+    const parsed = raw
+      ? (JSON.parse(raw) as { byFloor?: Record<string, StoredMeasurementView> })
+      : {};
+    window.localStorage.setItem(
+      MEASUREMENT_VIEW_STORAGE_KEY,
+      JSON.stringify({
+        ...parsed,
+        byFloor: {
+          ...(parsed.byFloor ?? {}),
+          [floorId]: view,
+        },
+      }),
+    );
+  } catch {
+    // Ignore storage failures; URL/query driven navigation still works.
+  }
 }
 
 // ============================================

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import { useFloorRfRuns } from '@/hooks/use-rf-run';
 import { useApLayouts, useCreateApLayout } from '@/hooks/use-ap-layouts';
-import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
+import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { useApRecommendation } from '@/hooks/use-ap-recommendation';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
@@ -48,13 +48,13 @@ export default function MobileAppPage() {
 
   const versionAsDraft = versionDetail ? versionToDraftShape(versionDetail) : null;
   const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
-  const fallbackAsset = (floorAssetsQuery.data ?? [])
-    .slice()
-    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
-  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const effectiveAssetId = sourceAssetId;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
-  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const localImage = useLocalFloorplanImage({
+    floorId,
+    sourceAssetId,
+    allowFloorFallback: false,
+  });
   const assetUrl = assetUrlQuery.data?.url ?? null;
   const usableAssetUrl =
     assetUrl && /^https?:\/\//i.test(assetUrl) ? assetUrl : null;

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,13 +1,19 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Ban, CheckCircle2, Loader2, MapPin, Sparkles, Target } from 'lucide-react';
 import type { HttpError } from '@/api/client';
 import { useAppStore } from '@/stores/app-store';
+import {
+  useApRecommendationStore,
+  type ApRecommendationSession,
+} from '@/stores/ap-recommendation-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
-import { useFloorRfRuns } from '@/hooks/use-rf-run';
+import { useFloorRfRuns, useRfMaps } from '@/hooks/use-rf-run';
 import { useApLayouts, useCreateApLayout } from '@/hooks/use-ap-layouts';
 import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
 import { useApRecommendation } from '@/hooks/use-ap-recommendation';
+import { useEstimatedCoverage, useFloorMeasurementSessions } from '@/hooks/use-measurement-session';
+import { useRfMapImageUrl } from '@/hooks/use-rf-map-image-url';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import { DEFAULT_TX_POWER_DBM } from '@/features/simulation/SimulationCanvas';
 import {
@@ -30,8 +36,8 @@ import { cn } from '@/lib/utils';
 type PageStatus = 'idle' | 'areaSelected' | 'loading' | 'success' | 'error';
 
 const PROGRESS_STEPS = [
-  { id: 1, label: '우선 개선 영역 선택' },
-  { id: 2, label: '최적 위치 계산' },
+  { id: 1, label: '설치할 수 있는 곳 선택' },
+  { id: 2, label: '와이파이 위치 계산' },
   { id: 3, label: '추천 위치 선택' },
 ] as const;
 
@@ -46,29 +52,22 @@ const AREA_TYPE_OPTIONS: Array<{
 }> = [
   {
     type: 'candidate',
-    label: '설치 가능 영역',
-    hint: 'AP 후보 생성',
+    label: '설치 가능한 곳',
+    hint: '공유기를 둘 수 있는 범위',
     className: 'border-blue-200 bg-blue-50 text-blue-700',
     icon: MapPin,
   },
   {
     type: 'priority',
-    label: '우선 평가 영역',
-    hint: 'weight 1.0',
+    label: '집중구간',
+    hint: '신호를 집중해서 볼 영역',
     className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
     icon: Target,
   },
   {
-    type: 'lowPriority',
-    label: '낮은 우선순위 영역',
-    hint: 'weight 0.2',
-    className: 'border-amber-200 bg-amber-50 text-amber-700',
-    icon: Target,
-  },
-  {
     type: 'excluded',
-    label: '제외 영역',
-    hint: '평가 제외',
+    label: '계산에서 뺄 곳',
+    hint: '추천 계산에서 제외',
     className: 'border-red-200 bg-red-50 text-red-700',
     icon: Ban,
   },
@@ -108,6 +107,23 @@ export default function MobileAppPage() {
   }, [rfRunsQuery.data, sceneVersionId]);
   const latestRfRunId = latestRfRun?.id ?? null;
   const apLayoutsQuery = useApLayouts(latestRfRunId);
+  const rfMapsQuery = useRfMaps(latestRfRunId, !!latestRfRunId);
+  const simulationHeatmapMap = useMemo(() => {
+    const maps = rfMapsQuery.data ?? [];
+    return maps.find((m) => m.map_type === 'heatmap') ?? maps[0] ?? null;
+  }, [rfMapsQuery.data]);
+  const simulationHeatmapSourceUrl = useMemo(() => {
+    if (!simulationHeatmapMap) return null;
+    if (simulationHeatmapMap.url) return simulationHeatmapMap.url;
+    const raw = simulationHeatmapMap.storage_url;
+    if (raw && /^https?:\/\//i.test(raw)) return raw;
+    return null;
+  }, [simulationHeatmapMap]);
+  const simulationHeatmapUrl = useRfMapImageUrl(simulationHeatmapSourceUrl);
+  const simulationHeatmapBounds = useMemo(
+    () => parseRfHeatmapBounds(simulationHeatmapMap?.bounds_json),
+    [simulationHeatmapMap],
+  );
 
   const existingAps = useMemo(() => {
     const layouts = apLayoutsQuery.data ?? [];
@@ -115,15 +131,105 @@ export default function MobileAppPage() {
     return apsFromRfRunRequest(latestRfRun?.request_json as Record<string, unknown> | undefined);
   }, [apLayoutsQuery.data, latestRfRun?.request_json]);
 
+  const patchRecommendationScene = useApRecommendationStore((s) => s.patchScene);
+  const clearRecommendationScene = useApRecommendationStore((s) => s.clearScene);
   const [selectedAreas, setSelectedAreas] = useState<ApRecommendationArea[]>([]);
   const [activeAreaType, setActiveAreaType] = useState<ApRecommendationAreaType>('candidate');
   const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
   const [selectedRank, setSelectedRank] = useState<number | null>(null);
   const [savedRank, setSavedRank] = useState<number | null>(null);
+  const [compareWithMeasurement, setCompareWithMeasurement] = useState(false);
+  const [recommendationUpdatedAt, setRecommendationUpdatedAt] = useState<string | null>(null);
   const [pageError, setPageError] = useState<string | null>(null);
 
   const recommendMutation = useApRecommendation();
   const createLayout = useCreateApLayout();
+  const measurementSessionsQuery = useFloorMeasurementSessions(floorId);
+  const comparisonSession = useMemo(() => {
+    const sessions = measurementSessionsQuery.data?.items ?? [];
+    if (!sceneVersionId) return null;
+    return (
+      sessions.find(
+        (session) =>
+          session.scene_version_id === sceneVersionId &&
+          session.status === 'completed',
+      ) ?? null
+    );
+  }, [measurementSessionsQuery.data, sceneVersionId]);
+  const comparisonCoverageQuery = useEstimatedCoverage(comparisonSession?.id ?? null, {
+    method: 'gp_only',
+  });
+  const measurementHeatmap = useMemo(() => {
+    const coverage = comparisonCoverageQuery.data;
+    if (!coverage) return null;
+    return {
+      url: coverage.heatmap_url,
+      bounds: coverage.bounds,
+      rssiRange: { min: coverage.rssi_range.min, max: coverage.rssi_range.max },
+      source: 'measurement' as const,
+    };
+  }, [comparisonCoverageQuery.data]);
+  const simulationHeatmap = useMemo(() => {
+    if (!simulationHeatmapUrl || !simulationHeatmapBounds) return null;
+    return {
+      url: simulationHeatmapUrl,
+      bounds: {
+        min_x: simulationHeatmapBounds.minX,
+        min_y: simulationHeatmapBounds.minY,
+        max_x: simulationHeatmapBounds.maxX,
+        max_y: simulationHeatmapBounds.maxY,
+      },
+      source: 'simulation' as const,
+    };
+  }, [simulationHeatmapBounds, simulationHeatmapUrl]);
+  const comparisonHeatmap = measurementHeatmap ?? simulationHeatmap;
+  const showComparisonHeatmap = compareWithMeasurement && !!comparisonHeatmap;
+
+  const persistRecommendationSession = (patch: Partial<ApRecommendationSession>) => {
+    if (!sceneVersionId) return;
+    const updatedAt = new Date().toISOString();
+    setRecommendationUpdatedAt(updatedAt);
+    patchRecommendationScene(sceneVersionId, {
+      sceneVersionId,
+      updatedAt,
+      ...patch,
+    });
+  };
+
+  useEffect(() => {
+    recommendMutation.reset();
+    setPageError(null);
+
+    if (!sceneVersionId) {
+      setSelectedAreas([]);
+      setRecommendations([]);
+      setSelectedRank(null);
+      setSavedRank(null);
+      setCompareWithMeasurement(false);
+      setRecommendationUpdatedAt(null);
+      return;
+    }
+
+    const stored = useApRecommendationStore.getState().byScene[sceneVersionId];
+    if (!stored) {
+      setSelectedAreas([]);
+      setRecommendations([]);
+      setSelectedRank(null);
+      setSavedRank(null);
+      setCompareWithMeasurement(false);
+      setRecommendationUpdatedAt(null);
+      return;
+    }
+
+    const storedAreas = validRecommendationAreas(stored.areas);
+    const storedRecommendations = stored.recommendations ?? [];
+    setSelectedAreas(storedAreas);
+    setRecommendations(storedRecommendations);
+    setSelectedRank(stored.selectedRank ?? storedRecommendations[0]?.rank ?? null);
+    setSavedRank(stored.savedRank);
+    setCompareWithMeasurement(stored.compareWithMeasurement);
+    setRecommendationUpdatedAt(stored.updatedAt);
+  }, [sceneVersionId]);
 
   const pageStatus: PageStatus = useMemo(() => {
     if (recommendMutation.isPending) return 'loading';
@@ -147,10 +253,24 @@ export default function MobileAppPage() {
   }, [pageStatus, selectedRank, savedRank]);
 
   const handleAreasChange = (areas: ApRecommendationArea[]) => {
-    setSelectedAreas(validRecommendationAreas(areas));
+    const validAreas = validRecommendationAreas(areas);
+    setSelectedAreas(validAreas);
     setRecommendations([]);
     setSelectedRank(null);
     setSavedRank(null);
+    setCompareWithMeasurement(false);
+    if (sceneVersionId && validAreas.length > 0) {
+      persistRecommendationSession({
+        areas: validAreas,
+        recommendations: [],
+        selectedRank: null,
+        savedRank: null,
+        compareWithMeasurement: false,
+      });
+    } else if (sceneVersionId) {
+      clearRecommendationScene(sceneVersionId);
+      setRecommendationUpdatedAt(null);
+    }
     setPageError(null);
     recommendMutation.reset();
   };
@@ -163,7 +283,7 @@ export default function MobileAppPage() {
     const validAreas = validRecommendationAreas(selectedAreas);
     const candidateAreas = validAreas.filter((area) => area.type === 'candidate');
     if (candidateAreas.length === 0) {
-      setPageError('설치 가능 영역을 먼저 선택해 주세요.');
+      setPageError('공유기를 설치할 수 있는 곳을 먼저 선택해 주세요.');
       return;
     }
 
@@ -180,10 +300,24 @@ export default function MobileAppPage() {
 
     setPageError(null);
     setSavedRank(null);
+    persistRecommendationSession({
+      areas: validAreas,
+      savedRank: null,
+      compareWithMeasurement: false,
+    });
     recommendMutation.mutate(payload, {
       onSuccess: (data) => {
         const normalized = normalizeRecommendations(data);
         setRecommendations(normalized);
+        setSelectedRank(normalized[0]?.rank ?? null);
+        setCompareWithMeasurement(false);
+        persistRecommendationSession({
+          areas: validAreas,
+          recommendations: normalized,
+          selectedRank: normalized[0]?.rank ?? null,
+          savedRank: null,
+          compareWithMeasurement: false,
+        });
         if (import.meta.env.DEV) {
           console.debug('[AP Recommendation] response:', data, 'normalized:', normalized);
         }
@@ -197,12 +331,13 @@ export default function MobileAppPage() {
 
   const handleSelectRecommendation = (rec: ApRecommendationResult) => {
     if (!latestRfRunId) {
-      setPageError('AP 배치를 저장하려면 먼저 시뮬레이션을 실행해 주세요.');
+      setPageError('와이파이 위치를 저장하려면 먼저 시뮬레이션을 실행해 주세요.');
       return;
     }
 
     setSelectedRank(rec.rank);
     setPageError(null);
+    persistRecommendationSession({ selectedRank: rec.rank });
 
     const apName = nextApLayoutName(apLayoutsQuery.data ?? [], existingAps);
 
@@ -220,14 +355,32 @@ export default function MobileAppPage() {
       {
         onSuccess: () => {
           setSavedRank(rec.rank);
+          persistRecommendationSession({ selectedRank: rec.rank, savedRank: rec.rank });
         },
         onError: (err) => {
           const e = err as HttpError | null;
-          setPageError(e?.message ?? 'AP 배치 저장에 실패했습니다.');
+          setPageError(e?.message ?? '와이파이 위치 저장에 실패했습니다.');
           setSelectedRank(null);
+          persistRecommendationSession({ selectedRank: null });
         },
       },
     );
+  };
+
+  const handlePreviewRecommendation = (rec: ApRecommendationResult) => {
+    setSelectedRank(rec.rank);
+    setCompareWithMeasurement(false);
+    setPageError(null);
+    persistRecommendationSession({
+      selectedRank: rec.rank,
+      compareWithMeasurement: false,
+    });
+  };
+
+  const handleToggleComparison = () => {
+    const next = !compareWithMeasurement;
+    setCompareWithMeasurement(next);
+    persistRecommendationSession({ compareWithMeasurement: next });
   };
 
   const canRecommend =
@@ -249,10 +402,10 @@ export default function MobileAppPage() {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
             <h1 className="text-2xl font-bold tracking-tight text-foreground">
-              AP 배치 추천
+              와이파이 설치 위치 추천
             </h1>
             <p className="mt-1.5 text-sm text-muted-foreground">
-              개선이 필요한 영역을 드래그하면 최적의 AP 설치 위치를 추천합니다.
+              공유기를 둘 수 있는 곳과 집중구간을 표시하면 좋은 설치 위치를 추천합니다.
             </p>
           </div>
           <div className="flex shrink-0 flex-col items-stretch gap-1.5 sm:items-end">
@@ -275,13 +428,13 @@ export default function MobileAppPage() {
               ) : (
                 <>
                   <Sparkles className="h-4 w-4" />
-                  최적 배치 추천
+                  추천 위치 찾기
                 </>
               )}
             </button>
             {!latestRfRunId && sceneVersionId && (
               <p className="text-[11px] text-amber-600 sm:text-right">
-                AP 저장은 시뮬레이션 실행 후 가능합니다.
+                와이파이 위치 저장은 시뮬레이션 실행 후 가능합니다.
               </p>
             )}
           </div>
@@ -294,7 +447,7 @@ export default function MobileAppPage() {
         <div className="flex min-h-0 flex-col gap-4">
           <div
             className={cn(
-              'relative flex min-h-[min(52vh,32rem)] flex-1 flex-col overflow-hidden rounded-2xl bg-white shadow-sm',
+              'relative flex min-h-[min(72vh,46rem)] flex-1 flex-col overflow-hidden rounded-2xl bg-white shadow-sm lg:min-h-[min(78vh,54rem)]',
               CARD_BORDER,
               'border',
             )}
@@ -318,18 +471,18 @@ export default function MobileAppPage() {
                 onAreasChange={handleAreasChange}
                 recommendations={recommendations}
                 selectedRecommendationRank={selectedRank}
+                heatmapMode={showComparisonHeatmap ? 'measurement' : 'prediction'}
+                measurementHeatmap={comparisonHeatmap}
                 disabled={recommendMutation.isPending || createLayout.isPending}
               />
             )}
-
-            {sceneVersionId && statusHint && pageStatus !== 'loading' && (
-              <div className="pointer-events-none absolute bottom-4 left-4 right-4">
-                <p className="rounded-lg border border-[#E5EAF2] bg-white/95 px-4 py-2.5 text-center text-xs text-muted-foreground shadow-sm backdrop-blur">
-                  {statusHint}
-                </p>
-              </div>
-            )}
           </div>
+
+          {sceneVersionId && statusHint && pageStatus !== 'loading' && (
+            <p className="rounded-lg border border-[#E5EAF2] bg-white px-4 py-2.5 text-center text-xs text-muted-foreground shadow-sm">
+              {statusHint}
+            </p>
+          )}
 
           {/* 진행 단계 카드 — 캔버스 아래 */}
           <div
@@ -362,7 +515,41 @@ export default function MobileAppPage() {
           )}
         >
           <div className="border-b border-[#E5EAF2] px-5 py-4">
-            <h2 className="text-base font-bold text-foreground">최적 배치 추천</h2>
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-base font-bold text-foreground">추천 위치</h2>
+              {recommendations.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleToggleComparison}
+                  disabled={!comparisonHeatmap}
+                  className={cn(
+                    'rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
+                    showComparisonHeatmap
+                      ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+                      : 'border-[#E5EAF2] bg-white text-foreground hover:bg-muted/60',
+                    !comparisonHeatmap && 'cursor-not-allowed opacity-50',
+                  )}
+                >
+                  {measurementHeatmap ? '실측과 비교' : '시뮬맵 보기'}
+                </button>
+              )}
+            </div>
+            {recommendations.length > 0 && (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                {showComparisonHeatmap
+                  ? comparisonHeatmap?.source === 'measurement'
+                    ? '현재 도면의 최신 실측 히트맵을 보고 있습니다.'
+                    : comparisonHeatmap?.source === 'simulation'
+                    ? '실측값이 없어 보정 전 시뮬레이션맵을 보고 있습니다.'
+                    : '현재 도면에 비교할 실측 또는 시뮬레이션맵이 없습니다.'
+                  : '추천 후보를 클릭하면 해당 위치의 예측 신호 지도가 표시됩니다.'}
+              </p>
+            )}
+            {recommendationUpdatedAt && recommendations.length > 0 && (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                저장된 추천 기록: {formatHistoryTime(recommendationUpdatedAt)}
+              </p>
+            )}
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
@@ -377,7 +564,7 @@ export default function MobileAppPage() {
                     : '추천 결과가 여기에 표시됩니다'}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  도면에서 설치 가능 영역을 먼저 지정한 뒤 「최적 배치 추천」을 눌러주세요.
+                  도면에서 공유기를 설치할 수 있는 곳을 먼저 지정한 뒤 추천을 실행해 주세요.
                 </p>
               </div>
             ) : (
@@ -390,6 +577,7 @@ export default function MobileAppPage() {
                     saved={savedRank === rec.rank}
                     saving={createLayout.isPending && selectedRank === rec.rank}
                     saveDisabled={!latestRfRunId || createLayout.isPending}
+                    onPreview={() => handlePreviewRecommendation(rec)}
                     onSelect={() => handleSelectRecommendation(rec)}
                   />
                 ))}
@@ -409,12 +597,12 @@ function getStatusHint(
 ): string | null {
   switch (pageStatus) {
     case 'idle':
-      return '도면 위에서 설치 가능 영역을 먼저 드래그하여 선택하세요.';
+      return '도면 위에서 공유기를 설치할 수 있는 곳을 먼저 드래그해 주세요.';
     case 'areaSelected':
-      return '필요하면 우선 평가·낮은 우선순위·제외 영역을 추가한 뒤 추천을 실행하세요.';
+      return '필요하면 집중구간이나 계산에서 뺄 곳을 추가한 뒤 추천을 실행하세요.';
     case 'success':
       return savedRank != null
-        ? '추천 위치가 AP 배치로 저장되었습니다.'
+        ? '추천 위치가 와이파이 설치 위치로 저장되었습니다.'
         : '추천 위치를 확인하고 우측 패널에서 선택하세요.';
     case 'error':
       return pageError ?? '추천 계산에 실패했습니다. 다시 시도해 주세요.';
@@ -437,7 +625,7 @@ function AreaControls({
   const validAreas = validRecommendationAreas(areas);
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
         {AREA_TYPE_OPTIONS.map((option) => {
           const Icon = option.icon;
           const active = activeAreaType === option.type;
@@ -465,7 +653,7 @@ function AreaControls({
         })}
       </div>
 
-      <div className="grid gap-2 lg:grid-cols-4">
+      <div className="grid gap-2 sm:grid-cols-3">
         {AREA_TYPE_OPTIONS.map((option) => {
           const items = validAreas.filter((area) => area.type === option.type);
           return (
@@ -509,6 +697,38 @@ function formatBBox(bbox: ApRecommendationArea['bbox']): string {
   return `${bbox.x_min.toFixed(1)},${bbox.y_min.toFixed(1)}-${bbox.x_max.toFixed(1)},${bbox.y_max.toFixed(1)}`;
 }
 
+function formatHistoryTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function parseRfHeatmapBounds(
+  bounds: Record<string, unknown> | null | undefined,
+): { minX: number; minY: number; maxX: number; maxY: number } | null {
+  if (!bounds) return null;
+  const minX = Number(bounds.min_x);
+  const minY = Number(bounds.min_y);
+  const maxX = Number(bounds.max_x);
+  const maxY = Number(bounds.max_y);
+  if (
+    !Number.isFinite(minX) ||
+    !Number.isFinite(minY) ||
+    !Number.isFinite(maxX) ||
+    !Number.isFinite(maxY) ||
+    maxX <= minX ||
+    maxY <= minY
+  ) {
+    return null;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
 function EmptyState({ message }: { message: string }) {
   return (
     <div className="flex h-full min-h-[320px] items-center justify-center px-6 text-center text-sm text-muted-foreground">
@@ -523,6 +743,7 @@ function RecommendationCard({
   saved,
   saving,
   saveDisabled,
+  onPreview,
   onSelect,
 }: {
   rec: ApRecommendationResult;
@@ -530,12 +751,22 @@ function RecommendationCard({
   saved: boolean;
   saving: boolean;
   saveDisabled: boolean;
+  onPreview: () => void;
   onSelect: () => void;
 }) {
   return (
     <article
+      role="button"
+      tabIndex={0}
+      onClick={onPreview}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onPreview();
+        }
+      }}
       className={cn(
-        'rounded-xl border bg-white p-4 transition-colors',
+        'cursor-pointer rounded-xl border bg-white p-4 transition-colors',
         saved || selected ? 'border-emerald-300 shadow-sm' : 'border-[#E5EAF2]',
       )}
     >
@@ -549,7 +780,7 @@ function RecommendationCard({
             위치 X {rec.recommended_x.toFixed(0)}m / Y {rec.recommended_y.toFixed(0)}m
           </p>
           <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
-            우선 개선 영역 커버리지 가장 높음
+            집중구간에 가장 잘 닿는 위치
           </p>
           <p className="mt-2 text-xs text-muted-foreground">
             후보 점수{' '}
@@ -562,7 +793,10 @@ function RecommendationCard({
       </div>
       <button
         type="button"
-        onClick={onSelect}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect();
+        }}
         disabled={saveDisabled && !saved}
         className={cn(
           'mt-4 w-full rounded-lg border py-2.5 text-sm font-medium transition-colors',

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { CheckCircle2, Loader2, Sparkles } from 'lucide-react';
+import { Ban, CheckCircle2, Loader2, MapPin, Sparkles, Target } from 'lucide-react';
 import type { HttpError } from '@/api/client';
 import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
@@ -20,8 +20,9 @@ import {
   AP_DEFAULT_Z_M,
   buildApRecommendationPayload,
   normalizeRecommendations,
-  validSelectionBBoxes,
-  type MeterBBox,
+  validRecommendationAreas,
+  type ApRecommendationArea,
+  type ApRecommendationAreaType,
 } from '@/features/ap-recommendation/recommendation-utils';
 import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import { cn } from '@/lib/utils';
@@ -35,6 +36,43 @@ const PROGRESS_STEPS = [
 ] as const;
 
 const CARD_BORDER = 'border-[#E5EAF2]';
+
+const AREA_TYPE_OPTIONS: Array<{
+  type: ApRecommendationAreaType;
+  label: string;
+  hint: string;
+  className: string;
+  icon: typeof MapPin;
+}> = [
+  {
+    type: 'candidate',
+    label: '설치 가능 영역',
+    hint: 'AP 후보 생성',
+    className: 'border-blue-200 bg-blue-50 text-blue-700',
+    icon: MapPin,
+  },
+  {
+    type: 'priority',
+    label: '우선 평가 영역',
+    hint: 'weight 1.0',
+    className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    icon: Target,
+  },
+  {
+    type: 'lowPriority',
+    label: '낮은 우선순위 영역',
+    hint: 'weight 0.2',
+    className: 'border-amber-200 bg-amber-50 text-amber-700',
+    icon: Target,
+  },
+  {
+    type: 'excluded',
+    label: '제외 영역',
+    hint: '평가 제외',
+    className: 'border-red-200 bg-red-50 text-red-700',
+    icon: Ban,
+  },
+];
 
 export default function MobileAppPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -77,7 +115,8 @@ export default function MobileAppPage() {
     return apsFromRfRunRequest(latestRfRun?.request_json as Record<string, unknown> | undefined);
   }, [apLayoutsQuery.data, latestRfRun?.request_json]);
 
-  const [selectionBBoxes, setSelectionBBoxes] = useState<MeterBBox[]>([]);
+  const [selectedAreas, setSelectedAreas] = useState<ApRecommendationArea[]>([]);
+  const [activeAreaType, setActiveAreaType] = useState<ApRecommendationAreaType>('candidate');
   const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
   const [selectedRank, setSelectedRank] = useState<number | null>(null);
   const [savedRank, setSavedRank] = useState<number | null>(null);
@@ -90,13 +129,13 @@ export default function MobileAppPage() {
     if (recommendMutation.isPending) return 'loading';
     if (recommendMutation.isError) return 'error';
     if (recommendations.length > 0) return 'success';
-    if (validSelectionBBoxes(selectionBBoxes).length > 0) return 'areaSelected';
+    if (validRecommendationAreas(selectedAreas).length > 0) return 'areaSelected';
     return 'idle';
   }, [
     recommendMutation.isPending,
     recommendMutation.isError,
     recommendations.length,
-    selectionBBoxes,
+    selectedAreas,
   ]);
 
   const activeStep = useMemo(() => {
@@ -107,8 +146,8 @@ export default function MobileAppPage() {
     return 1;
   }, [pageStatus, selectedRank, savedRank]);
 
-  const handleSelectionChange = (bboxes: MeterBBox[]) => {
-    setSelectionBBoxes(validSelectionBBoxes(bboxes));
+  const handleAreasChange = (areas: ApRecommendationArea[]) => {
+    setSelectedAreas(validRecommendationAreas(areas));
     setRecommendations([]);
     setSelectedRank(null);
     setSavedRank(null);
@@ -121,12 +160,16 @@ export default function MobileAppPage() {
       setPageError('도면 정보를 불러올 수 없습니다.');
       return;
     }
-    const validBBoxes = validSelectionBBoxes(selectionBBoxes);
-    if (validBBoxes.length === 0) return;
+    const validAreas = validRecommendationAreas(selectedAreas);
+    const candidateAreas = validAreas.filter((area) => area.type === 'candidate');
+    if (candidateAreas.length === 0) {
+      setPageError('설치 가능 영역을 먼저 선택해 주세요.');
+      return;
+    }
 
     const payload = buildApRecommendationPayload({
       sceneVersionId,
-      bboxes: validBBoxes,
+      areas: validAreas,
       existingAps,
       txPowerDbm: DEFAULT_TX_POWER_DBM,
     });
@@ -188,7 +231,9 @@ export default function MobileAppPage() {
   };
 
   const canRecommend =
-    !!sceneVersionId && validSelectionBBoxes(selectionBBoxes).length > 0 && !recommendMutation.isPending;
+    !!sceneVersionId &&
+    validRecommendationAreas(selectedAreas).some((area) => area.type === 'candidate') &&
+    !recommendMutation.isPending;
 
   const sceneLoading =
     versionsQuery.isLoading ||
@@ -268,8 +313,9 @@ export default function MobileAppPage() {
                 sceneVersion={versionDetail}
                 backgroundImageUrl={backgroundImageUrl}
                 existingAps={existingAps}
-                selectionBBoxes={selectionBBoxes}
-                onSelectionChange={handleSelectionChange}
+                selectedAreas={selectedAreas}
+                activeAreaType={activeAreaType}
+                onAreasChange={handleAreasChange}
                 recommendations={recommendations}
                 selectedRecommendationRank={selectedRank}
                 disabled={recommendMutation.isPending || createLayout.isPending}
@@ -293,7 +339,17 @@ export default function MobileAppPage() {
               'border',
             )}
           >
-            <ProgressStepper activeStep={activeStep} pageStatus={pageStatus} />
+            <AreaControls
+              activeAreaType={activeAreaType}
+              areas={selectedAreas}
+              onTypeChange={setActiveAreaType}
+              onRemoveArea={(id) =>
+                handleAreasChange(selectedAreas.filter((area) => area.id !== id))
+              }
+            />
+            <div className="mt-5 border-t border-[#E5EAF2] pt-5">
+              <ProgressStepper activeStep={activeStep} pageStatus={pageStatus} />
+            </div>
           </div>
         </div>
 
@@ -321,7 +377,7 @@ export default function MobileAppPage() {
                     : '추천 결과가 여기에 표시됩니다'}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  도면에서 우선 개선 영역을 드래그한 뒤 「최적 배치 추천」을 눌러주세요.
+                  도면에서 설치 가능 영역을 먼저 지정한 뒤 「최적 배치 추천」을 눌러주세요.
                 </p>
               </div>
             ) : (
@@ -353,9 +409,9 @@ function getStatusHint(
 ): string | null {
   switch (pageStatus) {
     case 'idle':
-      return '도면 위에서 우선 개선할 영역을 드래그하여 선택하세요.';
+      return '도면 위에서 설치 가능 영역을 먼저 드래그하여 선택하세요.';
     case 'areaSelected':
-      return '영역이 선택되었습니다. 우측 상단 「최적 배치 추천」 버튼을 눌러주세요.';
+      return '필요하면 우선 평가·낮은 우선순위·제외 영역을 추가한 뒤 추천을 실행하세요.';
     case 'success':
       return savedRank != null
         ? '추천 위치가 AP 배치로 저장되었습니다.'
@@ -365,6 +421,92 @@ function getStatusHint(
     default:
       return null;
   }
+}
+
+function AreaControls({
+  activeAreaType,
+  areas,
+  onTypeChange,
+  onRemoveArea,
+}: {
+  activeAreaType: ApRecommendationAreaType;
+  areas: ApRecommendationArea[];
+  onTypeChange: (type: ApRecommendationAreaType) => void;
+  onRemoveArea: (id: string) => void;
+}) {
+  const validAreas = validRecommendationAreas(areas);
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+        {AREA_TYPE_OPTIONS.map((option) => {
+          const Icon = option.icon;
+          const active = activeAreaType === option.type;
+          return (
+            <button
+              key={option.type}
+              type="button"
+              onClick={() => onTypeChange(option.type)}
+              className={cn(
+                'flex min-h-16 items-center gap-2 rounded-lg border px-3 py-2 text-left transition-colors',
+                active
+                  ? `${option.className} ring-2 ring-offset-1`
+                  : 'border-[#E5EAF2] bg-white text-muted-foreground hover:bg-muted/50',
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="min-w-0">
+                <span className="block text-xs font-semibold leading-tight">{option.label}</span>
+                <span className="mt-0.5 block text-[11px] leading-tight opacity-80">
+                  {option.hint}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-2 lg:grid-cols-4">
+        {AREA_TYPE_OPTIONS.map((option) => {
+          const items = validAreas.filter((area) => area.type === option.type);
+          return (
+            <div key={option.type} className="rounded-lg border border-[#E5EAF2] p-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold text-foreground">{option.label}</p>
+                <span className="text-[11px] text-muted-foreground">{items.length}</span>
+              </div>
+              <div className="mt-2 space-y-1.5">
+                {items.length === 0 ? (
+                  <p className="text-[11px] text-muted-foreground">선택 없음</p>
+                ) : (
+                  items.map((area, index) => (
+                    <div
+                      key={area.id}
+                      className="flex items-center justify-between gap-2 rounded-md bg-muted/40 px-2 py-1.5"
+                    >
+                      <span className="text-[11px] text-muted-foreground">
+                        #{index + 1} {formatBBox(area.bbox)}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => onRemoveArea(area.id)}
+                        className="rounded px-1.5 text-xs font-semibold text-red-600 hover:bg-red-50"
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatBBox(bbox: ApRecommendationArea['bbox']): string {
+  return `${bbox.x_min.toFixed(1)},${bbox.y_min.toFixed(1)}-${bbox.x_max.toFixed(1)},${bbox.y_max.toFixed(1)}`;
 }
 
 function EmptyState({ message }: { message: string }) {

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -11,7 +11,10 @@ import { useFloorRfRuns, useRfMaps } from '@/hooks/use-rf-run';
 import { useApLayouts, useCreateApLayout } from '@/hooks/use-ap-layouts';
 import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage } from '@/hooks/use-local-floorplan-image';
-import { useApRecommendation } from '@/hooks/use-ap-recommendation';
+import {
+  useApRecommendation,
+  useApRecommendationRuns,
+} from '@/hooks/use-ap-recommendation';
 import { useEstimatedCoverage, useFloorMeasurementSessions } from '@/hooks/use-measurement-session';
 import { useRfMapImageUrl } from '@/hooks/use-rf-map-image-url';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
@@ -25,12 +28,13 @@ import { ApRecommendationCanvas } from '@/features/ap-recommendation/ApRecommend
 import {
   AP_DEFAULT_Z_M,
   buildApRecommendationPayload,
+  normalizeRecommendationRun,
   normalizeRecommendations,
   validRecommendationAreas,
   type ApRecommendationArea,
   type ApRecommendationAreaType,
 } from '@/features/ap-recommendation/recommendation-utils';
-import type { ApRecommendationResult } from '@/types/ap-recommendation';
+import type { ApRecommendationResult, ApRecommendationRun } from '@/types/ap-recommendation';
 import { cn } from '@/lib/utils';
 
 type PageStatus = 'idle' | 'areaSelected' | 'loading' | 'success' | 'error';
@@ -143,6 +147,7 @@ export default function MobileAppPage() {
   const [pageError, setPageError] = useState<string | null>(null);
 
   const recommendMutation = useApRecommendation();
+  const recommendationRunsQuery = useApRecommendationRuns(sceneVersionId, 10);
   const createLayout = useCreateApLayout();
   const measurementSessionsQuery = useFloorMeasurementSessions(floorId);
   const comparisonSession = useMemo(() => {
@@ -230,6 +235,32 @@ export default function MobileAppPage() {
     setCompareWithMeasurement(stored.compareWithMeasurement);
     setRecommendationUpdatedAt(stored.updatedAt);
   }, [sceneVersionId]);
+
+  useEffect(() => {
+    const latestRun = recommendationRunsQuery.data?.items?.[0] ?? null;
+    if (!latestRun || latestRun.scene_version_id !== sceneVersionId) return;
+
+    const runAreas = areasFromRecommendationRun(latestRun);
+    const runRecommendations = normalizeRecommendationRun(latestRun);
+    setSelectedAreas(runAreas);
+    setRecommendations(runRecommendations);
+    setSelectedRank(runRecommendations[0]?.rank ?? null);
+    setSavedRank(null);
+    setCompareWithMeasurement(false);
+    setRecommendationUpdatedAt(latestRun.created_at);
+    setPageError(null);
+    if (sceneVersionId) {
+      patchRecommendationScene(sceneVersionId, {
+        sceneVersionId,
+        areas: runAreas,
+        recommendations: runRecommendations,
+        selectedRank: runRecommendations[0]?.rank ?? null,
+        savedRank: null,
+        compareWithMeasurement: false,
+        updatedAt: latestRun.created_at,
+      });
+    }
+  }, [recommendationRunsQuery.data, sceneVersionId, patchRecommendationScene]);
 
   const pageStatus: PageStatus = useMemo(() => {
     if (recommendMutation.isPending) return 'loading';
@@ -695,6 +726,35 @@ function AreaControls({
 
 function formatBBox(bbox: ApRecommendationArea['bbox']): string {
   return `${bbox.x_min.toFixed(1)},${bbox.y_min.toFixed(1)}-${bbox.x_max.toFixed(1)},${bbox.y_max.toFixed(1)}`;
+}
+
+function areasFromRecommendationRun(run: ApRecommendationRun): ApRecommendationArea[] {
+  const areas: ApRecommendationArea[] = [];
+  const input = run.input_areas_json ?? {};
+  const append = (
+    type: ApRecommendationAreaType,
+    bboxes: Array<ApRecommendationArea['bbox']> | undefined,
+  ) => {
+    for (const [index, bbox] of (bboxes ?? []).entries()) {
+      areas.push({
+        id: `${run.id}-${type}-${index}`,
+        type,
+        bbox,
+      });
+    }
+  };
+  append('candidate', input.candidate_bboxes);
+  append(
+    'priority',
+    input.priority_zones?.map((zone) => ({
+      x_min: zone.x_min,
+      x_max: zone.x_max,
+      y_min: zone.y_min,
+      y_max: zone.y_max,
+    })),
+  );
+  append('excluded', input.excluded_zones);
+  return validRecommendationAreas(areas);
 }
 
 function formatHistoryTime(value: string): string {

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -16,7 +16,7 @@ import { useAppStore } from '@/stores/app-store';
 import { useFloorVersions, useSceneVersion } from '@/hooks/use-scene-version';
 import { useCreateRfRun, useFloorRfRuns, useRfMaps, useRfRun } from '@/hooks/use-rf-run';
 import { useRfMapImageUrl } from '@/hooks/use-rf-map-image-url';
-import { useFloorAssets, useAssetDownloadUrl } from '@/hooks/use-assets';
+import { useAssetDownloadUrl } from '@/hooks/use-assets';
 import { useLocalFloorplanImage, linkFloorImageToAsset } from '@/hooks/use-local-floorplan-image';
 import { versionToDraftShape } from '@/features/editor/version-as-draft';
 import {
@@ -258,6 +258,13 @@ export default function SimulationPage() {
       }),
     [pastRuns, activeRunId, activeMapMetrics],
   );
+  const measurementMapTo = useMemo(() => {
+    const params = new URLSearchParams();
+    if (canvasSceneVersionId) params.set('sceneVersionId', canvasSceneVersionId);
+    if (state === 'complete' && activeRunId) params.set('rfRunId', activeRunId);
+    const query = params.toString();
+    return query ? `/measurement?${query}` : '/measurement';
+  }, [activeRunId, canvasSceneVersionId, state]);
 
   return (
     <div className="relative flex h-full flex-col p-5 lg:p-6">
@@ -368,6 +375,15 @@ export default function SimulationPage() {
               showCompareButton={false}
               onSelect={(id) => setActiveRunId(id)}
             />
+            {canvasSceneVersionId && (
+              <Link
+                to={measurementMapTo}
+                className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-50"
+              >
+                <MapIcon className="h-3.5 w-3.5 text-slate-500" />
+                선택 도면 실측맵 보기
+              </Link>
+            )}
           </aside>
         </div>
       )}
@@ -902,15 +918,13 @@ function useSceneFloorplanBackground(
 ): string | null {
   const versionAsDraft = sceneVersion ? versionToDraftShape(sceneVersion) : null;
   const sourceAssetId = versionAsDraft?.source_asset_id ?? null;
-  const floorAssetsQuery = useFloorAssets(floorId, 'floorplan_image');
-  const fallbackAsset = useMemo(() => {
-    const list = floorAssetsQuery.data ?? [];
-    if (list.length === 0) return null;
-    return [...list].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))[0];
-  }, [floorAssetsQuery.data]);
-  const effectiveAssetId = sourceAssetId ?? fallbackAsset?.id ?? null;
+  const effectiveAssetId = sourceAssetId;
   const assetUrlQuery = useAssetDownloadUrl(effectiveAssetId);
-  const localImage = useLocalFloorplanImage({ floorId, sourceAssetId });
+  const localImage = useLocalFloorplanImage({
+    floorId,
+    sourceAssetId,
+    allowFloorFallback: false,
+  });
   useEffect(() => {
     if (floorId && sourceAssetId) linkFloorImageToAsset(floorId, sourceAssetId);
   }, [floorId, sourceAssetId]);

--- a/frontend/src/stores/ap-recommendation-store.ts
+++ b/frontend/src/stores/ap-recommendation-store.ts
@@ -1,59 +1,69 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { MeterBBox } from '@/features/ap-recommendation/recommendation-utils';
+import type { ApRecommendationArea } from '@/features/ap-recommendation/recommendation-utils';
 import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import type { UUID } from '@/types/common';
 
-/** 층(floor)별 AP 배치 추천 UI 세션 — 페이지 이동 후에도 복원. */
+/** 도면 버전별 와이파이 추천 UI 기록. */
 export interface ApRecommendationSession {
   sceneVersionId: UUID | null;
-  selectionBBox: MeterBBox | null;
+  areas: ApRecommendationArea[];
   recommendations: ApRecommendationResult[];
   selectedRank: number | null;
   savedRank: number | null;
+  compareWithMeasurement: boolean;
+  updatedAt: string | null;
 }
 
 export const EMPTY_AP_RECOMMENDATION_SESSION: ApRecommendationSession = {
   sceneVersionId: null,
-  selectionBBox: null,
+  areas: [],
   recommendations: [],
   selectedRank: null,
   savedRank: null,
+  compareWithMeasurement: false,
+  updatedAt: null,
 };
 
 interface ApRecommendationStore {
-  byFloor: Record<string, ApRecommendationSession>;
-  patchFloor: (floorId: string, patch: Partial<ApRecommendationSession>) => void;
-  clearFloor: (floorId: string) => void;
+  byScene: Record<string, ApRecommendationSession>;
+  patchScene: (sceneVersionId: UUID, patch: Partial<ApRecommendationSession>) => void;
+  clearScene: (sceneVersionId: UUID) => void;
 }
 
 export const useApRecommendationStore = create<ApRecommendationStore>()(
   persist(
     (set) => ({
-      byFloor: {},
-      patchFloor: (floorId, patch) =>
+      byScene: {},
+      patchScene: (sceneVersionId, patch) =>
         set((s) => ({
-          byFloor: {
-            ...s.byFloor,
-            [floorId]: {
+          byScene: {
+            ...s.byScene,
+            [sceneVersionId]: {
               ...EMPTY_AP_RECOMMENDATION_SESSION,
-              ...s.byFloor[floorId],
+              ...s.byScene[sceneVersionId],
+              sceneVersionId,
               ...patch,
             },
           },
         })),
-      clearFloor: (floorId) =>
+      clearScene: (sceneVersionId) =>
         set((s) => {
-          const next = { ...s.byFloor };
-          delete next[floorId];
-          return { byFloor: next };
+          const next = { ...s.byScene };
+          delete next[sceneVersionId];
+          return { byScene: next };
         }),
     }),
     {
       name: 'wifang.ap-recommendation',
       partialize: (s) => ({
-        byFloor: Object.fromEntries(
-          Object.entries(s.byFloor).filter(([, v]) => v.savedRank != null),
+        byScene: Object.fromEntries(
+          Object.entries(s.byScene).filter(
+            ([, v]) =>
+              v.areas.length > 0 ||
+              v.recommendations.length > 0 ||
+              v.savedRank != null,
+          ),
         ),
       }),
     },

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -17,12 +17,17 @@ export interface ApRecommendationRequest {
   y_max?: number;
   target_bboxes?: MeterBBox[];
   candidate_bboxes?: MeterBBox[];
+  evaluation_bboxes?: MeterBBox[];
   priority_zones?: Array<MeterBBox & { label?: string | null; weight?: number }>;
   excluded_zones?: MeterBBox[];
+  default_unzoned_weight?: number;
   step_m?: number;
   existing_aps?: ExistingAp[];
   calibration_run_id?: UUID | null;
+  calibration_policy?: 'transfer_only' | 'best_params_only' | 'combined';
   recommendation_mode?: 'add' | 'replace';
+  replace_target_ap_id?: string | null;
+  candidate_tx_power_dbm?: number;
   coverage_threshold_dbm?: number;
   weak_zone_threshold_dbm?: number;
   shadow_threshold_dbm?: number;
@@ -56,8 +61,11 @@ export interface ApRecommendationItem {
 
 export interface ApRecommendationCalibrationInfo {
   method: string;
+  policy: 'transfer_only' | 'best_params_only' | 'combined';
   slope: number;
   intercept_db: number;
+  transfer_applied: boolean;
+  best_params_applied: boolean;
   residual_used: boolean;
   calibration_run_id?: UUID | null;
 }

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -57,6 +57,15 @@ export interface ApRecommendationItem {
   average_rssi_dbm?: number | null;
   baseline_improvement_score?: number | null;
   baseline_improvement_db?: number | null;
+  prediction_points?: ApRecommendationPredictionPoint[];
+}
+
+export interface ApRecommendationPredictionPoint {
+  x: number;
+  y: number;
+  rssi_dbm: number;
+  baseline_rssi_dbm?: number | null;
+  weight?: number;
 }
 
 export interface ApRecommendationCalibrationInfo {
@@ -99,4 +108,5 @@ export interface ApRecommendationResult {
   average_rssi_dbm?: number | null;
   baseline_improvement_score?: number | null;
   baseline_improvement_db?: number | null;
+  prediction_points: ApRecommendationPredictionPoint[];
 }

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -11,21 +11,29 @@ export interface ExistingAp {
 /** POST /ap-recommendation 요청 본문 (backend ApRecommendationRequest). */
 export interface ApRecommendationRequest {
   scene_version_id: UUID;
+  x_min?: number;
+  x_max?: number;
+  y_min?: number;
+  y_max?: number;
+  target_bboxes?: MeterBBox[];
+  candidate_bboxes?: MeterBBox[];
+  priority_zones?: Array<MeterBBox & { label?: string | null; weight?: number }>;
+  excluded_zones?: MeterBBox[];
+  step_m?: number;
+  existing_aps?: ExistingAp[];
+  calibration_run_id?: UUID | null;
+  recommendation_mode?: 'add' | 'replace';
+  coverage_threshold_dbm?: number;
+  weak_zone_threshold_dbm?: number;
+  shadow_threshold_dbm?: number;
+  shadow_penalty?: number;
+}
+
+export interface MeterBBox {
   x_min: number;
   x_max: number;
   y_min: number;
   y_max: number;
-  target_bboxes?: Array<{
-    x_min: number;
-    x_max: number;
-    y_min: number;
-    y_max: number;
-  }>;
-  step_m?: number;
-  existing_aps?: ExistingAp[];
-  calibration_run_id?: UUID | null;
-  shadow_threshold_dbm?: number;
-  shadow_penalty?: number;
 }
 
 /** POST /ap-recommendation 응답 내 단일 추천 항목. */
@@ -34,6 +42,24 @@ export interface ApRecommendationItem {
   recommended_x: number;
   recommended_y: number;
   score: number;
+  coverage_score?: number | null;
+  coverage_ratio?: number | null;
+  weak_zone_improvement_score?: number | null;
+  weak_zone_improvement_db?: number | null;
+  bottom_10_percent_score?: number | null;
+  bottom_10_percent_rssi_dbm?: number | null;
+  average_rssi_score?: number | null;
+  average_rssi_dbm?: number | null;
+  baseline_improvement_score?: number | null;
+  baseline_improvement_db?: number | null;
+}
+
+export interface ApRecommendationCalibrationInfo {
+  method: string;
+  slope: number;
+  intercept_db: number;
+  residual_used: boolean;
+  calibration_run_id?: UUID | null;
 }
 
 /** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
@@ -41,6 +67,11 @@ export interface ApRecommendationResponse {
   recommendations: ApRecommendationItem[];
   status: string;
   candidates_evaluated: number;
+  eval_points_count?: number | null;
+  weighted_eval_points_count?: number | null;
+  calibration_applied?: boolean;
+  calibration?: ApRecommendationCalibrationInfo | null;
+  score_weights?: Record<string, number>;
 }
 
 /** UI 표시용. */
@@ -50,4 +81,14 @@ export interface ApRecommendationResult {
   recommended_y: number;
   score: number;
   candidates_evaluated: number;
+  coverage_score?: number | null;
+  coverage_ratio?: number | null;
+  weak_zone_improvement_score?: number | null;
+  weak_zone_improvement_db?: number | null;
+  bottom_10_percent_score?: number | null;
+  bottom_10_percent_rssi_dbm?: number | null;
+  average_rssi_score?: number | null;
+  average_rssi_dbm?: number | null;
+  baseline_improvement_score?: number | null;
+  baseline_improvement_db?: number | null;
 }

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -1,4 +1,4 @@
-import type { UUID } from './common';
+import type { ISODateString, UUID } from './common';
 
 /** POST /ap-recommendation — existing_aps 항목. */
 export interface ExistingAp {
@@ -81,6 +81,7 @@ export interface ApRecommendationCalibrationInfo {
 
 /** POST /ap-recommendation 응답 (backend ApRecommendationResponse). */
 export interface ApRecommendationResponse {
+  run_id?: UUID | null;
   recommendations: ApRecommendationItem[];
   status: string;
   candidates_evaluated: number;
@@ -89,6 +90,7 @@ export interface ApRecommendationResponse {
   calibration_applied?: boolean;
   calibration?: ApRecommendationCalibrationInfo | null;
   score_weights?: Record<string, number>;
+  created_at?: ISODateString | null;
 }
 
 /** UI 표시용. */
@@ -109,4 +111,29 @@ export interface ApRecommendationResult {
   baseline_improvement_score?: number | null;
   baseline_improvement_db?: number | null;
   prediction_points: ApRecommendationPredictionPoint[];
+}
+
+export interface ApRecommendationRun {
+  id: UUID;
+  project_id: UUID;
+  floor_id: UUID;
+  scene_version_id: UUID;
+  calibration_run_id?: UUID | null;
+  status: string;
+  request_json: ApRecommendationRequest;
+  input_areas_json: {
+    candidate_bboxes?: MeterBBox[];
+    evaluation_bboxes?: MeterBBox[];
+    priority_zones?: Array<MeterBBox & { label?: string | null; weight?: number }>;
+    excluded_zones?: MeterBBox[];
+    default_unzoned_weight?: number;
+  };
+  existing_aps_json: ExistingAp[];
+  calibration_json: ApRecommendationCalibrationInfo | Record<string, unknown>;
+  score_weights_json: Record<string, number>;
+  candidates_evaluated: number;
+  eval_points_count?: number | null;
+  weighted_eval_points_count?: number | null;
+  recommendations: ApRecommendationItem[];
+  created_at: ISODateString;
 }


### PR DESCRIPTION
## 개요

AP 위치 추천 기능을 실제 서비스 흐름에 맞게 개선했습니다.

기존 AP 추천은 사용자가 입력한 단일 BBox 내부를 순회하며 후보 AP 위치를 생성하고, 각 후보의 RSSI 예측값을 단순 shadow penalty 방식으로 점수화했습니다. 이 방식은 MVP로는 동작하지만, 실제 공간에서는 AP를 설치할 수 있는 영역과 Wi-Fi 품질을 중요하게 평가해야 하는 영역이 다를 수 있고, 실측 보정 결과도 추천 점수에 충분히 반영되지 않는 문제가 있었습니다.

이번 PR에서는 설치 가능 영역, 평가 영역, 우선 평가 영역, 제외 영역을 분리하고, 실측 기반 보정식과 기존 AP 대비 개선량을 반영할 수 있도록 AP 추천 요청/응답 구조와 백엔드 로직, 프론트 UI 흐름을 정리했습니다.

## 주요 변경 사항

### 1. AP 추천 요청 구조 확장

- 기존 단일 BBox 기반 추천 구조를 유지하면서, 새로운 영역 기반 추천 구조를 추가했습니다.
- AP 후보를 생성하는 영역과 Wi-Fi 품질을 평가하는 영역을 분리했습니다.
- 요청 스키마에 다음 필드를 추가했습니다.
  - `candidate_bboxes`: AP 설치 가능 영역
  - `evaluation_bboxes`: Wi-Fi 품질 평가 영역
  - `priority_zones`: 중요 평가 영역 및 가중치
  - `excluded_zones`: 평가 제외 영역
  - `default_unzoned_weight`: 우선 영역 외 기본 평가 가중치
  - `calibration_run_id`: 실측 보정 결과 참조
  - `calibration_policy`: 보정 적용 방식
  - `coverage_threshold_dbm`
  - `weak_zone_threshold_dbm`
  - `recommendation_mode`
  - `candidate_tx_power_dbm`

### 2. AP 추천 점수 체계 개선

- 기존의 단순 RSSI/shadow penalty 방식에서 벗어나, 여러 품질 지표를 함께 계산하도록 개선했습니다.
- 추천 결과에 다음 세부 지표를 포함하도록 확장했습니다.
  - 커버리지 점수
  - 커버리지 비율
  - 약한 구역 개선 점수
  - 약한 구역 RSSI 개선량
  - 하위 10% RSSI 점수
  - 평균 RSSI 점수
  - 기존 AP 대비 개선량
  - 후보별 prediction point

### 3. 실측 기반 보정 정보 반영

- AP 추천 요청에서 `calibration_run_id`를 받을 수 있도록 하고, 추천 결과에 보정 적용 정보를 포함했습니다.
- `transfer_only`, `best_params_only`, `combined` 정책을 구분할 수 있도록 스키마를 확장했습니다.
- 추천 응답에 보정 방식, slope, intercept, 적용 여부 등을 포함하도록 했습니다.

### 4. AP 추천 실행 이력 저장

- AP 추천 실행 결과를 저장하기 위한 모델을 추가했습니다.
  - `ApRecommendationRun`
  - `ApRecommendationItem`
- 추천 실행 단위로 요청 정보, 입력 영역, 기존 AP 정보, 보정 정보, 점수 가중치, 평가 후보 수, 평가 포인트 수를 저장합니다.
- 추천 항목별로 추천 좌표, 점수, 세부 지표, prediction points를 저장합니다.

### 5. 추천 이력 조회 API 추가

- 도면 버전 기준 AP 추천 실행 이력 목록 조회 API를 추가했습니다.
- 단일 추천 실행 이력 조회 API를 추가했습니다.

### 6. 보정 실행 이력 조회 API 보강

- 도면 버전 기준 calibration run 목록 조회 API를 추가했습니다.
- AP 추천 화면에서 보정 실행 결과를 선택하거나 참조할 수 있는 기반을 마련했습니다.

### 7. 측정 링크와 도면 버전 연결 보강

- 측정 링크 생성 시 `scene_version_id`를 함께 전달할 수 있도록 수정했습니다.
- 실측 데이터가 어떤 도면 버전 기준으로 수집되었는지 연결할 수 있도록 개선했습니다.

### 8. 프론트엔드 AP 추천 화면 수정

- AP 추천 요청 구조 변경에 맞춰 API 타입과 훅, store, canvas 로직을 수정했습니다.
- 설치 가능 영역과 평가 영역을 분리해 다룰 수 있도록 프론트 상태 구조를 정리했습니다.
- 추천 결과와 추천 이력을 화면에서 사용할 수 있도록 API 연동을 보강했습니다.
## 변경 파일 요약

### Backend

- `backend/app/models/ap_recommendation_run.py`
  - AP 추천 실행 이력 및 추천 항목 저장 모델 추가

- `backend/app/models/__init__.py`
  - 신규 AP 추천 이력 모델 등록

- `backend/app/routers/rf/ap_recommendation.py`
  - AP 추천 이력 목록 조회 API 추가
  - AP 추천 이력 단건 조회 API 추가

- `backend/app/routers/rf/calibration_runs.py`
  - 도면 버전 기준 보정 실행 이력 목록 조회 API 추가

- `backend/app/routers/rf/measurements.py`
  - 측정 링크 생성 시 `scene_version_id` 전달 지원

- `backend/app/schemas/rf/ap_recommendation.py`
  - AP 추천 요청/응답 스키마 확장
  - 영역 분리, 보정 정보, 세부 점수 지표, 추천 이력 응답 타입 추가

- `backend/app/services/rf/ap_recommendation_service.py`
  - AP 추천 보정 로직 및 점수 계산 개선
  - 추천 결과 저장/조회 로직 추가

- `backend/app/services/rf/calibration_run_service.py`
  - 보정 실행 이력 조회 로직 보강

- `backend/app/services/rf/measurement_service.py`
  - 측정 링크와 도면 버전 매핑 보강

- `backend/migrations/versions/20260604_0013_ap_recommendation_history.py`
  - AP 추천 이력 저장 테이블 migration 추가

### Frontend

- `frontend/src/api/ap-recommendation.ts`
  - AP 추천 요청/응답 및 이력 조회 API 연동 수정

- `frontend/src/types/ap-recommendation.ts`
  - AP 추천 타입 확장

- `frontend/src/hooks/use-ap-recommendation.ts`
  - AP 추천 실행 훅 수정

- `frontend/src/hooks/use-ap-recommendation-session.ts`
  - AP 추천 세션 상태 관리 추가/수정

- `frontend/src/stores/ap-recommendation-store.ts`
  - AP 추천 관련 상태 저장 구조 정리

- `frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx`
  - AP 추천 영역 선택 및 결과 표시 로직 수정

- `frontend/src/features/ap-recommendation/recommendation-utils.ts`
  - 추천 관련 유틸 로직 수정

- `frontend/src/pages/SimulationPage.tsx`
  - AP 추천 결과 및 이력 흐름 반영