### PR TITLE
feat: 멀티 AP 배치 추천 — 설치 대수 지정 Greedy 탐색 (#130)

### DIFF
--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -56,6 +56,17 @@ class ApRecommendationRequest(BaseModel):
     shadow_threshold_dbm: float = Field(default=-80.0)
     shadow_penalty: float = Field(default=100.0)
     n_recommendations: int = Field(default=3, ge=1, le=10)
+    # 멀티 AP 추천 — 한 번에 설치할 AP 수
+    n_aps: int = Field(default=1, ge=1, le=5)
+
+
+class ApRecommendationApPosition(BaseModel):
+    """멀티 AP 세트 내 개별 AP 위치."""
+    model_config = ConfigDict(extra="forbid")
+
+    ap_index: int
+    x: float
+    y: float
 
 
 class ApRecommendationItem(BaseModel):
@@ -65,6 +76,8 @@ class ApRecommendationItem(BaseModel):
     recommended_x: float
     recommended_y: float
     score: float
+    # 멀티 AP일 때 전체 위치 목록 (n_aps=1이면 1개)
+    ap_positions: list[ApRecommendationApPosition] = Field(default_factory=list)
     coverage_score: float | None = None
     coverage_ratio: float | None = None
     weak_zone_improvement_score: float | None = None

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -23,6 +23,7 @@ from app.models.scene_version import SceneVersion
 from app.models.user import User
 from app.schemas.pagination import PaginatedResponse
 from app.schemas.rf.ap_recommendation import (
+    ApRecommendationApPosition,
     ApRecommendationBBox,
     ApRecommendationCalibrationInfo,
     ApRecommendationItem,
@@ -174,37 +175,64 @@ def recommend_ap_location(
         transfer=rssi_transfer,
     )
 
+    n_aps = max(1, request.n_aps)
+
     logger.info(
-        "AP recommendation start: scene=%s candidates=%d eval=%d weighted=%d existing_aps=%d calibration=%s",
+        "AP recommendation start: scene=%s candidates=%d eval=%d weighted=%d existing_aps=%d n_aps=%d calibration=%s",
         sv.id,
         len(candidates),
         len(raw_eval_points),
         len(weighted_points),
         len(existing_aps),
+        n_aps,
         rssi_transfer.method,
     )
 
-    top_results = _grid_search_topn(
-        candidates=candidates,
-        eval_points=weighted_points,
-        existing_aps=existing_aps,
-        walls=walls,
-        params=params,
-        transfer=rssi_transfer,
-        recommendation_mode=request.recommendation_mode,
-        replace_target_ap_id=request.replace_target_ap_id,
-        candidate_tx_power_dbm=request.candidate_tx_power_dbm,
-        coverage_threshold_dbm=request.coverage_threshold_dbm
-        or _DEFAULT_COVERAGE_THRESHOLD_DBM,
-        weak_zone_threshold_dbm=request.weak_zone_threshold_dbm
-        or _DEFAULT_WEAK_ZONE_THRESHOLD_DBM,
-        n=request.n_recommendations,
-    )
+    coverage_threshold = request.coverage_threshold_dbm or _DEFAULT_COVERAGE_THRESHOLD_DBM
+    weak_zone_threshold = request.weak_zone_threshold_dbm or _DEFAULT_WEAK_ZONE_THRESHOLD_DBM
 
-    recommendations = [
-        _to_response_item(i + 1, x, y, metrics, predicted)
-        for i, (x, y, metrics, predicted) in enumerate(top_results)
-    ]
+    if n_aps == 1:
+        top_results = _grid_search_topn(
+            candidates=candidates,
+            eval_points=weighted_points,
+            existing_aps=existing_aps,
+            walls=walls,
+            params=params,
+            transfer=rssi_transfer,
+            recommendation_mode=request.recommendation_mode,
+            replace_target_ap_id=request.replace_target_ap_id,
+            candidate_tx_power_dbm=request.candidate_tx_power_dbm,
+            coverage_threshold_dbm=coverage_threshold,
+            weak_zone_threshold_dbm=weak_zone_threshold,
+            n=request.n_recommendations,
+        )
+        recommendations = [
+            _to_response_item(i + 1, x, y, metrics, predicted, ap_positions=[(x, y)])
+            for i, (x, y, metrics, predicted) in enumerate(top_results)
+        ]
+    else:
+        top_sets = _greedy_multi_ap(
+            n_aps=n_aps,
+            n_sets=request.n_recommendations,
+            candidates=candidates,
+            eval_points=weighted_points,
+            existing_aps=existing_aps,
+            walls=walls,
+            params=params,
+            transfer=rssi_transfer,
+            candidate_tx_power_dbm=request.candidate_tx_power_dbm,
+            coverage_threshold_dbm=coverage_threshold,
+            weak_zone_threshold_dbm=weak_zone_threshold,
+        )
+        recommendations = [
+            _to_response_item(
+                i + 1,
+                ap_set[0][0], ap_set[0][1],
+                metrics, predicted,
+                ap_positions=ap_set,
+            )
+            for i, (ap_set, metrics, predicted) in enumerate(top_sets)
+        ]
 
     response = ApRecommendationResponse(
         recommendations=recommendations,
@@ -423,6 +451,11 @@ def _item_row_to_schema(row: ApRecommendationItemRow) -> ApRecommendationItem:
             for p in (row.prediction_points_json or [])
             if isinstance(p, dict)
         ],
+        ap_positions=[
+            ApRecommendationApPosition(**p)
+            for p in (metrics.get("ap_positions") or [])
+            if isinstance(p, dict)
+        ],
     )
 
 
@@ -442,12 +475,18 @@ def _to_response_item(
     y: float,
     metrics: CandidateMetrics,
     prediction_points: list[PredictedEvalPoint],
+    ap_positions: list[tuple[float, float]] | None = None,
 ) -> ApRecommendationItem:
+    positions = [
+        ApRecommendationApPosition(ap_index=i + 1, x=round(px, 3), y=round(py, 3))
+        for i, (px, py) in enumerate(ap_positions or [(x, y)])
+    ]
     return ApRecommendationItem(
         rank=rank,
         recommended_x=round(x, 3),
         recommended_y=round(y, 3),
         score=round(metrics.final_score, 4),
+        ap_positions=positions,
         coverage_score=round(metrics.coverage_score, 4),
         coverage_ratio=round(metrics.coverage_ratio, 4),
         weak_zone_improvement_score=_round_optional(metrics.weak_zone_improvement_score),
@@ -469,6 +508,101 @@ def _to_response_item(
             for p in prediction_points
         ],
     )
+
+
+def _greedy_multi_ap(
+    *,
+    n_aps: int,
+    n_sets: int,
+    candidates: list[tuple[float, float]],
+    eval_points: list[WeightedEvalPoint],
+    existing_aps: list[AccessPoint],
+    walls: list[WallSegment],
+    params: CalibrationParams,
+    transfer: RssiTransfer,
+    candidate_tx_power_dbm: float,
+    coverage_threshold_dbm: float,
+    weak_zone_threshold_dbm: float,
+) -> list[tuple[list[tuple[float, float]], CandidateMetrics, list[PredictedEvalPoint]]]:
+    """Greedy 방식으로 n_aps개 AP 세트를 n_sets개 생성.
+
+    각 세트는 다음 방식으로 생성:
+      1st AP: 단일 AP 탐색 상위 n_sets개 중 하나를 시작점으로
+      2nd~nth AP: 이전까지 배치된 AP 고정 후 추가 효과 최대 위치 탐색
+    """
+    # 1단계: 1번 AP 후보 상위 n_sets개 추출
+    top_first = _grid_search_topn(
+        candidates=candidates,
+        eval_points=eval_points,
+        existing_aps=existing_aps,
+        walls=walls,
+        params=params,
+        transfer=transfer,
+        recommendation_mode="add",
+        replace_target_ap_id=None,
+        candidate_tx_power_dbm=candidate_tx_power_dbm,
+        coverage_threshold_dbm=coverage_threshold_dbm,
+        weak_zone_threshold_dbm=weak_zone_threshold_dbm,
+        n=n_sets,
+    )
+
+    result_sets: list[tuple[list[tuple[float, float]], CandidateMetrics, list[PredictedEvalPoint]]] = []
+
+    for first_x, first_y, _, _ in top_first:
+        ap_set: list[tuple[float, float]] = [(first_x, first_y)]
+        current_aps = existing_aps + [
+            AccessPoint(name=f"rec_{i+1}", x=px, y=py, tx_power_dbm=candidate_tx_power_dbm)
+            for i, (px, py) in enumerate(ap_set)
+        ]
+
+        # 2번째 AP부터 greedy 추가
+        for _ in range(n_aps - 1):
+            next_results = _grid_search_topn(
+                candidates=[c for c in candidates if c not in ap_set],
+                eval_points=eval_points,
+                existing_aps=current_aps,
+                walls=walls,
+                params=params,
+                transfer=transfer,
+                recommendation_mode="add",
+                replace_target_ap_id=None,
+                candidate_tx_power_dbm=candidate_tx_power_dbm,
+                coverage_threshold_dbm=coverage_threshold_dbm,
+                weak_zone_threshold_dbm=weak_zone_threshold_dbm,
+                n=1,
+            )
+            if not next_results:
+                break
+            nx, ny, _, _ = next_results[0]
+            ap_set.append((nx, ny))
+            current_aps.append(
+                AccessPoint(name=f"rec_{len(ap_set)}", x=nx, y=ny, tx_power_dbm=candidate_tx_power_dbm)
+            )
+
+        # 최종 세트 전체 점수 계산
+        final_results = _grid_search_topn(
+            candidates=[ap_set[-1]],
+            eval_points=eval_points,
+            existing_aps=existing_aps + [
+                AccessPoint(name=f"rec_{i+1}", x=px, y=py, tx_power_dbm=candidate_tx_power_dbm)
+                for i, (px, py) in enumerate(ap_set[:-1])
+            ],
+            walls=walls,
+            params=params,
+            transfer=transfer,
+            recommendation_mode="add",
+            replace_target_ap_id=None,
+            candidate_tx_power_dbm=candidate_tx_power_dbm,
+            coverage_threshold_dbm=coverage_threshold_dbm,
+            weak_zone_threshold_dbm=weak_zone_threshold_dbm,
+            n=1,
+        )
+        if final_results:
+            _, _, metrics, predicted = final_results[0]
+            result_sets.append((ap_set, metrics, predicted))
+
+    result_sets.sort(key=lambda t: t[1].final_score, reverse=True)
+    return result_sets[:n_sets]
 
 
 def _round_optional(value: float | None, digits: int = 4) -> float | None:

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -346,14 +346,22 @@ export function ApRecommendationCanvas({
             <ObjectShape key={o.id} object={o} />
           ))}
 
