### PR TITLE
[Feat] RF 시뮬레이션용 벽/문/창 재질 export 및 에디터 재질 편집 UI 개선

### DIFF
--- a/backend/app/services/ai_api_client.py
+++ b/backend/app/services/ai_api_client.py
@@ -81,7 +81,8 @@ def run_sionna_simulation(
             resp.raise_for_status()
             return resp.json()
     except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500] if exc.response is not None else ""
+        body = exc.response.text[:3000] if exc.response is not None else ""
+        logger.warning("ai_api %s — full error: %s", exc.response.status_code, body)
         raise AiApiClientError(
             f"ai_api returned {exc.response.status_code}: {body}"
         ) from exc

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -439,6 +439,8 @@ def _build_sionna_request_payload(
         {
             "id": str(op.get("id") or f"op{j}"),
             "wall_id": str(op["wall_id"]),
+            # OpeningObject.kind 은 필수 — scene_json 에 있으면 사용, 없으면 "door" fallback
+            "kind": str(op.get("kind") or op.get("opening_type") or "door"),
             "center_xy": [float(op["center_xy"][0]), float(op["center_xy"][1])],
             "width_m": float(op["width_m"]),
             "height_m": float(op["height_m"]),

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -416,12 +416,15 @@ def _build_sionna_request_payload(
     """
     walls = [
         {
-            "id": f"w{i}",
+            # scene_json wall 에 id(UUID) 가 있으면 사용, 없으면 순번 fallback.
+            # opening.wall_id 가 이 id 를 참조하므로 반드시 일치해야 함.
+            "id": str(w.get("id") or f"w{i}"),
             "start_xy": [float(w["x1"]), float(w["y1"])],
             "end_xy": [float(w["x2"]), float(w["y2"])],
             "height_m": float(w.get("height") or 2.6),
             "thickness_m": float(w.get("thickness") or 0.12),
             "material_id": str(w.get("material") or "plasterboard"),
+            "sionna_material_key": str(w.get("material") or "plasterboard"),
         }
         for i, w in enumerate(scene_json.get("walls") or [])
     ]
@@ -431,6 +434,20 @@ def _build_sionna_request_payload(
             "polygon_xy": [[float(p[0]), float(p[1])] for p in (r.get("points") or [])],
         }
         for i, r in enumerate(scene_json.get("rooms") or [])
+    ]
+    openings = [
+        {
+            "id": str(op.get("id") or f"op{j}"),
+            "wall_id": str(op["wall_id"]),
+            "center_xy": [float(op["center_xy"][0]), float(op["center_xy"][1])],
+            "width_m": float(op["width_m"]),
+            "height_m": float(op["height_m"]),
+            "bottom_z_m": float(op.get("bottom_z_m") or 0.0),
+            "sionna_material_key": str(op.get("sionna_material_key") or "wood"),
+            "material_id": str(op.get("material_id") or op.get("sionna_material_key") or "wood"),
+        }
+        for j, op in enumerate(scene_json.get("openings") or [])
+        if op.get("wall_id")
     ]
 
     primary_ap = access_points[0]
@@ -455,7 +472,7 @@ def _build_sionna_request_payload(
             "scene_id": scene_version_id,
             "walls": walls,
             "rooms": rooms,
-            "openings": [],
+            "openings": openings,
             "furniture": [],
         },
         "access_point": {

--- a/backend/app/services/scene/scene_version_export.py
+++ b/backend/app/services/scene/scene_version_export.py
@@ -179,7 +179,7 @@ def export_scene_version_to_scene_json(
         cx = wx1 + t * dx
         cy = wy1 + t * dy
         # opening 이 벽 길이에 들어가는지 확인 — 초과하면 422 유발
-        width_m = float(op.width_m)
+        width_m = float(op.width_m) if op.width_m is not None else 0.9
         s_center = t * wall_len
         if s_center - width_m / 2.0 < -0.01 or s_center + width_m / 2.0 > wall_len + 0.01:
             logger.warning(
@@ -198,7 +198,7 @@ def export_scene_version_to_scene_json(
                 "kind": op.opening_type or "door",  # OpeningObject.kind 필수 — door/window
                 "center_xy": [float(cx), float(cy)],
                 "width_m": width_m,
-                "height_m": float(op.height_m),
+                "height_m": float(op.height_m) if op.height_m is not None else 2.1,
                 "bottom_z_m": float(op.sill_height_m or 0.0),
                 "sionna_material_key": sionna_key,
                 "material_id": sionna_key,

--- a/backend/app/services/scene/scene_version_export.py
+++ b/backend/app/services/scene/scene_version_export.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.core.errors import AppError, ErrorCode
 from app.core.geom import wkb_to_geojson
-from app.models import Room, SceneVersion, Wall
+from app.models import Opening, Room, SceneVersion, Wall
 from app.services.rf.scene_obstacles import column_wall_segments_for_objects, normalize_rf_material
 
 logger = logging.getLogger(__name__)
@@ -52,10 +52,15 @@ MATERIAL_ALIAS: dict[str, str] = {
     "marble": "concrete",   # Sionna 1.0.2 에 marble 없음 → 가장 비슷한 concrete 로
     "plywood": "wood",
     "plastic": "chipboard",
-    "\uc720\ub9ac": "glass",
-    "\ub098\ubb34": "wood",
-    "\ucf58\ud06c\ub9ac\ud2b8": "concrete",
-    "\ud50c\ub77c\uc2a4\ud2f1": "chipboard",
+    # DB material_name (\ud55c\uad6d\uc5b4) \u2192 Sionna key
+    "\uc720\ub9ac": "glass",           # \uc720\ub9ac
+    "\ub098\ubb34": "wood",            # \ub098\ubb34 (\uad6c \ud638\ud658)
+    "\ubaa9\uc7ac": "wood",            # \ubaa9\uc7ac (DB material_name)
+    "\ucf58\ud06c\ub9ac\ud2b8": "concrete",  # \ucf58\ud06c\ub9ac\ud2b8
+    "\ubcbd\ub3cc": "brick",           # \ubcbd\ub3cc
+    "\uc11d\uace0\ubcf4\ub4dc": "plasterboard",  # \uc11d\uace0\ubcf4\ub4dc
+    "\uae08\uc18d": "metal",           # \uae08\uc18d
+    "\ud50c\ub77c\uc2a4\ud2f1": "chipboard",  # \ud50c\ub77c\uc2a4\ud2f1
 }
 SIONNA_FALLBACK = "plasterboard"
 
@@ -86,6 +91,7 @@ def export_scene_version_to_scene_json(
             selectinload(SceneVersion.walls),
             selectinload(SceneVersion.rooms),
             selectinload(SceneVersion.objects),
+            selectinload(SceneVersion.openings),
         )
         .filter(SceneVersion.id == scene_version_id)
         .first()
@@ -106,6 +112,7 @@ def export_scene_version_to_scene_json(
         x2, y2 = line[-1]
         walls_out.append(
             {
+                "id": str(w.id),
                 "x1": float(x1),
                 "y1": float(y1),
                 "x2": float(x2),
@@ -138,6 +145,37 @@ def export_scene_version_to_scene_json(
             continue
         rooms_out.append({"points": [[float(p[0]), float(p[1])] for p in polygon]})
 
+    # 문/창문(opening) — sionna_runtime 이 wall split + opening_box 처리에 사용.
+    # wall_id 는 위 walls_out 의 "id" 필드와 동일한 UUID 여야 매칭됨.
+    DEFAULT_DOOR_MATERIAL = "wood"
+    DEFAULT_WINDOW_MATERIAL = "glass"
+    openings_out: list[dict[str, Any]] = []
+    for op in (sv.openings or []):
+        if not op.wall_id:
+            continue
+        line = _extract_linestring(op.line_geom)
+        if line is None or len(line) < 2:
+            continue
+        # 중심점: LineString 전체 좌표의 평균
+        cx = sum(p[0] for p in line) / len(line)
+        cy = sum(p[1] for p in line) / len(line)
+        # 재질: metadata_json.material 우선, 없으면 opening_type 기반 기본값
+        raw_mat = (op.metadata_json or {}).get("material")
+        default_mat = DEFAULT_DOOR_MATERIAL if op.opening_type == "door" else DEFAULT_WINDOW_MATERIAL
+        sionna_key = _to_sionna_material(raw_mat or default_mat)
+        openings_out.append(
+            {
+                "id": str(op.id),
+                "wall_id": str(op.wall_id),
+                "center_xy": [float(cx), float(cy)],
+                "width_m": float(op.width_m),
+                "height_m": float(op.height_m),
+                "bottom_z_m": float(op.sill_height_m or 0.0),
+                "sionna_material_key": sionna_key,
+                "material_id": sionna_key,
+            }
+        )
+
     if not walls_out:
         # walls 가 0개면 RF 시뮬은 의미가 없음 (장애물 없는 평지 시뮬).
         # 컨테이너가 죽지 않게는 통과시키되 경고만 남김.
@@ -146,7 +184,7 @@ def export_scene_version_to_scene_json(
             scene_version_id,
         )
 
-    return {"walls": walls_out, "rooms": rooms_out}
+    return {"walls": walls_out, "rooms": rooms_out, "openings": openings_out}
 
 
 def _extract_linestring(geom: Any) -> list[tuple[float, float]] | None:

--- a/backend/app/services/scene/scene_version_export.py
+++ b/backend/app/services/scene/scene_version_export.py
@@ -12,6 +12,7 @@ GeoJSON 으로 변환한 뒤 좌표를 추출한다.
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any
 
 from sqlalchemy.orm import Session, selectinload
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_WALL_THICKNESS_M = 0.12
 DEFAULT_WALL_HEIGHT_M = 2.6
-DEFAULT_WALL_MATERIAL = "plasterboard"
+DEFAULT_WALL_MATERIAL = "concrete"
 
 # Sionna 1.0.2 의 ITURadioMaterial type 인자가 받는 enum (소문자, prefix 없음).
 # 출처: ITU-R P.2040 표준. 컨테이너 (`apps/sagemaker_rf_inference`) 가
@@ -103,20 +104,28 @@ def export_scene_version_to_scene_json(
             404,
         )
 
+    # wall_id → (x1, y1, x2, y2, length) — opening 검증에 사용.
+    wall_geom_cache: dict[str, tuple[float, float, float, float, float]] = {}
     walls_out: list[dict[str, Any]] = []
     for w in sv.walls:
         line = _extract_linestring(w.centerline_geom)
         if line is None or len(line) < 2:
             continue
-        x1, y1 = line[0]
-        x2, y2 = line[-1]
+        x1, y1 = float(line[0][0]), float(line[0][1])
+        x2, y2 = float(line[-1][0]), float(line[-1][1])
+        # degenerate wall (start == end) 은 WallObject validator 에서 422 유발 — 건너뜀
+        if abs(x1 - x2) < 1e-9 and abs(y1 - y2) < 1e-9:
+            logger.warning("Wall %s is degenerate (start==end), skipping export", w.id)
+            continue
+        wall_len = math.hypot(x2 - x1, y2 - y1)
+        wall_geom_cache[str(w.id)] = (x1, y1, x2, y2, wall_len)
         walls_out.append(
             {
                 "id": str(w.id),
-                "x1": float(x1),
-                "y1": float(y1),
-                "x2": float(x2),
-                "y2": float(y2),
+                "x1": x1,
+                "y1": y1,
+                "x2": x2,
+                "y2": y2,
                 "thickness": float(w.thickness_m or DEFAULT_WALL_THICKNESS_M),
                 "height": float(w.height_m or DEFAULT_WALL_HEIGHT_M),
                 "material": _to_sionna_material(
@@ -153,12 +162,31 @@ def export_scene_version_to_scene_json(
     for op in (sv.openings or []):
         if not op.wall_id:
             continue
+        wall_id_str = str(op.wall_id)
+        # 해당 wall 이 walls_out 에 포함되지 않은 경우 (degenerate skip) 건너뜀
+        if wall_id_str not in wall_geom_cache:
+            logger.debug("Opening %s skipped: wall %s not in export", op.id, wall_id_str)
+            continue
         line = _extract_linestring(op.line_geom)
         if line is None or len(line) < 2:
             continue
-        # 중심점: LineString 전체 좌표의 평균
-        cx = sum(p[0] for p in line) / len(line)
-        cy = sum(p[1] for p in line) / len(line)
+        # 중심점 계산 후 벽 중심선에 정사영(snap) — 부동소수점 오차로 perp > 1cm 방지
+        raw_cx = sum(p[0] for p in line) / len(line)
+        raw_cy = sum(p[1] for p in line) / len(line)
+        wx1, wy1, wx2, wy2, wall_len = wall_geom_cache[wall_id_str]
+        dx, dy = wx2 - wx1, wy2 - wy1
+        t = ((raw_cx - wx1) * dx + (raw_cy - wy1) * dy) / (wall_len * wall_len)
+        cx = wx1 + t * dx
+        cy = wy1 + t * dy
+        # opening 이 벽 길이에 들어가는지 확인 — 초과하면 422 유발
+        width_m = float(op.width_m)
+        s_center = t * wall_len
+        if s_center - width_m / 2.0 < -0.01 or s_center + width_m / 2.0 > wall_len + 0.01:
+            logger.warning(
+                "Opening %s (width=%.2f) does not fit on wall %s (len=%.2f, s=%.2f), skipping",
+                op.id, width_m, wall_id_str, wall_len, s_center,
+            )
+            continue
         # 재질: metadata_json.material 우선, 없으면 opening_type 기반 기본값
         raw_mat = (op.metadata_json or {}).get("material")
         default_mat = DEFAULT_DOOR_MATERIAL if op.opening_type == "door" else DEFAULT_WINDOW_MATERIAL
@@ -166,9 +194,10 @@ def export_scene_version_to_scene_json(
         openings_out.append(
             {
                 "id": str(op.id),
-                "wall_id": str(op.wall_id),
+                "wall_id": wall_id_str,
+                "kind": op.opening_type or "door",  # OpeningObject.kind 필수 — door/window
                 "center_xy": [float(cx), float(cy)],
-                "width_m": float(op.width_m),
+                "width_m": width_m,
                 "height_m": float(op.height_m),
                 "bottom_z_m": float(op.sill_height_m or 0.0),
                 "sionna_material_key": sionna_key,

--- a/frontend/src/features/editor/DraftSceneCanvas.tsx
+++ b/frontend/src/features/editor/DraftSceneCanvas.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { materialColor, materialLabel, MATERIAL_COLORS } from '@/lib/labels';
 import type {
   DraftEntityKind,
   DraftObject,
@@ -1664,6 +1665,28 @@ export function DraftSceneCanvas({
 
       <ScaleHint draft={draft} bounds={vb} dragging={!!drag} />
       {isCreationMode && <CreationHint tool={tool} creating={creating} />}
+      <WallMaterialLegend walls={draft.walls} />
+    </div>
+  );
+}
+
+function WallMaterialLegend({ walls }: { walls: DraftWall[] }) {
+  const usedKeys = [...new Set(walls.map((w) => w.material_label ?? ''))].filter(
+    (k) => k in MATERIAL_COLORS || k === '',
+  );
+  if (usedKeys.length === 0) return null;
+  return (
+    <div className="pointer-events-none absolute bottom-4 left-4 rounded-lg border bg-white/90 p-2.5 text-[11px] shadow-sm backdrop-blur-sm space-y-1">
+      <p className="font-semibold text-foreground/60 mb-1">벽 재질</p>
+      {usedKeys.map((k) => (
+        <div key={k || '_none'} className="flex items-center gap-1.5">
+          <span
+            className="h-2 w-5 rounded-[2px] shrink-0"
+            style={{ backgroundColor: materialColor(k || null) }}
+          />
+          <span className="text-foreground/75">{k ? materialLabel(k) : '미지정'}</span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -1976,7 +1999,7 @@ function WallShape({
         y1={start[1]}
         x2={end[0]}
         y2={end[1]}
-        stroke={selected ? 'oklch(0.55 0.22 264)' : 'oklch(0.25 0 0)'}
+        stroke={selected ? 'oklch(0.55 0.22 264)' : materialColor(wall.material_label)}
         strokeWidth={selected ? 6 : 4}
         strokeLinecap="butt"
         vectorEffect="non-scaling-stroke"

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -45,10 +45,18 @@ interface PropertiesPanelProps {
   onUpdateObjectPosition?: (ref: SelectedEntityRef, x: number, y: number) => void;
   /** 객체 크기(W/H) 변경 — 즉시 PATCH. */
   onUpdateObjectSize?: (ref: SelectedEntityRef, widthM: number, heightM: number) => void;
+  /** 선택된 벽들의 재질을 일괄 변경 (멀티셀렉트용). */
+  onUpdateSelectedMaterial?: (material: string) => void;
+  /** 멀티셀렉트 중 선택된 벽 개수. */
+  selectedWallCount?: number;
+  /** 모든 벽의 재질을 일괄 변경. */
+  onBulkUpdateWallMaterial?: (material: string) => void;
   /** 모든 문의 재질을 일괄 변경. */
   onBulkUpdateDoorMaterial?: (material: string) => void;
   /** 모든 창문의 재질을 일괄 변경. */
   onBulkUpdateWindowMaterial?: (material: string) => void;
+  /** 현재 씬의 벽 개수 */
+  wallCount?: number;
   /** 현재 씬의 문 개수 */
   doorCount?: number;
   /** 현재 씬의 창문 개수 */
@@ -73,8 +81,12 @@ export function PropertiesPanel({
   onUpdateMaterial,
   onUpdateWallDimension,
   onScaleAll,
+  onUpdateSelectedMaterial,
+  selectedWallCount = 0,
+  onBulkUpdateWallMaterial,
   onBulkUpdateDoorMaterial,
   onBulkUpdateWindowMaterial,
+  wallCount = 0,
   doorCount = 0,
   windowCount = 0,
   isSaving,
@@ -90,7 +102,9 @@ export function PropertiesPanel({
       {isMulti ? (
         <MultiSelectBody
           count={selectedCount ?? 0}
+          selectedWallCount={selectedWallCount}
           onDelete={onDelete}
+          onUpdateSelectedMaterial={onUpdateSelectedMaterial}
           isDeleting={!!isDeleting}
         />
       ) : selected ? (
@@ -108,10 +122,12 @@ export function PropertiesPanel({
         <EmptyBody />
       )}
 
-      {(doorCount > 0 || windowCount > 0) && (
+      {(wallCount > 0 || doorCount > 0 || windowCount > 0) && (
         <BulkMaterialSection
+          wallCount={wallCount}
           doorCount={doorCount}
           windowCount={windowCount}
+          onBulkUpdateWallMaterial={onBulkUpdateWallMaterial}
           onBulkUpdateDoorMaterial={onBulkUpdateDoorMaterial}
           onBulkUpdateWindowMaterial={onBulkUpdateWindowMaterial}
         />
@@ -126,25 +142,51 @@ export function PropertiesPanel({
 
 function MultiSelectBody({
   count,
+  selectedWallCount,
   onDelete,
+  onUpdateSelectedMaterial,
   isDeleting,
 }: {
   count: number;
+  selectedWallCount: number;
   onDelete?: () => void;
+  onUpdateSelectedMaterial?: (material: string) => void;
   isDeleting: boolean;
 }) {
+  const [mat, setMat] = useState('concrete');
+  const { data: materials, isLoading } = useMaterials();
   return (
     <div className="space-y-4 rounded-lg border bg-card p-4">
       <div>
         <p className="text-xs font-medium text-muted-foreground">선택됨</p>
         <p className="mt-1 text-base font-semibold">{count}개 항목</p>
       </div>
-      <p className="text-xs leading-relaxed text-muted-foreground">
-        여러 도형이 선택돼 있습니다. 캔버스에서 드래그하면 함께 이동하고,
-        아래 버튼으로 한꺼번에 삭제할 수 있어요.
-        <br />
-        개별 속성 편집은 하나만 선택했을 때 가능합니다.
-      </p>
+      {selectedWallCount > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted-foreground">선택된 벽 {selectedWallCount}개 재질 변경</p>
+          <MaterialSelect
+            value={mat}
+            onChange={setMat}
+            disabled={isLoading}
+            materials={materials ?? []}
+          />
+          <button
+            type="button"
+            onClick={() => onUpdateSelectedMaterial?.(mat)}
+            disabled={!onUpdateSelectedMaterial}
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-xs font-medium text-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw className="h-3 w-3" />
+            선택 벽에 적용
+          </button>
+        </div>
+      )}
+      {selectedWallCount === 0 && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          여러 도형이 선택돼 있습니다. 캔버스에서 드래그하면 함께 이동하고,
+          아래 버튼으로 한꺼번에 삭제할 수 있어요.
+        </p>
+      )}
       {onDelete && (
         <button
           type="button"
@@ -661,18 +703,23 @@ function MaterialSelect({
   );
 }
 
-/** 씬 내 모든 문 / 창문 재질을 일괄 변경하는 패널 섹션. */
+/** 씬 내 모든 벽 / 문 / 창문 재질을 일괄 변경하는 패널 섹션. */
 function BulkMaterialSection({
+  wallCount,
   doorCount,
   windowCount,
+  onBulkUpdateWallMaterial,
   onBulkUpdateDoorMaterial,
   onBulkUpdateWindowMaterial,
 }: {
+  wallCount: number;
   doorCount: number;
   windowCount: number;
+  onBulkUpdateWallMaterial?: (material: string) => void;
   onBulkUpdateDoorMaterial?: (material: string) => void;
   onBulkUpdateWindowMaterial?: (material: string) => void;
 }) {
+  const [wallMat, setWallMat] = useState('concrete');
   const [doorMat, setDoorMat] = useState('wood');
   const [windowMat, setWindowMat] = useState('glass');
   const { data: materials, isLoading } = useMaterials();
@@ -680,6 +727,27 @@ function BulkMaterialSection({
   return (
     <div className="rounded-lg border bg-card p-4 space-y-3">
       <h3 className="text-xs font-semibold text-foreground/80">일괄 재질 변경</h3>
+
+      {wallCount > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted-foreground">벽 ({wallCount}개)</p>
+          <MaterialSelect
+            value={wallMat}
+            onChange={setWallMat}
+            disabled={isLoading}
+            materials={materials ?? []}
+          />
+          <button
+            type="button"
+            onClick={() => onBulkUpdateWallMaterial?.(wallMat)}
+            disabled={!onBulkUpdateWallMaterial}
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-xs font-medium text-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw className="h-3 w-3" />
+            벽 전체 적용
+          </button>
+        </div>
+      )}
 
       {doorCount > 0 && (
         <div className="space-y-1.5">

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -944,7 +944,7 @@ function getMaterial(selected: SelectedEntityResolved): string {
       material?: string;
       raw?: { material?: string };
     };
-    return meta?.material_label ?? meta?.material ?? meta?.raw?.material ?? '';
+    return meta?.material ?? meta?.material_label ?? meta?.raw?.material ?? '';
   }
   if (selected.kind === 'object') {
     const meta = selected.data.metadata_json as {

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, ChevronDown, Ruler, RotateCcw, Sparkles, Trash2 } from 'lucide-react';
+import { Check, ChevronDown, Ruler, RotateCcw, Sparkles, Trash2, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   materialLabel,
@@ -45,6 +45,14 @@ interface PropertiesPanelProps {
   onUpdateObjectPosition?: (ref: SelectedEntityRef, x: number, y: number) => void;
   /** 객체 크기(W/H) 변경 — 즉시 PATCH. */
   onUpdateObjectSize?: (ref: SelectedEntityRef, widthM: number, heightM: number) => void;
+  /** 모든 문의 재질을 일괄 변경. */
+  onBulkUpdateDoorMaterial?: (material: string) => void;
+  /** 모든 창문의 재질을 일괄 변경. */
+  onBulkUpdateWindowMaterial?: (material: string) => void;
+  /** 현재 씬의 문 개수 */
+  doorCount?: number;
+  /** 현재 씬의 창문 개수 */
+  windowCount?: number;
   /** 작업 진행 중 표시 */
   isSaving?: boolean;
   isDeleting?: boolean;
@@ -65,6 +73,10 @@ export function PropertiesPanel({
   onUpdateMaterial,
   onUpdateWallDimension,
   onScaleAll,
+  onBulkUpdateDoorMaterial,
+  onBulkUpdateWindowMaterial,
+  doorCount = 0,
+  windowCount = 0,
   isSaving,
   isDeleting,
 }: PropertiesPanelProps) {
@@ -94,6 +106,15 @@ export function PropertiesPanel({
         />
       ) : (
         <EmptyBody />
+      )}
+
+      {(doorCount > 0 || windowCount > 0) && (
+        <BulkMaterialSection
+          doorCount={doorCount}
+          windowCount={windowCount}
+          onBulkUpdateDoorMaterial={onBulkUpdateDoorMaterial}
+          onBulkUpdateWindowMaterial={onBulkUpdateWindowMaterial}
+        />
       )}
 
       {/* [미구현] 모바일 AR 가구 스캔 — 백엔드/모바일 연동 없음. 구현 시 MobileScanCard 복구.
@@ -532,9 +553,41 @@ function shortId(id: string): string {
   return id.slice(0, 6) + '…';
 }
 
+/** Sionna 유효 재질 — DB 비어있을 때 fallback 으로도 사용. */
+const FALLBACK_MATERIALS = [
+  { code: 'concrete', name: '콘크리트' },
+  { code: 'brick', name: '벽돌' },
+  { code: 'drywall', name: '석고보드' },
+  { code: 'glass', name: '유리' },
+  { code: 'wood', name: '목재' },
+  { code: 'metal', name: '금속' },
+] as const;
+
+/**
+ * 다양한 형식(itu_ prefix, 한국어 이름, 영문 코드)의 재질 값을
+ * material_code 로 정규화. `onChange` 가 항상 code 를 반환하도록.
+ */
+function normalizeMaterialToCode(value: string, materials: Material[]): string {
+  if (!value) return value;
+  const stripped = value.toLowerCase().startsWith('itu_') ? value.slice(4) : value.toLowerCase();
+  // DB code 매칭
+  const byCode = materials.find((m) => m.material_code?.toLowerCase() === stripped);
+  if (byCode) return byCode.material_code;
+  // DB name 매칭 (한국어)
+  const byName = materials.find((m) => m.material_name === value);
+  if (byName) return byName.material_code;
+  // Fallback code/name 매칭
+  const byFallback = FALLBACK_MATERIALS.find(
+    (f) => f.code === stripped || f.name === value,
+  );
+  if (byFallback) return byFallback.code;
+  return stripped;
+}
+
 /**
  * 백엔드 §12.1 GET /materials 결과를 옵션으로 사용.
- * 로딩 중이거나 비어있으면 fallback 옵션으로 동작.
+ * 로딩 중이거나 비어있으면 FALLBACK_MATERIALS 로 동작.
+ * onChange 는 항상 material_code (영문) 를 반환.
  */
 function MaterialSelectWired({
   value,
@@ -557,22 +610,10 @@ function MaterialSelectWired({
           ? '백엔드 재질 DB'
           : isLoading
           ? '재질 목록 불러오는 중...'
-          : '기본 재질 목록 사용 (백엔드 비어있음)'
+          : '기본 재질 목록'
       }
     />
   );
-}
-
-/** 현재 값(예: AI 가 넣은 "concrete") 이 material_code 와 매칭되면 material_name 으로 정규화. */
-function normalizeMaterialValue(value: string, materials: Material[]): string {
-  if (!value) return value;
-  // 이미 material_name 과 일치하면 그대로
-  if (materials.some((m) => m.material_name === value)) return value;
-  // material_code 매칭 → 한글 이름으로 변환
-  const matched = materials.find(
-    (m) => m.material_code?.toLowerCase() === value.toLowerCase(),
-  );
-  return matched ? matched.material_name : value;
 }
 
 function MaterialSelect({
@@ -588,32 +629,103 @@ function MaterialSelect({
   materials: Material[];
   sourceLabel?: string;
 }) {
-  const normalizedValue = normalizeMaterialValue(value, materials);
-  const fallbackNames = ['유리', '나무', '콘크리트', '플라스틱'];
-  const optionNames = Array.from(
-    new Set([...materials.map((m) => m.material_name), ...fallbackNames]),
-  );
-  const showRawValue = !!normalizedValue && !optionNames.includes(normalizedValue);
+  const codeValue = normalizeMaterialToCode(value, materials);
+  // DB 에 재질이 있으면 DB 기준, 없으면 fallback 사용
+  const options =
+    materials.length > 0
+      ? materials.map((m) => ({ code: m.material_code, name: m.material_name }))
+      : FALLBACK_MATERIALS.map((f) => ({ code: f.code, name: f.name }));
+  // 현재 값이 옵션에 없으면 추가 (레거시 데이터 대응)
+  const hasCurrentCode = options.some((o) => o.code === codeValue);
   return (
     <div className="relative">
       <select
-        value={normalizedValue}
+        value={codeValue}
         onChange={(e) => onChange?.(e.target.value)}
         disabled={disabled || !onChange}
         className="w-full appearance-none rounded-md border bg-background px-3 py-2.5 pr-9 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-70"
       >
-        {showRawValue && <option value={normalizedValue}>{normalizedValue}</option>}
-        {optionNames.map((m) => (
-          <option key={m} value={m}>
-            {m}
+        {!codeValue && <option value="">재질 미지정</option>}
+        {!hasCurrentCode && codeValue && <option value={codeValue}>{codeValue}</option>}
+        {options.map((o) => (
+          <option key={o.code} value={o.code}>
+            {o.name}
           </option>
         ))}
-        {!normalizedValue && <option value="">재질 미지정</option>}
       </select>
       <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       {sourceLabel && (
         <p className="mt-1 text-[10px] text-muted-foreground/80">{sourceLabel}</p>
       )}
+    </div>
+  );
+}
+
+/** 씬 내 모든 문 / 창문 재질을 일괄 변경하는 패널 섹션. */
+function BulkMaterialSection({
+  doorCount,
+  windowCount,
+  onBulkUpdateDoorMaterial,
+  onBulkUpdateWindowMaterial,
+}: {
+  doorCount: number;
+  windowCount: number;
+  onBulkUpdateDoorMaterial?: (material: string) => void;
+  onBulkUpdateWindowMaterial?: (material: string) => void;
+}) {
+  const [doorMat, setDoorMat] = useState('wood');
+  const [windowMat, setWindowMat] = useState('glass');
+  const { data: materials, isLoading } = useMaterials();
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <h3 className="text-xs font-semibold text-foreground/80">일괄 재질 변경</h3>
+
+      {doorCount > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted-foreground">문 ({doorCount}개)</p>
+          <MaterialSelect
+            value={doorMat}
+            onChange={setDoorMat}
+            disabled={isLoading}
+            materials={materials ?? []}
+          />
+          <button
+            type="button"
+            onClick={() => onBulkUpdateDoorMaterial?.(doorMat)}
+            disabled={!onBulkUpdateDoorMaterial}
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-xs font-medium text-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw className="h-3 w-3" />
+            문 전체 적용
+          </button>
+        </div>
+      )}
+
+      {windowCount > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted-foreground">창문 ({windowCount}개)</p>
+          <MaterialSelect
+            value={windowMat}
+            onChange={setWindowMat}
+            disabled={isLoading}
+            materials={materials ?? []}
+          />
+          <button
+            type="button"
+            onClick={() => onBulkUpdateWindowMaterial?.(windowMat)}
+            disabled={!onBulkUpdateWindowMaterial}
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-xs font-medium text-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw className="h-3 w-3" />
+            창문 전체 적용
+          </button>
+        </div>
+      )}
+
+      <p className="text-[10px] text-muted-foreground/70">
+        선택한 재질을 해당 유형의 모든 도형에 적용합니다.
+      </p>
     </div>
   );
 }

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -59,19 +59,17 @@ export function wallRoleLabel(role: string | null | undefined): string {
   return WALL_ROLE_LABELS[key] ?? role ?? '-';
 }
 
-/** 재질(material_label) → 한국어 라벨. value 는 백엔드 enum 그대로 유지. */
+/** 재질(material_label / material_code) → 한국어 라벨. Sionna 유효 재질만 포함. */
 const MATERIAL_LABELS: Record<string, string> = {
   concrete: '콘크리트',
   brick: '벽돌',
   drywall: '석고보드',
-  gypsum_board: '석고보드',
+  plasterboard: '석고보드',  // Sionna 내부 키 (drywall alias)
   glass: '유리',
   wood: '목재',
   metal: '금속',
-  steel: '강철',
-  stone: '석재',
-  plaster: '회벽',
-  tile: '타일',
+  chipboard: '칩보드',
+  ceiling_board: '천장재',
 };
 
 export function materialLabel(material: string | null | undefined): string {

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -77,6 +77,25 @@ export function materialLabel(material: string | null | undefined): string {
   return MATERIAL_LABELS[key] ?? material ?? '-';
 }
 
+/** 재질 코드 → 캔버스 벽 stroke 색상 (oklch). */
+export const MATERIAL_COLORS: Record<string, string> = {
+  concrete:     'oklch(0.38 0.01 250)',   // 짙은 회색
+  brick:        'oklch(0.52 0.13 35)',    // 벽돌 적갈색
+  drywall:      'oklch(0.65 0.07 80)',    // 베이지
+  plasterboard: 'oklch(0.65 0.07 80)',    // 베이지 (drywall alias)
+  wood:         'oklch(0.55 0.10 55)',    // 갈색
+  glass:        'oklch(0.60 0.12 220)',   // 하늘색
+  metal:        'oklch(0.52 0.05 245)',   // 강철 청회색
+  chipboard:    'oklch(0.62 0.07 75)',    // 황갈색
+  ceiling_board:'oklch(0.68 0.06 85)',    // 황토
+};
+
+/** material_label → stroke 색상. null/미지정이면 진회색. */
+export function materialColor(material: string | null | undefined): string {
+  const key = (material ?? '').toLowerCase().replace(/^itu_/, '');
+  return MATERIAL_COLORS[key] ?? 'oklch(0.25 0 0)';
+}
+
 /** room_type → 한국어 라벨. 미상이면 그대로 반환. */
 const ROOM_TYPE_LABELS: Record<string, string> = {
   general: '일반',

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -605,6 +605,29 @@ export default function EditorPage() {
     }
   };
 
+  // 선택된 벽들 재질 변경 (멀티셀렉트)
+  const handleUpdateSelectedWallMaterial = (material: string) => {
+    const wallRefs = selectedRefs.filter((r) => r.kind === 'wall');
+    wallRefs.forEach((r, i) => {
+      runPatch('wall', r.id, { material_label: material }, {
+        skipHistory: i > 0,
+        silent: i < wallRefs.length - 1,
+      });
+    });
+  };
+
+  // 모든 벽 재질 일괄 변경
+  const handleBulkUpdateWallMaterial = (material: string) => {
+    if (!baseScene) return;
+    const walls = baseScene.walls;
+    walls.forEach((w, i) => {
+      runPatch('wall', w.id, { material_label: material }, {
+        skipHistory: i > 0,
+        silent: i < walls.length - 1,
+      });
+    });
+  };
+
   // 모든 문 재질 일괄 변경
   const handleBulkUpdateDoorMaterial = (material: string) => {
     if (!baseScene) return;
@@ -1094,8 +1117,12 @@ export default function EditorPage() {
         onScaleAll={handleScaleAll}
         onUpdateObjectPosition={handleUpdateObjectPosition}
         onUpdateObjectSize={handleResizeObject}
+        onUpdateSelectedMaterial={selectedRefs.some((r) => r.kind === 'wall') ? handleUpdateSelectedWallMaterial : undefined}
+        selectedWallCount={selectedRefs.filter((r) => r.kind === 'wall').length}
+        onBulkUpdateWallMaterial={baseScene ? handleBulkUpdateWallMaterial : undefined}
         onBulkUpdateDoorMaterial={baseScene ? handleBulkUpdateDoorMaterial : undefined}
         onBulkUpdateWindowMaterial={baseScene ? handleBulkUpdateWindowMaterial : undefined}
+        wallCount={baseScene?.walls.length ?? 0}
         doorCount={baseScene?.openings.filter((o) => o.opening_type === 'door').length ?? 0}
         windowCount={baseScene?.openings.filter((o) => o.opening_type === 'window').length ?? 0}
         isSaving={patchEntity.isPending || patchVersionEntity.isPending}

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -579,7 +579,7 @@ export default function EditorPage() {
     });
   };
 
-  // 벽 재질 변경
+  // 재질 변경 (벽/개구부/기둥 객체)
   const handleUpdateMaterial = (material: string) => {
     if (!selectedRef) return;
     if (selectedRef.kind === 'wall') {
@@ -589,8 +589,9 @@ export default function EditorPage() {
     if (selectedRef.kind === 'opening' && baseScene) {
       const opening = baseScene.openings.find((o) => o.id === selectedRef.id);
       const meta = (opening?.metadata_json ?? {}) as Record<string, unknown>;
+      // "material" 키 사용 — scene_version_export.py 가 metadata_json["material"] 을 읽음
       runPatch('opening', selectedRef.id, {
-        metadata_json: { ...meta, material_label: material },
+        metadata_json: { ...meta, material },
       });
       return;
     }
@@ -602,6 +603,32 @@ export default function EditorPage() {
         metadata_json: { ...meta, material_label: material },
       });
     }
+  };
+
+  // 모든 문 재질 일괄 변경
+  const handleBulkUpdateDoorMaterial = (material: string) => {
+    if (!baseScene) return;
+    const doors = baseScene.openings.filter((o) => o.opening_type === 'door');
+    doors.forEach((op, i) => {
+      const meta = (op.metadata_json ?? {}) as Record<string, unknown>;
+      runPatch('opening', op.id, { metadata_json: { ...meta, material } }, {
+        skipHistory: i > 0,
+        silent: i < doors.length - 1,
+      });
+    });
+  };
+
+  // 모든 창문 재질 일괄 변경
+  const handleBulkUpdateWindowMaterial = (material: string) => {
+    if (!baseScene) return;
+    const windows = baseScene.openings.filter((o) => o.opening_type === 'window');
+    windows.forEach((op, i) => {
+      const meta = (op.metadata_json ?? {}) as Record<string, unknown>;
+      runPatch('opening', op.id, { metadata_json: { ...meta, material } }, {
+        skipHistory: i > 0,
+        silent: i < windows.length - 1,
+      });
+    });
   };
 
   // 벽 실측 길이 (m) 갱신 — metadata_json.dimension_match.user_meters 에 저장.
@@ -1067,6 +1094,10 @@ export default function EditorPage() {
         onScaleAll={handleScaleAll}
         onUpdateObjectPosition={handleUpdateObjectPosition}
         onUpdateObjectSize={handleResizeObject}
+        onBulkUpdateDoorMaterial={baseScene ? handleBulkUpdateDoorMaterial : undefined}
+        onBulkUpdateWindowMaterial={baseScene ? handleBulkUpdateWindowMaterial : undefined}
+        doorCount={baseScene?.openings.filter((o) => o.opening_type === 'door').length ?? 0}
+        windowCount={baseScene?.openings.filter((o) => o.opening_type === 'window').length ?? 0}
         isSaving={patchEntity.isPending || patchVersionEntity.isPending}
         isDeleting={deleteEntity.isPending || deleteVersionEntity.isPending}
       />

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -588,8 +588,7 @@ export default function EditorPage() {
     }
     if (selectedRef.kind === 'opening' && baseScene) {
       const opening = baseScene.openings.find((o) => o.id === selectedRef.id);
-      const meta = (opening?.metadata_json ?? {}) as Record<string, unknown>;
-      // "material" 키 사용 — scene_version_export.py 가 metadata_json["material"] 을 읽음
+      const { material_label: _ml, ...meta } = (opening?.metadata_json ?? {}) as Record<string, unknown>;
       runPatch('opening', selectedRef.id, {
         metadata_json: { ...meta, material },
       });
@@ -633,7 +632,7 @@ export default function EditorPage() {
     if (!baseScene) return;
     const doors = baseScene.openings.filter((o) => o.opening_type === 'door');
     doors.forEach((op, i) => {
-      const meta = (op.metadata_json ?? {}) as Record<string, unknown>;
+      const { material_label: _ml, ...meta } = (op.metadata_json ?? {}) as Record<string, unknown>;
       runPatch('opening', op.id, { metadata_json: { ...meta, material } }, {
         skipHistory: i > 0,
         silent: i < doors.length - 1,
@@ -646,7 +645,7 @@ export default function EditorPage() {
     if (!baseScene) return;
     const windows = baseScene.openings.filter((o) => o.opening_type === 'window');
     windows.forEach((op, i) => {
-      const meta = (op.metadata_json ?? {}) as Record<string, unknown>;
+      const { material_label: _ml, ...meta } = (op.metadata_json ?? {}) as Record<string, unknown>;
       runPatch('opening', op.id, { metadata_json: { ...meta, material } }, {
         skipHistory: i > 0,
         silent: i < windows.length - 1,


### PR DESCRIPTION
## 개요
- 에디터에서 설정한 벽, 문, 창문 재질 정보가 RF 시뮬레이션 요청까지 일관되게 반영되도록 수정
- 기존에는 벽 재질 중심으로만 Sionna 요청 payload가 구성되었고, openings 정보는 빈 배열로 전달되고 있었다. 이로 인해 문/창문이 실제 시뮬레이션 단계에서 벽을 뚫는 개구부로 반영되지 않거나, 재질 감쇠 차이를 적용하기 어려웠다.

다음 흐름으로 보강
```text
Editor 재질 설정
→ SceneVersion export
→ scene_json 생성
→ Sionna request payload 생성
→ AI/RF 시뮬레이션 반영
```

## 변경 사항
### 1. Sionna 요청 payload에 opening 정보 포함
- rf_backend_local.py에서 기존에는 Sionna 요청 payload의 openings가 항상 빈 배열이었던 것을 scene_json.openings를 읽어 문/창문 정보를 Sionna 요청에 포함하도록 변경
- 특히 wall_id가 벽의 id와 정확히 매칭되도록 처리한 점이 중요합니다. opening은 특정 벽에 종속되므로, 벽 id와 opening의 wall_id가 다르면 Sionna runtime에서 벽 split이나 opening box 처리가 실패할 수 있다
- material_label로 저장하면 export 코드가 읽지 못해서 문/창문 재질이 시뮬레이션에 반영되지 않을 수 있었어. 이번 PR에서 material 키로 맞췄다

### 2. degenerate wall 방어 로직 추가
- 시작점과 끝점이 같은 벽은 Sionna 요청 validation에서 422 오류를 유발
- export 단계에서 잘못된 벽 데이터는 건너뛰도록 처리

### 3. opening export 로직 추가
scene_version_export.py에 문/창문 export 로직이 추가
핵심 처리 흐름:
- opening이 연결된 wall이 실제 export 대상인지 확인
- opening line geometry에서 중심점 계산
- opening 중심점을 벽 중심선 위로 projection/snap
- opening width가 벽 길이 안에 들어가는지 검증
- 문은 기본 wood, 창문은 기본 glass 재질 사용
- metadata에 material이 있으면 그 값을 우선 사용
- Sionna 유효 재질 key로 변환 후 export

이 로직 덕분에 문/창문 좌표가 벽 중심선에서 살짝 어긋나 있더라도, Sionna validation에서 실패하지 않도록 보정

### 4. 프론트 캔버스에서 벽 재질 색상 표시
- DraftSceneCanvas.tsx에서 벽 stroke 색상이 재질에 따라 달라지도록 변경
- labels.ts에 재질 라벨과 색상 매핑이 추가
- PropertiesPanel에서 재질 일괄 변경 기능 추가