-          {recommendations.map((rec) => (
-            <RecommendationMarker
-              key={rec.rank}
-              rec={rec}
-              selected={selectedRecommendationRank === rec.rank}
-              labelFontM={labelFontM}
-            />
-          ))}
+          {[...recommendations]
+            .sort((a, b) => {
+              // 선택된 순위를 맨 위에 (마지막 렌더 = SVG 최상단)
+              if (a.rank === selectedRecommendationRank) return 1;
+              if (b.rank === selectedRecommendationRank) return -1;
+              // 나머지는 역순 (낮은 순위일수록 위에 — 1순위가 가장 마지막)
+              return b.rank - a.rank;
+            })
+            .map((rec) => (
+              <RecommendationMarker
+                key={rec.rank}
+                rec={rec}
+                selected={selectedRecommendationRank === rec.rank}
+                labelFontM={labelFontM}
+              />
+            ))}
         </g>
 
         {/* 선택 영역 — clamp된 좌표, clipPath 밖(배지가 상단에서 잘리지 않도록) */}
@@ -583,45 +591,65 @@ function RecommendationMarker({
   labelFontM: number;
 }) {
   const r = RECOMMEND_RADIUS_M;
-  const fill = selected ? 'oklch(0.62 0.19 145)' : 'oklch(0.72 0.19 145)';
+
+  // 순위별 색상 — 선택 시 진하게, 비선택 시 연하게
+  const RANK_COLORS: Record<number, { base: string; dim: string; label: string }> = {
+    1: { base: 'oklch(0.55 0.20 145)', dim: 'oklch(0.72 0.18 145)', label: 'oklch(0.28 0.10 145)' },  // 초록
+    2: { base: 'oklch(0.55 0.20 260)', dim: 'oklch(0.72 0.18 260)', label: 'oklch(0.28 0.10 260)' },  // 파랑
+    3: { base: 'oklch(0.55 0.20 50)',  dim: 'oklch(0.72 0.18 50)',  label: 'oklch(0.28 0.10 50)'  },  // 주황
+  };
+  const color = RANK_COLORS[rec.rank] ?? RANK_COLORS[1];
+  const fill = selected ? color.base : color.dim;
+  const labelColor = color.label;
+
+  // 멀티 AP일 때 ap_positions 전체 표시, 단일 AP면 recommended_x/y 사용
+  const positions =
+    rec.ap_positions && rec.ap_positions.length > 0
+      ? rec.ap_positions.map((p) => ({ x: p.x, y: p.y, index: p.ap_index }))
+      : [{ x: rec.recommended_x, y: rec.recommended_y, index: 1 }];
+
   return (
     <g pointerEvents="none">
-      <circle
-        cx={rec.recommended_x}
-        cy={rec.recommended_y}
-        r={r}
-        fill={fill}
-        stroke="white"
-        strokeWidth="2"
-        vectorEffect="non-scaling-stroke"
-      />
-      <text
-        x={rec.recommended_x}
-        y={rec.recommended_y}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fontSize={Math.max(r * 0.75, labelFontM * 0.85)}
-        fontWeight="700"
-        fill="white"
-        style={{ userSelect: 'none' }}
-      >
-        {rec.rank}
-      </text>
-      <text
-        x={rec.recommended_x}
-        y={rec.recommended_y + r + labelFontM * 1.05}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fontSize={labelFontM}
-        fontWeight="700"
-        fill="oklch(0.28 0.1 145)"
-        stroke="white"
-        strokeWidth={labelFontM * 0.12}
-        paintOrder="stroke fill"
-        style={{ userSelect: 'none' }}
-      >
-        추천 {rec.rank}
-      </text>
+      {positions.map((pos) => (
+        <g key={pos.index}>
+          <circle
+            cx={pos.x}
+            cy={pos.y}
+            r={r}
+            fill={fill}
+            stroke="white"
+            strokeWidth="2"
+            vectorEffect="non-scaling-stroke"
+          />
+          <text
+            x={pos.x}
+            y={pos.y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontSize={Math.max(r * 0.75, labelFontM * 0.85)}
+            fontWeight="700"
+            fill="white"
+            style={{ userSelect: 'none' }}
+          >
+            {positions.length > 1 ? `${rec.rank}-${pos.index}` : rec.rank}
+          </text>
+          <text
+            x={pos.x}
+            y={pos.y + r + labelFontM * 1.05}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontSize={labelFontM}
+            fontWeight="700"
+            fill={labelColor}
+            stroke="white"
+            strokeWidth={labelFontM * 0.12}
+            paintOrder="stroke fill"
+            style={{ userSelect: 'none' }}
+          >
+            {positions.length > 1 ? `추천${rec.rank} AP${pos.index}` : `추천 ${rec.rank}`}
+          </text>
+        </g>
+      ))}
     </g>
   );
 }

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -94,6 +94,7 @@ export function buildApRecommendationPayload(params: {
   areas?: ApRecommendationArea[];
   existingAps: { id: string; x_m: number; y_m: number }[];
   txPowerDbm?: number;
+  nAps?: number;
 }): ApRecommendationRequest {
   const areas = validRecommendationAreas(params.areas);
   const legacyBboxes = validSelectionBBoxes(params.bboxes);
@@ -132,6 +133,7 @@ export function buildApRecommendationPayload(params: {
     calibration_policy: 'transfer_only',
     candidate_tx_power_dbm: params.txPowerDbm,
     existing_aps: mapToExistingAps(params.existingAps, params.txPowerDbm),
+    ...(params.nAps && params.nAps > 1 ? { n_aps: params.nAps } : {}),
   };
   if (legacyUnion) {
     request.x_min = legacyUnion.x_min;
@@ -165,6 +167,7 @@ export function normalizeRecommendations(
     baseline_improvement_score: item.baseline_improvement_score,
     baseline_improvement_db: item.baseline_improvement_db,
     prediction_points: item.prediction_points ?? [],
+    ap_positions: item.ap_positions,
   }));
 }
 

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -144,6 +144,7 @@ export default function MobileAppPage() {
   const [recommendations, setRecommendations] = useState<ApRecommendationResult[]>([]);
   const [selectedRank, setSelectedRank] = useState<number | null>(null);
   const [savedRank, setSavedRank] = useState<number | null>(null);
+  const [nAps, setNAps] = useState(1);
   const [compareWithMeasurement, setCompareWithMeasurement] = useState(false);
   const [verificationRunId, setVerificationRunId] = useState<string | null>(null);
   const [verificationRank, setVerificationRank] = useState<number | null>(null);
@@ -458,6 +459,7 @@ export default function MobileAppPage() {
       areas: validAreas,
       existingAps,
       txPowerDbm: DEFAULT_TX_POWER_DBM,
+      nAps,
     });
 
     if (import.meta.env.DEV) {
@@ -663,6 +665,26 @@ export default function MobileAppPage() {
             </p>
           </div>
           <div className="flex shrink-0 flex-col items-stretch gap-1.5 sm:items-end">
+            <div className="flex items-center gap-2 sm:justify-end">
+              <span className="text-[12px] text-slate-500">설치할 AP 수</span>
+              <div className="flex gap-1">
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setNAps(n)}
+                    className={cn(
+                      'h-7 w-7 rounded-md text-[12px] font-semibold transition-colors',
+                      nAps === n
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                    )}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
             <button
               type="button"
               onClick={handleRecommend}
@@ -1355,6 +1377,13 @@ function RecommendationCard({
   onPreview: () => void;
   onSelect: () => void;
 }) {
+  const RANK_STYLES = [
+    { border: 'border-emerald-300', badge: 'bg-emerald-500', selectedBorder: 'border-emerald-400 ring-1 ring-emerald-300' },
+    { border: 'border-blue-300',    badge: 'bg-blue-500',    selectedBorder: 'border-blue-400 ring-1 ring-blue-300' },
+    { border: 'border-orange-300',  badge: 'bg-orange-500',  selectedBorder: 'border-orange-400 ring-1 ring-orange-300' },
+  ];
+  const style = RANK_STYLES[(rec.rank - 1) % RANK_STYLES.length];
+
   return (
     <article
       role="button"
@@ -1368,17 +1397,19 @@ function RecommendationCard({
       }}
       className={cn(
         'cursor-pointer rounded-xl border bg-white p-4 transition-colors',
-        saved || selected ? 'border-emerald-300 shadow-sm' : 'border-[#E5EAF2]',
+        saved || selected ? `${style.selectedBorder} shadow-sm` : 'border-[#E5EAF2]',
       )}
     >
       <div className="flex items-start gap-3">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-sm font-bold text-white">
+        <div className={cn('flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white', style.badge)}>
           {rec.rank}
         </div>
         <div className="min-w-0 flex-1">
           <h3 className="text-sm font-bold text-foreground">{rec.rank}순위 추천</h3>
           <p className="mt-1 text-xs text-muted-foreground">
-            위치 X {rec.recommended_x.toFixed(0)}m / Y {rec.recommended_y.toFixed(0)}m
+            {rec.ap_positions && rec.ap_positions.length > 1
+              ? rec.ap_positions.map((p) => `AP${p.ap_index} (${p.x.toFixed(0)}m, ${p.y.toFixed(0)}m)`).join(' · ')
+              : `위치 X ${rec.recommended_x.toFixed(0)}m / Y ${rec.recommended_y.toFixed(0)}m`}
           </p>
           <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
             우선 평가 영역에 가장 잘 닿는 위치

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -32,6 +32,14 @@ export interface ApRecommendationRequest {
   weak_zone_threshold_dbm?: number;
   shadow_threshold_dbm?: number;
   shadow_penalty?: number;
+  n_aps?: number;
+}
+
+/** 멀티 AP 세트 내 개별 AP 위치. */
+export interface ApRecommendationApPosition {
+  ap_index: number;
+  x: number;
+  y: number;
 }
 
 export interface MeterBBox {
@@ -52,6 +60,7 @@ export interface ApRecommendationItem {
   recommended_x: number;
   recommended_y: number;
   score: number;
+  ap_positions?: ApRecommendationApPosition[];
   coverage_score?: number | null;
   coverage_ratio?: number | null;
   weak_zone_improvement_score?: number | null;
@@ -104,6 +113,7 @@ export interface ApRecommendationResult {
   recommended_x: number;
   recommended_y: number;
   score: number;
+  ap_positions?: ApRecommendationApPosition[];
   candidates_evaluated: number;
   coverage_score?: number | null;
   coverage_ratio?: number | null;


### PR DESCRIPTION
## 1. Summary
* 사용자가 설치할 AP 개수(1~5개)를 직접 지정하면 해당 수만큼의 최적 AP 배치 세트를 추천하는 기능을 추가합니다.
* **Greedy 탐색 방식**을 적용하여 조합 폭발 없이 선형 시간 내에 최적 세트를 도출합니다.
* 추천 세트별로 다른 색상(초록/파랑/주황)을 적용하여 캔버스 마커와 카드 디자인의 시각적 일치성을 높였습니다.
* 멀티 AP 배치 시 `ap_positions` 필드를 도입하여 전체 위치 정보를 반환하고, DB 저장 및 이력 복원 기능을 지원합니다.

---

## 2. 구현 방식 (Greedy 알고리즘)
1. **1번 AP 선정**: 후보군 전체를 탐색하여 점수가 높은 상위 N개의 시작점을 선정합니다.
2. **2번 AP 선정**: 선정된 1번 AP의 위치를 고정한 상태에서, 나머지 음영 지역의 커버리지를 최대화하는 위치를 탐색합니다.
3. **N번 AP까지 반복**: 사용자가 지정한 개수만큼 위 과정을 반복하여 최종 **상위 3개 세트**를 반환합니다.

---

## 3. 변경 파일 및 상세 내용

### 💡 Backend
* `backend/app/schemas/rf/ap_recommendation.py`
  * `n_aps`, `ap_positions` 필드 및 `ApRecommendationApPosition` 스키마 추가
* `backend/app/services/rf/ap_recommendation_service.py`
  * 멀티 AP 추천 코어 로직인 `_greedy_multi_ap()` 함수 구현
  * 추천 이력 DB 저장 및 복원(Restore) 시 `ap_positions` 데이터 파싱 로직 포함

### 🎨 Frontend
* `frontend/src/types/ap-recommendation.ts`
  * `ApRecommendationApPosition` 인터페이스 및 `ap_positions` 타입 정의 추가
* `frontend/src/features/ap-recommendation/recommendation-utils.ts`
  * API 요청 시 `nAps` 파라미터 전달 및 응답 데이터 `ap_positions` 복원/정형화(normalize)
* `frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx`
  * 멀티 AP 마커 렌더링 지원 및 추천 순위별 전용 색상 적용
  * 사용자가 선택한 순위의 마커가 캔버스 최상단에 렌더링되도록 Z-Index/정렬 로직 수정
* `frontend/src/pages/MobileAppPage.tsx`
  * AP 개수 선택 UI(1~5개 버튼) 구현
  * 추천 결과 카드에 순위별 고유 색상 및 멀티 AP 위치 텍스트 표시

---

## 4. Test Plan (완료 조건)
- [x] UI에서 AP 수를 1~5개까지 정상적으로 선택할 수 있는지 확인
- [x] `n_aps=2` 요청 시 각 추천 결과 카드에 2개의 AP 위치 좌표가 정상 표시되는지 확인
- [x] 캔버스 렌더링 시 1순위(초록), 2순위(파랑), 3순위(주황) 색상이 명확히 구분되는지 확인
- [x] 특정 추천 세트를 선택했을 때, 해당 마커들이 가려지지 않고 캔버스 최상단에 표시되는지 확인
- [x] `n_aps=1` 조건(기본값) 요청 시 기존 단일 AP 동작에 사이드 이펙트가 없는지 확인
- [x] 페이지를 새로고침하거나 재방문했을 때 `ap_positions`가 포함된 이전 이력이 정상 복원되는지 확인

---

Closes #130