### PR TITLE
[Feat] Physical AP / Radio Interface 분리 및 band별 RF 시뮬레이션 지원

### DIFF
--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.schemas.rf.physical_ap import BandLiteral, PhysicalApInput
+
 
 class ApRecommendationBBox(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
@@ -42,6 +44,22 @@ class ApRecommendationRequest(BaseModel):
 
     step_m: float = Field(default=1.0, gt=0.0, le=5.0)
     existing_aps: list[dict[str, Any]] = Field(default_factory=list)
+
+    # ── Physical AP / Radio Interface 구조 (신규) ────────────
+    # physical_aps가 있으면 existing_aps보다 우선한다.
+    # 없으면 기존 existing_aps를 내부에서 PhysicalApInput으로 변환한다.
+    physical_aps: list[PhysicalApInput] = Field(default_factory=list)
+    # 추천 단위: 현재는 physical_ap만 지원. radio 단위 추천은 후속 작업.
+    recommendation_unit: Literal["physical_ap"] = "physical_ap"
+    # 시뮬 대상 band 우선순위. 현재 추천은 leading band 단일 시뮬로 동작한다.
+    # TODO: band별 scoring 완성 후 멀티 band 평가 지원
+    target_bands: list[BandLiteral] = Field(default_factory=lambda: ["5G", "2.4G"])
+    # band 결과 통합 정책
+    # max: cell별 max RSSI
+    # prefer_5g_then_2g: 5G 가용 시 5G, 아니면 2.4G
+    # weighted: 가중 평균 (후속 작업)
+    combine_policy: Literal["max", "prefer_5g_then_2g", "weighted"] = "prefer_5g_then_2g"
+
     calibration_run_id: UUID | None = None
     calibration_policy: Literal["transfer_only", "best_params_only", "combined"] = (
         "transfer_only"
@@ -127,6 +145,26 @@ class ApRecommendationResponse(BaseModel):
     calibration: ApRecommendationCalibrationInfo | None = None
     score_weights: dict[str, float] = Field(default_factory=dict)
     created_at: datetime | None = None
+
+    # ── Physical AP / band 메타데이터 ────────────────────────
+    # 추천에 사용된 physical AP 목록 스냅샷
+    physical_aps_snapshot: list[dict[str, Any]] = Field(default_factory=list)
+    # band별 시뮬 정보 (어떤 band/radio가 사용됐는지)
+    band_metadata: dict[str, Any] = Field(default_factory=dict)
+    # 추천이 어떤 band 기준으로 수행됐는지
+    recommendation_band: str | None = None
+    # coverage semantics 설명
+    coverage_semantics: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "multi_ap_rssi_merge": "max_per_cell",
+            "rssi_is_not_summed": True,
+            "note": (
+                "복수 AP/radio의 RSSI는 합산되지 않습니다. "
+                "cell별 coverage는 max(rssi per radio)로 평가합니다. "
+                "채널/혼잡 완화 효과는 별도 capacity/congestion 관점으로 다룹니다."
+            ),
+        }
+    )
 
 
 class ApRecommendationRunResponse(BaseModel):

--- a/backend/app/schemas/rf/ap_recommendation.py
+++ b/backend/app/schemas/rf/ap_recommendation.py
@@ -64,8 +64,18 @@ class ApRecommendationRequest(BaseModel):
     calibration_policy: Literal["transfer_only", "best_params_only", "combined"] = (
         "transfer_only"
     )
-    recommendation_mode: Literal["add", "replace"] = "add"
+    recommendation_mode: Literal["add", "replace", "relocate_all", "relocate_selected"] = "add"
     replace_target_ap_id: str | None = None
+    # Multi-target replace: list of AP IDs to swap out simultaneously.
+    replace_target_ap_ids: list[str] = Field(default_factory=list)
+    # relocate_selected: IDs that stay fixed (never moved).
+    fixed_ap_ids: list[str] = Field(default_factory=list)
+    # relocate_selected: IDs to relocate.
+    relocate_target_ap_ids: list[str] = Field(default_factory=list)
+    # add mode: explicit count of new APs to add (overrides n_aps when > 0).
+    additional_ap_count: int = Field(default=0, ge=0, le=5)
+    # relocate_all mode: total number of APs in the new layout.
+    target_total_aps: int | None = Field(default=None, ge=1, le=10)
     candidate_tx_power_dbm: float = 20.0
     coverage_threshold_dbm: float = -67.0
     weak_zone_threshold_dbm: float = -67.0
@@ -145,6 +155,20 @@ class ApRecommendationResponse(BaseModel):
     calibration: ApRecommendationCalibrationInfo | None = None
     score_weights: dict[str, float] = Field(default_factory=dict)
     created_at: datetime | None = None
+
+    # ── Recommendation mode metadata ────────────────────────────────────────
+    recommendation_mode: str = "add"
+    mode_explanation: str = ""
+    # All existing APs before any moves (for before/after comparison).
+    baseline_aps_snapshot: list[dict[str, Any]] = Field(default_factory=list)
+    # APs that stayed fixed (not moved).
+    fixed_aps_snapshot: list[dict[str, Any]] = Field(default_factory=list)
+    # APs that were replaced / relocated.
+    movable_aps_snapshot: list[dict[str, Any]] = Field(default_factory=list)
+    # Final AP layout for the top recommendation (fixed + recommended).
+    final_aps: list[dict[str, Any]] = Field(default_factory=list)
+    # Per-AP move records: {ap_id, from_x, from_y, to_x, to_y}.
+    relocation_moves: list[dict[str, Any]] = Field(default_factory=list)
 
     # ── Physical AP / band 메타데이터 ────────────────────────
     # 추천에 사용된 physical AP 목록 스냅샷

--- a/backend/app/schemas/rf/physical_ap.py
+++ b/backend/app/schemas/rf/physical_ap.py
@@ -1,0 +1,163 @@
+"""Physical AP and Radio Interface schemas.
+
+용어 정의:
+- Physical AP: 실제로 설치/이동할 수 있는 하드웨어 장비 단위.
+  x, y, z 좌표를 가지며 AP 추천의 평가 단위이다.
+- Radio Interface: Physical AP 안의 송신 radio 단위.
+  2.4GHz 또는 5GHz band를 가지며 Sionna RF run의 transmitter에 대응한다.
+
+왜 band를 분리하는가:
+- 2.4GHz와 5GHz는 재질 감쇠, 다중경로 특성, 전파 범위가 다르다.
+- 동일 Sionna 파라미터로 두 band를 한꺼번에 시뮬하면 물리적으로 부정확하다.
+- band별 calibration slope/intercept도 분리해야 한다.
+
+RSSI 합산 금지 원칙:
+- 복수 AP/radio가 같은 위치에 있어도 RSSI는 합산되지 않는다.
+- cell별 coverage는 max(rssi_from_radio_1, rssi_from_radio_2, ...) 로 평가한다.
+- 채널/혼잡 완화 효과는 별도 capacity/congestion 관점으로 다룬다.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+BandLiteral = Literal["2.4G", "5G"]
+
+# ─── band default frequencies ────────────────────────────────
+BAND_DEFAULT_FREQ_MHZ: dict[str, int] = {
+    "2.4G": 2437,  # channel 6
+    "5G": 5180,    # channel 36
+}
+
+BAND_DEFAULT_FREQ_GHZ: dict[str, float] = {
+    "2.4G": 2.437,
+    "5G": 5.18,
+}
+
+# ─── IEEE 802.11 channel table (MHz → channel number) ────────
+_CHANNEL_TABLE: dict[int, int] = {
+    # 2.4GHz (802.11b/g/n)
+    2412: 1, 2417: 2, 2422: 3, 2427: 4, 2432: 5,
+    2437: 6, 2442: 7, 2447: 8, 2452: 9, 2457: 10,
+    2462: 11, 2467: 12, 2472: 13,
+    # 5GHz UNII-1
+    5180: 36, 5200: 40, 5220: 44, 5240: 48,
+    # UNII-2A
+    5260: 52, 5280: 56, 5300: 60, 5320: 64,
+    # UNII-2C
+    5500: 100, 5520: 104, 5540: 108, 5560: 112,
+    5580: 116, 5600: 120, 5620: 124, 5640: 128,
+    5660: 132, 5680: 136, 5700: 140, 5720: 144,
+    # UNII-3
+    5745: 149, 5765: 153, 5785: 157, 5805: 161, 5825: 165,
+}
+
+_SAME_POSITION_TOLERANCE_M: float = 0.3
+
+
+# ─── helpers ────────────────────────────────────────────────
+
+def infer_band_from_mhz(freq_mhz: int) -> BandLiteral | None:
+    """주파수(MHz)로 Wi-Fi band를 추론한다. 알 수 없으면 None."""
+    if 2400 <= freq_mhz <= 2500:
+        return "2.4G"
+    if 4900 <= freq_mhz <= 5900:
+        return "5G"
+    return None
+
+
+def mhz_to_channel(freq_mhz: int) -> int | None:
+    """주파수(MHz)를 IEEE 802.11 채널 번호로 변환한다. 테이블에 없으면 None."""
+    return _CHANNEL_TABLE.get(freq_mhz)
+
+
+def ghz_to_mhz(freq_ghz: float) -> int:
+    return round(freq_ghz * 1000)
+
+
+# ─── schemas ────────────────────────────────────────────────
+
+class RadioInterfaceInput(BaseModel):
+    """Physical AP 내부의 송신 radio.
+
+    radio는 자신의 좌표를 갖지 않는다 — parent Physical AP의 x, y, z를 그대로 사용한다.
+    """
+
+    id: str | None = None
+    band: BandLiteral | None = None
+    frequency_mhz: int | None = None
+    frequency_ghz: float | None = None
+    channel: int | None = None
+    ssid: str | None = None
+    bssid: str | None = None
+    tx_power_dbm: float | None = None
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _resolve_freq_band_channel(self) -> "RadioInterfaceInput":
+        # Resolve frequency_mhz ↔ frequency_ghz
+        if self.frequency_mhz is None and self.frequency_ghz is not None:
+            self.frequency_mhz = ghz_to_mhz(self.frequency_ghz)
+        if self.frequency_ghz is None and self.frequency_mhz is not None:
+            self.frequency_ghz = self.frequency_mhz / 1000.0
+
+        # 두 값이 모두 있으면 일관성 검증 (±5 MHz 허용)
+        if self.frequency_mhz is not None and self.frequency_ghz is not None:
+            expected_mhz = ghz_to_mhz(self.frequency_ghz)
+            if abs(self.frequency_mhz - expected_mhz) > 5:
+                raise ValueError(
+                    f"frequency_mhz ({self.frequency_mhz}) and frequency_ghz "
+                    f"({self.frequency_ghz}) are inconsistent."
+                )
+
+        # band 추론 (frequency_mhz 기반)
+        if self.band is None and self.frequency_mhz is not None:
+            self.band = infer_band_from_mhz(self.frequency_mhz)
+
+        # channel 추론 (frequency_mhz 기반)
+        if self.channel is None and self.frequency_mhz is not None:
+            self.channel = mhz_to_channel(self.frequency_mhz)
+
+        return self
+
+    def effective_frequency_ghz(self) -> float:
+        """Sionna transmitter에 넣을 실효 주파수(GHz). 미지정이면 band default."""
+        if self.frequency_ghz is not None:
+            return self.frequency_ghz
+        if self.band is not None:
+            return BAND_DEFAULT_FREQ_GHZ[self.band]
+        return BAND_DEFAULT_FREQ_GHZ["5G"]
+
+    def effective_tx_power_dbm(self, fallback: float = 20.0) -> float:
+        return self.tx_power_dbm if self.tx_power_dbm is not None else fallback
+
+
+class PhysicalApInput(BaseModel):
+    """실제 설치/이동 가능한 물리 AP 장비.
+
+    - 하나 이상의 RadioInterfaceInput을 가진다.
+    - radios가 0개면 backward-compat을 위해 default 5G radio 1개가 생성된다.
+    - AP 추천에서 candidate 위치는 Physical AP 단위로 평가된다.
+    - 모든 radio는 이 AP의 x, y, z 좌표를 공유한다.
+    """
+
+    id: str | None = None
+    name: str | None = None
+    x: float
+    y: float
+    z: float = Field(default=2.0)
+    movable: bool = True
+    radios: list[RadioInterfaceInput] = Field(default_factory=list)
+
+    def effective_radios(self) -> list[RadioInterfaceInput]:
+        """활성화된 radio 목록. 없으면 default 5G radio를 반환한다."""
+        enabled = [r for r in self.radios if r.enabled]
+        if enabled:
+            return enabled
+        # backward compat: radio 미지정 → default 5G
+        ap_id = self.id or "ap"
+        return [RadioInterfaceInput(id=f"{ap_id}-5g-default", band="5G")]
+
+    def radios_for_band(self, band: BandLiteral) -> list[RadioInterfaceInput]:
+        return [r for r in self.effective_radios() if r.band == band]

--- a/backend/app/schemas/rf/physical_ap.py
+++ b/backend/app/schemas/rf/physical_ap.py
@@ -137,7 +137,8 @@ class PhysicalApInput(BaseModel):
     """실제 설치/이동 가능한 물리 AP 장비.
 
     - 하나 이상의 RadioInterfaceInput을 가진다.
-    - radios가 0개면 backward-compat을 위해 default 5G radio 1개가 생성된다.
+    - radios가 None이면 backward-compat을 위해 default 5G radio 1개가 생성된다.
+    - 빈 리스트 또는 모두 disabled이면 radio가 없는 것으로 간주한다.
     - AP 추천에서 candidate 위치는 Physical AP 단위로 평가된다.
     - 모든 radio는 이 AP의 x, y, z 좌표를 공유한다.
     """
@@ -148,16 +149,14 @@ class PhysicalApInput(BaseModel):
     y: float
     z: float = Field(default=2.0)
     movable: bool = True
-    radios: list[RadioInterfaceInput] = Field(default_factory=list)
+    radios: list[RadioInterfaceInput] | None = Field(default=None)
 
     def effective_radios(self) -> list[RadioInterfaceInput]:
-        """활성화된 radio 목록. 없으면 default 5G radio를 반환한다."""
-        enabled = [r for r in self.radios if r.enabled]
-        if enabled:
-            return enabled
-        # backward compat: radio 미지정 → default 5G
-        ap_id = self.id or "ap"
-        return [RadioInterfaceInput(id=f"{ap_id}-5g-default", band="5G")]
+        """활성화된 radio 목록. None이면 default 5G radio를 반환한다."""
+        if self.radios is None:
+            ap_id = self.id or "ap"
+            return [RadioInterfaceInput(id=f"{ap_id}-5g-default", band="5G")]
+        return [r for r in self.radios if r.enabled]
 
     def radios_for_band(self, band: BandLiteral) -> list[RadioInterfaceInput]:
         return [r for r in self.effective_radios() if r.band == band]

--- a/backend/app/schemas/rf/rf_run.py
+++ b/backend/app/schemas/rf/rf_run.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, conlist, field_validator
 
-from typing import Literal
-
 from app.core.enums import normalize_job_status
+from app.schemas.rf.physical_ap import BandLiteral, PhysicalApInput
 from app.core.rf_defaults import (
     DEFAULT_DIFFRACTION,
     DEFAULT_DIFFUSE_REFLECTION,
@@ -66,11 +65,29 @@ class RfSimulationParams(BaseModel):
     diffraction: bool = DEFAULT_DIFFRACTION
 
 
+class BandSimulationParams(BaseModel):
+    """band별 RF run 파라미터 (신규).
+
+    현재는 bands 목록과 combine_policy만 지원한다.
+    실제 band별 Sionna run은 각 band의 leading radio frequency를 사용한다.
+
+    TODO: band별 calibration slope/intercept 분리 적용
+    TODO: overall_quality_map (2.4G/5G 통합 맵) 생성
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    bands: list[BandLiteral] = Field(default_factory=lambda: ["5G"])
+    combine_policy: Literal["max", "prefer_5g_then_2g", "weighted"] = "prefer_5g_then_2g"
+
+
 class RfRunCreate(BaseModel):
     """POST /rf-runs 요청.
 
     기존 호환을 위해 access_points/simulation 은 optional. 둘 다 없으면 단순
     queue 등록 (sagemaker invoke 안 함) — 추후 deprecate 예정.
+
+    신규: physical_aps로 Physical AP + Radio Interface 구조를 직접 전달할 수 있다.
+    physical_aps가 있으면 access_points보다 우선한다.
     """
     model_config = ConfigDict(extra="forbid")
 
@@ -86,6 +103,12 @@ class RfRunCreate(BaseModel):
     backend: RfBackend = "sagemaker"
     # 옛 호출자 호환 (deprecated)
     request_json: Optional[dict[str, Any]] = None
+
+    # ── Physical AP / Radio Interface 구조 (신규) ────────────
+    # physical_aps가 있으면 access_points보다 우선해 transmitter list를 빌드한다.
+    physical_aps: list[PhysicalApInput] = Field(default_factory=list)
+    # band별 시뮬 파라미터 — 미지정 시 single band (5G default) 로 동작한다.
+    band_simulation: Optional[BandSimulationParams] = None
 
 
 class RfRunResponse(BaseModel):

--- a/backend/app/services/rf/ap_recommendation_modes.py
+++ b/backend/app/services/rf/ap_recommendation_modes.py
@@ -1,0 +1,206 @@
+"""Mode-aware AP recommendation plan builder.
+
+Four modes:
+  add              — keep existing APs, recommend N new positions
+  replace          — remove target AP(s), search replacement position(s)
+  relocate_all     — discard all existing positions, redesign from scratch
+  relocate_selected — fix some APs, relocate the chosen ones
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.schemas.rf.ap_recommendation import ApRecommendationRequest
+    from app.services.rf.ap_recommendation_service import AccessPoint
+
+
+@dataclass
+class RecommendationPlan:
+    """Resolved placement plan for a recommendation request.
+
+    baseline_aps:  All existing APs — used for before/after RSSI comparison.
+    fixed_aps:     APs always included in eval (never moved).
+                   Greedy search adds candidate APs on top of these.
+    movable_count: How many new AP positions to search for.
+    movable_ap_ids:    IDs of APs being moved/replaced (for relocation_moves).
+    movable_ap_coords: Original (x, y) of each movable AP.
+    mode_explanation:  Human-readable description of this plan.
+    """
+
+    mode: str
+    baseline_aps: list  # list[AccessPoint]
+    fixed_aps: list     # list[AccessPoint]
+    movable_count: int
+    movable_ap_ids: list[str] = field(default_factory=list)
+    movable_ap_coords: list[tuple[float, float]] = field(default_factory=list)
+    mode_explanation: str = ""
+
+
+def build_recommendation_plan(
+    request: "ApRecommendationRequest",
+    existing_aps: list,  # list[AccessPoint]
+) -> "RecommendationPlan":
+    """Resolve request fields into a RecommendationPlan."""
+    mode = request.recommendation_mode
+    n_aps = max(1, request.n_aps)
+
+    # ── add ───────────────────────────────────────────────────────────────────
+    if mode == "add":
+        additional = getattr(request, "additional_ap_count", 0) or 0
+        movable_count = max(1, additional if additional > 0 else n_aps)
+        return RecommendationPlan(
+            mode="add",
+            baseline_aps=existing_aps,
+            fixed_aps=existing_aps,
+            movable_count=movable_count,
+            mode_explanation=(
+                f"기존 AP {len(existing_aps)}개 유지, {movable_count}개 신규 AP 위치 추천."
+            ),
+        )
+
+    # ── replace ───────────────────────────────────────────────────────────────
+    if mode == "replace":
+        targets: list[str] = list(getattr(request, "replace_target_ap_ids", None) or [])
+        if request.replace_target_ap_id and request.replace_target_ap_id not in targets:
+            targets.append(request.replace_target_ap_id)
+
+        if not targets:
+            return RecommendationPlan(
+                mode="replace",
+                baseline_aps=existing_aps,
+                fixed_aps=existing_aps,
+                movable_count=1,
+                mode_explanation="교체 대상 미지정 — 신규 AP 1개 위치 추천.",
+            )
+
+        target_set = set(targets)
+        fixed = [ap for ap in existing_aps if ap.name not in target_set]
+        moved = [ap for ap in existing_aps if ap.name in target_set]
+        return RecommendationPlan(
+            mode="replace",
+            baseline_aps=existing_aps,
+            fixed_aps=fixed,
+            movable_count=max(1, len(targets)),
+            movable_ap_ids=[ap.name for ap in moved],
+            movable_ap_coords=[(ap.x, ap.y) for ap in moved],
+            mode_explanation=(
+                f"AP [{', '.join(targets)}] 교체. "
+                f"나머지 {len(fixed)}개 유지 후 {len(targets)}개 새 위치 추천."
+            ),
+        )
+
+    # ── relocate_all ──────────────────────────────────────────────────────────
+    if mode == "relocate_all":
+        total = getattr(request, "target_total_aps", None) or len(existing_aps) or n_aps
+        return RecommendationPlan(
+            mode="relocate_all",
+            baseline_aps=existing_aps,
+            fixed_aps=[],  # start from scratch
+            movable_count=max(1, total),
+            movable_ap_ids=[ap.name for ap in existing_aps],
+            movable_ap_coords=[(ap.x, ap.y) for ap in existing_aps],
+            mode_explanation=(
+                f"전체 재배치 — 기존 {len(existing_aps)}개 기준, "
+                f"{total}개 새 위치로 재설계."
+            ),
+        )
+
+    # ── relocate_selected ─────────────────────────────────────────────────────
+    if mode == "relocate_selected":
+        relocate_ids: set[str] = set(getattr(request, "relocate_target_ap_ids", None) or [])
+        fixed_ids: set[str] = set(getattr(request, "fixed_ap_ids", None) or [])
+        if fixed_ids:
+            relocate_ids -= fixed_ids
+
+        fixed = [ap for ap in existing_aps if ap.name not in relocate_ids]
+        moved = [ap for ap in existing_aps if ap.name in relocate_ids]
+
+        if not moved:
+            return RecommendationPlan(
+                mode="relocate_selected",
+                baseline_aps=existing_aps,
+                fixed_aps=existing_aps,
+                movable_count=n_aps,
+                mode_explanation=f"이동 대상 미지정 — 신규 AP {n_aps}개 위치 추천.",
+            )
+
+        return RecommendationPlan(
+            mode="relocate_selected",
+            baseline_aps=existing_aps,
+            fixed_aps=fixed,
+            movable_count=len(moved),
+            movable_ap_ids=[ap.name for ap in moved],
+            movable_ap_coords=[(ap.x, ap.y) for ap in moved],
+            mode_explanation=(
+                f"선택 AP [{', '.join(ap.name for ap in moved)}] 재배치. "
+                f"나머지 {len(fixed)}개 고정."
+            ),
+        )
+
+    # ── unknown mode fallback → add ───────────────────────────────────────────
+    return RecommendationPlan(
+        mode=mode,
+        baseline_aps=existing_aps,
+        fixed_aps=existing_aps,
+        movable_count=n_aps,
+        mode_explanation="",
+    )
+
+
+def compute_relocation_moves(
+    plan: "RecommendationPlan",
+    top_ap_positions: list[tuple[float, float]],
+) -> list[dict[str, Any]]:
+    """Build relocation_moves for replace / relocate modes.
+
+    Matches each movable AP to the corresponding recommended position
+    by insertion order (1st moved AP → 1st new position, etc.).
+    """
+    if plan.mode not in ("replace", "relocate_all", "relocate_selected"):
+        return []
+
+    moves: list[dict[str, Any]] = []
+    for i, (old_x, old_y) in enumerate(plan.movable_ap_coords):
+        if i >= len(top_ap_positions):
+            break
+        new_x, new_y = top_ap_positions[i]
+        ap_id = plan.movable_ap_ids[i] if i < len(plan.movable_ap_ids) else f"ap_{i + 1}"
+        moves.append(
+            {
+                "ap_id": ap_id,
+                "from_x": round(old_x, 3),
+                "from_y": round(old_y, 3),
+                "to_x": round(new_x, 3),
+                "to_y": round(new_y, 3),
+            }
+        )
+    return moves
+
+
+def compute_final_aps(
+    plan: "RecommendationPlan",
+    top_ap_positions: list[tuple[float, float]],
+) -> list[dict[str, Any]]:
+    """Build final_aps — the complete AP layout for the top recommendation.
+
+    fixed=True  : AP that stays in place.
+    fixed=False : newly placed / relocated AP.
+    """
+    final: list[dict[str, Any]] = []
+
+    for ap in plan.fixed_aps:
+        final.append(
+            {"id": ap.name, "x": round(ap.x, 3), "y": round(ap.y, 3), "fixed": True}
+        )
+
+    for i, (x, y) in enumerate(top_ap_positions):
+        ap_id = (
+            plan.movable_ap_ids[i]
+            if i < len(plan.movable_ap_ids)
+            else f"new_ap_{i + 1}"
+        )
+        final.append({"id": ap_id, "x": round(x, 3), "y": round(y, 3), "fixed": False})
+
+    return final

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -42,6 +42,10 @@ from app.services.rf.calibration_worker.path_loss import (
     WallSegment,
     predict_rssi_best_ap,
 )
+from app.services.rf.physical_ap_helpers import (
+    build_band_metadata,
+    normalize_physical_aps_from_request,
+)
 from app.services.rf.scene_obstacles import (
     column_wall_segments_for_objects,
     normalize_rf_material,
@@ -154,7 +158,15 @@ def recommend_ap_location(
         residual_weight=0.5,
     )
 
-    existing_aps = _parse_existing_aps(request.existing_aps)
+    # Physical AP 정규화 — physical_aps 우선, 없으면 legacy existing_aps 변환
+    _physical_aps = normalize_physical_aps_from_request(
+        physical_aps=request.physical_aps or None,
+        existing_aps=request.existing_aps,
+        candidate_tx_power_dbm=request.candidate_tx_power_dbm,
+    )
+    existing_aps = _physical_aps_to_access_points(
+        _physical_aps, request.candidate_tx_power_dbm
+    )
     _validate_replace_target(request, existing_aps)
 
     candidates = _generate_candidates_for_request(request)
@@ -251,6 +263,7 @@ def recommend_ap_location(
             for i, (ap_set, metrics, predicted) in enumerate(top_sets)
         ]
 
+    leading_band = request.target_bands[0] if request.target_bands else "5G"
     response = ApRecommendationResponse(
         recommendations=recommendations,
         candidates_evaluated=len(candidates),
@@ -270,6 +283,9 @@ def recommend_ap_location(
             else None,
         ),
         score_weights=SCORE_WEIGHTS,
+        physical_aps_snapshot=[ap.model_dump(mode="json") for ap in _physical_aps],
+        band_metadata=build_band_metadata(_physical_aps, request.target_bands),
+        recommendation_band=leading_band,
     )
     run = _persist_recommendation_run(
         db=db,
@@ -1232,6 +1248,33 @@ def _finite_float(value: Any, default: float) -> float:
     except (TypeError, ValueError):
         return default
     return parsed if math.isfinite(parsed) else default
+
+
+def _physical_aps_to_access_points(
+    physical_aps: list,  # list[PhysicalApInput]
+    candidate_tx_power_dbm: float = 20.0,
+) -> list[AccessPoint]:
+    """PhysicalApInput list → 경로 손실 모델용 AccessPoint list.
+
+    현재는 AP별 leading radio(첫 번째 활성 radio)를 single-band 기준으로 변환한다.
+    TODO: band별 scoring 완성 후 band-aware AccessPoint로 확장.
+    """
+    result: list[AccessPoint] = []
+    for ap in physical_aps:
+        radios = ap.effective_radios()
+        leading = radios[0] if radios else None
+        result.append(
+            AccessPoint(
+                name=str(ap.id or ap.name or f"ap_{id(ap)}"),
+                x=ap.x,
+                y=ap.y,
+                tx_power_dbm=(
+                    leading.effective_tx_power_dbm(candidate_tx_power_dbm)
+                    if leading else candidate_tx_power_dbm
+                ),
+            )
+        )
+    return result
 
 
 def _parse_existing_aps(raw: list[dict]) -> list[AccessPoint]:

--- a/backend/app/services/rf/ap_recommendation_service.py
+++ b/backend/app/services/rf/ap_recommendation_service.py
@@ -42,6 +42,12 @@ from app.services.rf.calibration_worker.path_loss import (
     WallSegment,
     predict_rssi_best_ap,
 )
+from app.services.rf.ap_recommendation_modes import (
+    RecommendationPlan,
+    build_recommendation_plan,
+    compute_final_aps,
+    compute_relocation_moves,
+)
 from app.services.rf.physical_ap_helpers import (
     build_band_metadata,
     normalize_physical_aps_from_request,
@@ -167,7 +173,8 @@ def recommend_ap_location(
     existing_aps = _physical_aps_to_access_points(
         _physical_aps, request.candidate_tx_power_dbm
     )
-    _validate_replace_target(request, existing_aps)
+    _validate_mode_targets(request, existing_aps)
+    plan = build_recommendation_plan(request, existing_aps)
 
     candidates = _generate_candidates_for_request(request)
     if not candidates:
@@ -198,38 +205,42 @@ def recommend_ap_location(
 
     _attach_baseline_rssi(
         points=weighted_points,
-        existing_aps=existing_aps,
+        existing_aps=plan.baseline_aps,
         walls=walls,
         params=params,
         transfer=rssi_transfer,
     )
 
-    n_aps = max(1, request.n_aps)
+    n_movable = plan.movable_count
 
     logger.info(
-        "AP recommendation start: scene=%s candidates=%d eval=%d weighted=%d existing_aps=%d n_aps=%d calibration=%s",
+        "AP recommendation start: scene=%s mode=%s candidates=%d eval=%d weighted=%d "
+        "fixed_aps=%d movable=%d calibration=%s",
         sv.id,
+        plan.mode,
         len(candidates),
         len(raw_eval_points),
         len(weighted_points),
-        len(existing_aps),
-        n_aps,
+        len(plan.fixed_aps),
+        n_movable,
         rssi_transfer.method,
     )
 
     coverage_threshold = request.coverage_threshold_dbm or _DEFAULT_COVERAGE_THRESHOLD_DBM
     weak_zone_threshold = request.weak_zone_threshold_dbm or _DEFAULT_WEAK_ZONE_THRESHOLD_DBM
 
-    if n_aps == 1:
+    # plan.fixed_aps already encodes the mode logic (targets removed, etc.).
+    # Always use mode="add" internally — fixed_aps is the adjusted base.
+    if n_movable == 1:
         top_results = _grid_search_topn(
             candidates=candidates,
             eval_points=weighted_points,
-            existing_aps=existing_aps,
+            existing_aps=plan.fixed_aps,
             walls=walls,
             params=params,
             transfer=rssi_transfer,
-            recommendation_mode=request.recommendation_mode,
-            replace_target_ap_id=request.replace_target_ap_id,
+            recommendation_mode="add",
+            replace_target_ap_id=None,
             candidate_tx_power_dbm=request.candidate_tx_power_dbm,
             coverage_threshold_dbm=coverage_threshold,
             weak_zone_threshold_dbm=weak_zone_threshold,
@@ -239,13 +250,16 @@ def recommend_ap_location(
             _to_response_item(i + 1, x, y, metrics, predicted, ap_positions=[(x, y)])
             for i, (x, y, metrics, predicted) in enumerate(top_results)
         ]
+        top_positions: list[tuple[float, float]] = (
+            [(top_results[0][0], top_results[0][1])] if top_results else []
+        )
     else:
         top_sets = _greedy_multi_ap(
-            n_aps=n_aps,
+            n_aps=n_movable,
             n_sets=request.n_recommendations,
             candidates=candidates,
             eval_points=weighted_points,
-            existing_aps=existing_aps,
+            existing_aps=plan.fixed_aps,
             walls=walls,
             params=params,
             transfer=rssi_transfer,
@@ -262,6 +276,10 @@ def recommend_ap_location(
             )
             for i, (ap_set, metrics, predicted) in enumerate(top_sets)
         ]
+        top_positions = top_sets[0][0] if top_sets else []
+
+    relocation_moves = compute_relocation_moves(plan, top_positions)
+    final_aps_list = compute_final_aps(plan, top_positions)
 
     leading_band = request.target_bands[0] if request.target_bands else "5G"
     response = ApRecommendationResponse(
@@ -283,6 +301,22 @@ def recommend_ap_location(
             else None,
         ),
         score_weights=SCORE_WEIGHTS,
+        recommendation_mode=plan.mode,
+        mode_explanation=plan.mode_explanation,
+        baseline_aps_snapshot=[
+            {"id": ap.name, "x": round(ap.x, 3), "y": round(ap.y, 3)}
+            for ap in plan.baseline_aps
+        ],
+        fixed_aps_snapshot=[
+            {"id": ap.name, "x": round(ap.x, 3), "y": round(ap.y, 3)}
+            for ap in plan.fixed_aps
+        ],
+        movable_aps_snapshot=[
+            {"id": ap_id, "x": round(x, 3), "y": round(y, 3)}
+            for ap_id, (x, y) in zip(plan.movable_ap_ids, plan.movable_ap_coords)
+        ],
+        final_aps=final_aps_list,
+        relocation_moves=relocation_moves,
         physical_aps_snapshot=[ap.model_dump(mode="json") for ap in _physical_aps],
         band_metadata=build_band_metadata(_physical_aps, request.target_bands),
         recommendation_band=leading_band,
@@ -1298,19 +1332,26 @@ def _parse_existing_aps(raw: list[dict]) -> list[AccessPoint]:
     return aps
 
 
-def _validate_replace_target(
+def _validate_mode_targets(
     request: ApRecommendationRequest,
     existing_aps: list[AccessPoint],
 ) -> None:
-    if request.recommendation_mode != "replace" or not request.replace_target_ap_id:
+    """Validate that AP IDs referenced in mode-specific fields exist in existing_aps."""
+    if request.recommendation_mode != "replace":
         return
-    if any(ap.name == request.replace_target_ap_id for ap in existing_aps):
+    targets = list(request.replace_target_ap_ids or [])
+    if request.replace_target_ap_id and request.replace_target_ap_id not in targets:
+        targets.append(request.replace_target_ap_id)
+    if not targets:
         return
-    raise AppError(
-        ErrorCode.INVALID_REQUEST_BODY,
-        f"replace_target_ap_id '{request.replace_target_ap_id}' was not found in existing_aps.",
-        400,
-    )
+    existing_names = {ap.name for ap in existing_aps}
+    for target in targets:
+        if target not in existing_names:
+            raise AppError(
+                ErrorCode.INVALID_REQUEST_BODY,
+                f"replace target AP '{target}' was not found in existing_aps.",
+                400,
+            )
 
 
 def _attach_baseline_rssi(

--- a/backend/app/services/rf/physical_ap_helpers.py
+++ b/backend/app/services/rf/physical_ap_helpers.py
@@ -1,0 +1,343 @@
+"""Physical AP / Radio Interface 정규화 및 band grouping 헬퍼.
+
+이 모듈은 다음을 담당한다:
+1. 기존 existing_aps (list[dict]) 를 PhysicalApInput 구조로 변환.
+2. 새 physical_aps 요청을 그대로 수용.
+3. band별 transmitter 그룹 생성.
+4. RF run payload 빌드 시 band별 AP 분리.
+
+coverage 계산 원칙:
+- 복수 AP/radio의 RSSI는 합산하지 않는다.
+- cell별 best RSSI = max(rssi_from_radio_1, rssi_from_radio_2, ...) 로 평가한다.
+- 채널/혼잡 완화는 capacity/congestion 관점의 별도 작업이다 (TODO: congestion score).
+"""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from app.schemas.rf.physical_ap import (
+    BAND_DEFAULT_FREQ_GHZ,
+    BandLiteral,
+    PhysicalApInput,
+    RadioInterfaceInput,
+    _SAME_POSITION_TOLERANCE_M,
+    infer_band_from_mhz,
+)
+
+logger = logging.getLogger(__name__)
+
+_SAME_POSITION_TOL = _SAME_POSITION_TOLERANCE_M
+
+
+# ─── internal transmitter DTO ─────────────────────────────────
+
+@dataclass
+class RadioTransmitter:
+    """Sionna RF run에 넣을 단일 transmitter.
+
+    physical_ap_id, radio_id를 유지해 결과 metadata에 매칭할 수 있게 한다.
+    """
+    id: str
+    physical_ap_id: str
+    radio_id: str | None
+    band: BandLiteral
+    x: float
+    y: float
+    z: float
+    frequency_ghz: float
+    tx_power_dbm: float
+    ssid: str | None = None
+    bssid: str | None = None
+    channel: int | None = None
+
+
+# ─── normalize ───────────────────────────────────────────────
+
+def normalize_physical_aps_from_request(
+    *,
+    physical_aps: list[PhysicalApInput] | None,
+    existing_aps: list[dict[str, Any]] | None,
+    candidate_tx_power_dbm: float = 20.0,
+) -> list[PhysicalApInput]:
+    """요청에서 Physical AP 목록을 반환한다.
+
+    우선순위:
+    1. physical_aps가 있으면 그대로 사용.
+    2. 없으면 existing_aps를 PhysicalApInput으로 변환 (legacy compat).
+    """
+    if physical_aps:
+        return physical_aps
+    return _legacy_existing_aps_to_physical(
+        existing_aps or [],
+        fallback_tx_power_dbm=candidate_tx_power_dbm,
+    )
+
+
+def _legacy_existing_aps_to_physical(
+    raw: list[dict[str, Any]],
+    fallback_tx_power_dbm: float = 20.0,
+) -> list[PhysicalApInput]:
+    """기존 existing_aps dict list를 PhysicalApInput list로 변환한다.
+
+    처리 규칙:
+    - physical_ap_id가 같은 항목은 하나의 Physical AP로 묶어 radios에 추가한다.
+    - physical_ap_id가 없고 좌표가 매우 가까우면 (< 0.3m) 같은 AP로 병합한다
+      (단, 자동 병합은 warning을 남기고 보수적으로 처리한다).
+    - x, y가 없는 항목은 건너뛴다.
+    """
+    # physical_ap_id로 먼저 그룹핑
+    groups: dict[str, list[dict[str, Any]]] = {}
+    ungrouped: list[dict[str, Any]] = []
+
+    for item in raw:
+        phys_id = item.get("physical_ap_id")
+        if phys_id:
+            groups.setdefault(str(phys_id), []).append(item)
+        else:
+            ungrouped.append(item)
+
+    result: list[PhysicalApInput] = []
+
+    # physical_ap_id 기반 그룹 변환
+    for phys_id, items in groups.items():
+        anchor = items[0]
+        x = _coerce_float(anchor.get("x_m") or anchor.get("x"))
+        y = _coerce_float(anchor.get("y_m") or anchor.get("y"))
+        if x is None or y is None:
+            continue
+        z = _coerce_float(anchor.get("z_m") or anchor.get("z")) or 2.0
+        radios = [_item_to_radio(it, i, fallback_tx_power_dbm) for i, it in enumerate(items)]
+        result.append(
+            PhysicalApInput(
+                id=phys_id,
+                name=anchor.get("name") or phys_id,
+                x=x,
+                y=y,
+                z=z,
+                radios=radios,
+            )
+        )
+
+    # physical_ap_id 없는 항목: 좌표 근접 자동 병합 (보수적)
+    merged_indices: set[int] = set()
+    ungrouped_aps: list[PhysicalApInput] = []
+    for i, item in enumerate(ungrouped):
+        if i in merged_indices:
+            continue
+        x = _coerce_float(item.get("x_m") or item.get("x"))
+        y = _coerce_float(item.get("y_m") or item.get("y"))
+        if x is None or y is None:
+            continue
+        z = _coerce_float(item.get("z_m") or item.get("z")) or 2.0
+        ap_id = str(item.get("id") or item.get("name") or f"ap{i + 1}")
+        radios = [_item_to_radio(item, 0, fallback_tx_power_dbm)]
+
+        # 근접 항목 병합 (같은 물리 AP의 다른 band로 간주)
+        for j, other in enumerate(ungrouped):
+            if j <= i or j in merged_indices:
+                continue
+            ox = _coerce_float(other.get("x_m") or other.get("x"))
+            oy = _coerce_float(other.get("y_m") or other.get("y"))
+            if ox is None or oy is None:
+                continue
+            dist = math.hypot(ox - x, oy - y)
+            if dist < _SAME_POSITION_TOL:
+                logger.warning(
+                    "physical_ap_helpers: AP items %d and %d are %.3fm apart (<%.1fm) — "
+                    "auto-merging as same physical AP '%s'. Set physical_ap_id to suppress.",
+                    i, j, dist, _SAME_POSITION_TOL, ap_id,
+                )
+                radios.append(_item_to_radio(other, len(radios), fallback_tx_power_dbm))
+                merged_indices.add(j)
+
+        ungrouped_aps.append(
+            PhysicalApInput(
+                id=ap_id,
+                name=item.get("name") or ap_id,
+                x=x,
+                y=y,
+                z=z,
+                radios=radios,
+            )
+        )
+
+    return result + ungrouped_aps
+
+
+def _item_to_radio(
+    item: dict[str, Any],
+    idx: int,
+    fallback_tx_power_dbm: float,
+) -> RadioInterfaceInput:
+    """existing_aps 항목 하나를 RadioInterfaceInput으로 변환한다."""
+    freq_mhz = item.get("frequency_mhz")
+    freq_ghz = item.get("frequency_ghz")
+    band_raw = item.get("band")
+    band: BandLiteral | None = None
+    if band_raw in ("2.4G", "5G"):
+        band = band_raw  # type: ignore[assignment]
+    elif freq_mhz:
+        band = infer_band_from_mhz(int(freq_mhz))
+    if band is None:
+        band = "5G"  # legacy item에 band/frequency 정보 없으면 5G 기본
+
+    radio_id = item.get("radio_id") or item.get("id")
+    if radio_id and idx > 0:
+        radio_id = f"{radio_id}-radio{idx}"
+
+    return RadioInterfaceInput(
+        id=str(radio_id) if radio_id else None,
+        band=band,
+        frequency_mhz=int(freq_mhz) if freq_mhz is not None else None,
+        frequency_ghz=float(freq_ghz) if freq_ghz is not None else None,
+        channel=item.get("channel"),
+        ssid=item.get("ssid"),
+        bssid=item.get("bssid"),
+        tx_power_dbm=_coerce_float(
+            item.get("tx_power_dbm") or item.get("power_dbm")
+        ) or fallback_tx_power_dbm,
+    )
+
+
+# ─── band grouping ────────────────────────────────────────────
+
+def group_radios_by_band(
+    physical_aps: list[PhysicalApInput],
+) -> dict[BandLiteral, list[RadioTransmitter]]:
+    """Physical AP 목록에서 band별 RadioTransmitter 그룹을 만든다.
+
+    - 2.4G radio → "2.4G" 그룹
+    - 5G radio   → "5G" 그룹
+    - band 미지정 radio는 "5G" 그룹으로 fallback (경고 출력)
+
+    각 transmitter는 parent physical AP의 x, y, z를 그대로 사용한다.
+    """
+    bands: dict[BandLiteral, list[RadioTransmitter]] = {"2.4G": [], "5G": []}
+
+    for ap in physical_aps:
+        ap_id = ap.id or f"ap_{id(ap)}"
+        for radio in ap.effective_radios():
+            effective_band: BandLiteral = radio.band or "5G"
+            if radio.band is None:
+                logger.warning(
+                    "Radio %s on AP %s has no band — defaulting to 5G.",
+                    radio.id, ap_id,
+                )
+            tx = RadioTransmitter(
+                id=f"{ap_id}-{radio.id or effective_band}",
+                physical_ap_id=ap_id,
+                radio_id=radio.id,
+                band=effective_band,
+                x=ap.x,
+                y=ap.y,
+                z=ap.z,
+                frequency_ghz=radio.effective_frequency_ghz(),
+                tx_power_dbm=radio.effective_tx_power_dbm(fallback=20.0),
+                ssid=radio.ssid,
+                bssid=radio.bssid,
+                channel=radio.channel,
+            )
+            bands[effective_band].append(tx)
+
+    return bands
+
+
+def build_band_metadata(
+    physical_aps: list[PhysicalApInput],
+    bands_used: list[BandLiteral] | None = None,
+) -> dict[str, Any]:
+    """RF run 결과 metadata에 포함할 band별 정보를 빌드한다."""
+    grouped = group_radios_by_band(physical_aps)
+    active_bands: list[BandLiteral] = bands_used or ["5G", "2.4G"]
+    out: dict[str, Any] = {}
+    for band in active_bands:
+        txs = grouped.get(band, [])
+        out[band] = {
+            "frequency_ghz": BAND_DEFAULT_FREQ_GHZ[band],
+            "radio_ids": [tx.radio_id for tx in txs],
+            "transmitter_count": len(txs),
+            "calibration_applied": False,  # TODO: band별 calibration 분리 후 갱신
+        }
+    return out
+
+
+def physical_aps_to_access_point_list(
+    physical_aps: list[PhysicalApInput],
+    band: BandLiteral | None = None,
+    fallback_tx_power_dbm: float = 20.0,
+) -> list[dict[str, Any]]:
+    """PhysicalApInput list를 rf_backend_local / SageMaker 호환 access_point dict list로 변환.
+
+    band가 None이면 첫 번째 radio (또는 default 5G)를 사용한다.
+    band가 지정되면 해당 band radio만 포함한다.
+    """
+    result: list[dict[str, Any]] = []
+    grouped = group_radios_by_band(physical_aps)
+
+    if band is not None:
+        for tx in grouped.get(band, []):
+            result.append({
+                "id": tx.id,
+                "x_m": tx.x,
+                "y_m": tx.y,
+                "z_m": tx.z,
+                "frequency_ghz": tx.frequency_ghz,
+                "tx_power_dbm": tx.tx_power_dbm,
+                "band": tx.band,
+                "physical_ap_id": tx.physical_ap_id,
+                "radio_id": tx.radio_id,
+            })
+    else:
+        # band 미지정: AP별로 첫 번째 radio 사용 (legacy single-band 호환)
+        for ap in physical_aps:
+            radios = ap.effective_radios()
+            if not radios:
+                continue
+            radio = radios[0]
+            ap_id = ap.id or f"ap_{id(ap)}"
+            result.append({
+                "id": ap_id,
+                "x_m": ap.x,
+                "y_m": ap.y,
+                "z_m": ap.z,
+                "frequency_ghz": radio.effective_frequency_ghz(),
+                "tx_power_dbm": radio.effective_tx_power_dbm(fallback_tx_power_dbm),
+                "band": radio.band or "5G",
+                "physical_ap_id": ap_id,
+                "radio_id": radio.id,
+            })
+    return result
+
+
+# ─── RSSI merge semantics ─────────────────────────────────────
+
+def merge_rssi_max_per_cell(rssi_values: list[float]) -> float:
+    """여러 AP/radio의 RSSI를 cell별 max로 병합한다.
+
+    올바른 coverage 계산 원칙:
+    - RSSI dBm 값을 단순 합산하지 않는다.
+    - 같은 위치에 AP가 여러 대 있다고 coverage가 2배 강해지는 것이 아니다.
+    - 채널/혼잡 완화 효과는 별도 capacity/congestion 관점으로 다룬다.
+
+    Args:
+        rssi_values: 같은 cell에서 여러 radio가 예측한 RSSI(dBm) 목록.
+
+    Returns:
+        그 중 가장 강한 (숫자가 큰) RSSI 값.
+    """
+    if not rssi_values:
+        return float("-inf")
+    return max(rssi_values)
+
+
+# ─── internal utils ───────────────────────────────────────────
+
+def _coerce_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
+    except (TypeError, ValueError):
+        return None

--- a/backend/app/services/rf/physical_ap_helpers.py
+++ b/backend/app/services/rf/physical_ap_helpers.py
@@ -104,11 +104,12 @@ def _legacy_existing_aps_to_physical(
     # physical_ap_id 기반 그룹 변환
     for phys_id, items in groups.items():
         anchor = items[0]
-        x = _coerce_float(anchor.get("x_m") or anchor.get("x"))
-        y = _coerce_float(anchor.get("y_m") or anchor.get("y"))
+        x = _coerce_float(anchor.get("x_m") if anchor.get("x_m") is not None else anchor.get("x"))
+        y = _coerce_float(anchor.get("y_m") if anchor.get("y_m") is not None else anchor.get("y"))
         if x is None or y is None:
             continue
-        z = _coerce_float(anchor.get("z_m") or anchor.get("z")) or 2.0
+        _z_raw = anchor.get("z_m") if anchor.get("z_m") is not None else anchor.get("z")
+        z = _coerce_float(_z_raw) if _z_raw is not None else 2.0
         radios = [_item_to_radio(it, i, fallback_tx_power_dbm) for i, it in enumerate(items)]
         result.append(
             PhysicalApInput(
@@ -127,11 +128,12 @@ def _legacy_existing_aps_to_physical(
     for i, item in enumerate(ungrouped):
         if i in merged_indices:
             continue
-        x = _coerce_float(item.get("x_m") or item.get("x"))
-        y = _coerce_float(item.get("y_m") or item.get("y"))
+        x = _coerce_float(item.get("x_m") if item.get("x_m") is not None else item.get("x"))
+        y = _coerce_float(item.get("y_m") if item.get("y_m") is not None else item.get("y"))
         if x is None or y is None:
             continue
-        z = _coerce_float(item.get("z_m") or item.get("z")) or 2.0
+        _z_raw = item.get("z_m") if item.get("z_m") is not None else item.get("z")
+        z = _coerce_float(_z_raw) if _z_raw is not None else 2.0
         ap_id = str(item.get("id") or item.get("name") or f"ap{i + 1}")
         radios = [_item_to_radio(item, 0, fallback_tx_power_dbm)]
 
@@ -139,8 +141,8 @@ def _legacy_existing_aps_to_physical(
         for j, other in enumerate(ungrouped):
             if j <= i or j in merged_indices:
                 continue
-            ox = _coerce_float(other.get("x_m") or other.get("x"))
-            oy = _coerce_float(other.get("y_m") or other.get("y"))
+            ox = _coerce_float(other.get("x_m") if other.get("x_m") is not None else other.get("x"))
+            oy = _coerce_float(other.get("y_m") if other.get("y_m") is not None else other.get("y"))
             if ox is None or oy is None:
                 continue
             dist = math.hypot(ox - x, oy - y)
@@ -196,9 +198,10 @@ def _item_to_radio(
         channel=item.get("channel"),
         ssid=item.get("ssid"),
         bssid=item.get("bssid"),
-        tx_power_dbm=_coerce_float(
-            item.get("tx_power_dbm") or item.get("power_dbm")
-        ) or fallback_tx_power_dbm,
+        tx_power_dbm=next(
+            (v for v in (_coerce_float(item.get("tx_power_dbm")), _coerce_float(item.get("power_dbm"))) if v is not None),
+            fallback_tx_power_dbm,
+        ),
     )
 
 

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -500,9 +500,9 @@ def _build_sionna_request_payload(
 
     ap_id = str(ap.get("id") or "ap0")
     ap_position = [
-        float(ap.get("x_m") or ap.get("x") or 0.0),
-        float(ap.get("y_m") or ap.get("y") or 0.0),
-        float(ap.get("z_m") or ap.get("z") or 1.2),
+        float(ap.get("x_m") if ap.get("x_m") is not None else ap.get("x") if ap.get("x") is not None else 0.0),
+        float(ap.get("y_m") if ap.get("y_m") is not None else ap.get("y") if ap.get("y") is not None else 0.0),
+        float(ap.get("z_m") if ap.get("z_m") is not None else ap.get("z") if ap.get("z") is not None else 1.2),
     ]
 
     # 모든 fallback 은 `app/core/rf_defaults.py` 에서 import — 같은 source of truth 유지.

--- a/backend/app/services/rf/rf_backend_local.py
+++ b/backend/app/services/rf/rf_backend_local.py
@@ -87,13 +87,16 @@ async def submit_via_local_ai_api(
             400,
         )
 
-    payload = _build_sionna_request_payload(
-        scene_json=scene_json,
-        floor_id=str(sv.floor_id),
-        scene_version_id=str(sv.id),
-        access_points=access_points,
-        simulation=simulation,
-    )
+    payloads = [
+        _build_sionna_request_payload(
+            scene_json=scene_json,
+            floor_id=str(sv.floor_id),
+            scene_version_id=str(sv.id),
+            ap=ap,
+            simulation=simulation,
+        )
+        for ap in access_points
+    ]
 
     now = _now_utc()
     rf_run = RfRun(
@@ -123,7 +126,7 @@ async def submit_via_local_ai_api(
             "ai_api_payload_summary": {
                 "walls": len(scene_json.get("walls") or []),
                 "rooms": len(scene_json.get("rooms") or []),
-                "primary_ap_id": access_points[0].get("id"),
+                "ap_ids": [ap.get("id") for ap in access_points],
             },
         },
     }
@@ -164,7 +167,7 @@ async def submit_via_local_ai_api(
 
     thread = threading.Thread(
         target=_background_run_ai_api,
-        kwargs={"job_id": job_id, "rf_run_id": rf_run_id, "payload": payload},
+        kwargs={"job_id": job_id, "rf_run_id": rf_run_id, "payloads": payloads},
         name=f"rf-local-{job_id[:8]}",
         daemon=True,
     )
@@ -181,51 +184,94 @@ async def submit_via_local_ai_api(
 # Background worker
 # ============================================================
 def _background_run_ai_api(
-    *, job_id: str, rf_run_id: str, payload: dict[str, Any]
+    *, job_id: str, rf_run_id: str, payloads: list[dict[str, Any]]
 ) -> None:
-    """Thread entry point: ai_api 호출 + 결과 DB 영속화 (성공/실패 분기)."""
-    # 디버그: 어떤 simulation 설정으로 호출되는지 확인 — 3초 미만으로 끝나는 등 의심
-    # 상황에서 실제 적용된 값이 무엇인지 빠르게 검증하기 위한 단일 로그.
-    sim_cfg = payload.get("simulation") or {}
+    """Thread entry point: AP별 ai_api 호출 → element-wise max 합산 → DB 영속화."""
+    sim_cfg = (payloads[0].get("simulation") or {}) if payloads else {}
     logger.info(
-        "RF job %s: sending to ai_api — solver=%s, propagation=%s, mp=%s",
-        job_id,
+        "RF job %s: sending %d AP(s) to ai_api — solver=%s propagation=%s mp=%s",
+        job_id, len(payloads),
         sim_cfg.get("solver"),
         sim_cfg.get("propagation"),
-        payload.get("measurement_plane"),
+        payloads[0].get("measurement_plane") if payloads else None,
     )
-    # try 범위를 호출 + 응답 파싱 + 영속화 전체로 확장 — 어디서 예외 나도 job 이
-    # running 으로 dangling 되지 않도록 (백그라운드 thread 가 silent 크래시 했을 때 폴링이
-    # 영원히 running 응답을 받게 되는 버그 방지).
     try:
-        response = ai_api_client.run_sionna_simulation(payload=payload)
-        status = str(response.get("status") or "").lower()
-        if status != "succeeded":
-            detail = (
-                response.get("detail")
-                or response.get("error")
-                or "ai_api returned non-success status"
-            )
+        responses: list[dict[str, Any]] = []
+        for i, payload in enumerate(payloads):
+            ap_id = (payload.get("access_point") or {}).get("id", f"ap{i}")
+            logger.info("RF job %s: AP %d/%d id=%s → ai_api", job_id, i + 1, len(payloads), ap_id)
+            try:
+                response = ai_api_client.run_sionna_simulation(payload=payload)
+            except ai_api_client.AiApiClientError as exc:
+                logger.warning("RF job %s: AP %d (%s) call failed: %s", job_id, i + 1, ap_id, exc)
+                if len(payloads) == 1:
+                    raise
+                continue
+            status = str(response.get("status") or "").lower()
+            if status != "succeeded":
+                detail = response.get("detail") or response.get("error") or "non-success"
+                logger.warning("RF job %s: AP %d status=%s (%s)", job_id, i + 1, status, detail)
+                if len(payloads) == 1:
+                    _persist_local_failure(
+                        job_id=job_id, rf_run_id=rf_run_id,
+                        message=f"ai_api status={status}: {detail}",
+                    )
+                    return
+                continue
+            responses.append(response)
+
+        if not responses:
             _persist_local_failure(
                 job_id=job_id, rf_run_id=rf_run_id,
-                message=f"ai_api status={status or 'unknown'}: {detail}",
+                message="all AP simulations failed",
             )
             return
 
-        _persist_local_success(job_id=job_id, rf_run_id=rf_run_id, response=response)
+        merged = _merge_ap_responses(responses)
+        _persist_local_success(job_id=job_id, rf_run_id=rf_run_id, response=merged)
+
     except ai_api_client.AiApiClientError as exc:
-        logger.warning(
-            "RF job %s: local ai_api call failed: %s", job_id, exc,
-        )
+        logger.warning("RF job %s: local ai_api call failed: %s", job_id, exc)
         _persist_local_failure(job_id=job_id, rf_run_id=rf_run_id, message=str(exc))
-    except Exception as exc:  # pragma: no cover — 방어
-        # response 파싱 (KeyError/TypeError 등) 이나 _persist_local_success 내부에서
-        # 새 예외가 터질 수 있음. 그 경우도 반드시 failure 로 기록.
+    except Exception as exc:  # pragma: no cover
         logger.exception("RF job %s: unexpected error during local ai_api call", job_id)
         _persist_local_failure(
             job_id=job_id, rf_run_id=rf_run_id,
             message=f"unexpected error: {exc}",
         )
+
+
+def _merge_ap_responses(responses: list[dict[str, Any]]) -> dict[str, Any]:
+    """여러 AP 시뮬 응답을 하나로 합산. 각 셀에서 RSSI가 가장 강한 AP 값 선택."""
+    if len(responses) == 1:
+        return responses[0]
+
+    import copy
+
+    base = copy.deepcopy(responses[0])
+    base_values: list[list[float]] | None = None
+    try:
+        base_values = base["artifacts"]["radiomap"]["values_dbm"]
+    except (KeyError, TypeError):
+        pass
+
+    if base_values is None:
+        return base
+
+    for resp in responses[1:]:
+        try:
+            values: list[list[float]] = resp["artifacts"]["radiomap"]["values_dbm"]
+        except (KeyError, TypeError):
+            continue
+        for r, row in enumerate(values):
+            if r >= len(base_values):
+                break
+            for c, val in enumerate(row):
+                if c < len(base_values[r]) and isinstance(val, (int, float)) and val > base_values[r][c]:
+                    base_values[r][c] = val
+
+    base["artifacts"]["radiomap"]["values_dbm"] = base_values
+    return base
 
 
 def _persist_local_success(
@@ -406,13 +452,13 @@ def _build_sionna_request_payload(
     scene_json: dict[str, Any],
     floor_id: str,
     scene_version_id: str,
-    access_points: list[dict[str, Any]],
+    ap: dict[str, Any],
     simulation: dict[str, Any],
 ) -> dict[str, Any]:
-    """web-platform scene/simulation/AP 형식 → ai_api `/internal/sionna/run` body.
+    """web-platform AP 1개 + scene/simulation → ai_api `/internal/sionna/run` body.
 
-    Local backend 는 ai_api 가 single-AP 모델이므로 첫 번째 AP 만 사용한다.
-    다중 AP 가 들어오면 첫 번째만 시뮬 (한계 — 추후 per-AP 반복 호출로 확장 가능).
+    멀티 AP 는 submit_via_local_ai_api 가 AP별로 이 함수를 호출하고
+    _merge_ap_responses 로 element-wise max 합산한다.
     """
     walls = [
         {
@@ -452,12 +498,11 @@ def _build_sionna_request_payload(
         if op.get("wall_id")
     ]
 
-    primary_ap = access_points[0]
-    ap_id = str(primary_ap.get("id") or "ap0")
+    ap_id = str(ap.get("id") or "ap0")
     ap_position = [
-        float(primary_ap.get("x_m") or primary_ap.get("x") or 0.0),
-        float(primary_ap.get("y_m") or primary_ap.get("y") or 0.0),
-        float(primary_ap.get("z_m") or primary_ap.get("z") or 1.2),
+        float(ap.get("x_m") or ap.get("x") or 0.0),
+        float(ap.get("y_m") or ap.get("y") or 0.0),
+        float(ap.get("z_m") or ap.get("z") or 1.2),
     ]
 
     # 모든 fallback 은 `app/core/rf_defaults.py` 에서 import — 같은 source of truth 유지.

--- a/backend/app/services/rf/scene_obstacles.py
+++ b/backend/app/services/rf/scene_obstacles.py
@@ -11,17 +11,43 @@ DEFAULT_COLUMN_SIZE_M = 0.6
 MIN_COLUMN_SIZE_M = 0.05
 
 MATERIAL_ALIASES: dict[str, str] = {
+    # English codes / synonyms
     "drywall": "plasterboard",
     "plywood": "wood",
     "marble": "concrete",
+    "stone": "concrete",
+    "cement": "concrete",
     "glass": "glass",
     "wood": "wood",
     "concrete": "concrete",
     "plastic": "plastic",
-    "\uc720\ub9ac": "glass",
-    "\ub098\ubb34": "wood",
-    "\ucf58\ud06c\ub9ac\ud2b8": "concrete",
-    "\ud50c\ub77c\uc2a4\ud2f1": "plastic",
+    "brick": "brick",
+    "metal": "metal",
+    "steel": "metal",
+    "aluminum": "metal",
+    "aluminium": "metal",
+    # \ud55c\uad6d\uc5b4 \ub3d9\uc758\uc5b4 (\ud504\ub860\ud2b8 KO_ALIASES \uc640 \ub3d9\uae30)
+    "\ub098\ubb34": "wood",       # \ub098\ubb34
+    "\ubaa9\uc7ac": "wood",       # \ubaa9\uc7ac
+    "\ud569\ud310": "wood",       # \ud569\ud310
+    "\uc6d0\ubaa9": "wood",       # \uc6d0\ubaa9
+    "\ucf58\ud06c\ub9ac\ud2b8": "concrete",  # \ucf58\ud06c\ub9ac\ud2b8
+    "\uc2dc\uba58\ud2b8": "concrete",         # \uc2dc\uba58\ud2b8
+    "\uc11d\uc7ac": "concrete",               # \uc11d\uc7ac
+    "\ub3cc": "concrete",                     # \ub3cc
+    "\ub300\ub9ac\uc11d": "concrete",         # \ub300\ub9ac\uc11d
+    "\ubcbd\ub3cc": "brick",                  # \ubcbd\ub3cc
+    "\uc801\ubcbd\ub3cc": "brick",            # \uc801\ubcbd\ub3cc
+    "\uc11d\uace0\ubcf4\ub4dc": "plasterboard",  # \uc11d\uace0\ubcf4\ub4dc
+    "\uc11d\uace0": "plasterboard",               # \uc11d\uace0
+    "\ub0b4\uc7a5\uc7ac": "plasterboard",         # \ub0b4\uc7a5\uc7ac
+    "\uc720\ub9ac": "glass",      # \uc720\ub9ac
+    "\uae08\uc18d": "metal",      # \uae08\uc18d
+    "\ucca0": "metal",            # \ucca0
+    "\uac15\ucca0": "metal",      # \uac15\ucca0
+    "\uc54c\ub8e8\ubbf8\ub284": "metal",  # \uc54c\ub8e8\ubbf8\ub284
+    "\uc2a4\ud2f8": "metal",      # \uc2a4\ud2f8
+    "\ud50c\ub77c\uc2a4\ud2f1": "plastic",  # \ud50c\ub77c\uc2a4\ud2f1
 }
 
 

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -251,7 +251,7 @@ export function ApRecommendationCanvas({
       if (!ctm) return;
       const sp = pt.matrixTransform(ctm.inverse());
 
-      if (heatmapMode === 'measurement' && measurementHeatmap?.valuesDbm) {
+      if (heatmapMode === 'measurement' && measurementHeatmap?.valuesDbm && measurementHeatmap.bounds) {
         const { min_x, min_y, max_x, max_y } = measurementHeatmap.bounds;
         const rows = measurementHeatmap.valuesDbm.length;
         const cols = measurementHeatmap.valuesDbm[0]?.length ?? 0;
@@ -355,13 +355,13 @@ export function ApRecommendationCanvas({
             </g>
           )}
 
-          {heatmapMode === 'measurement' && measurementHeatmap?.valuesDbm ? (
+          {heatmapMode === 'measurement' && measurementHeatmap?.valuesDbm && measurementHeatmap.bounds ? (
             <g opacity={0.65} pointerEvents="none">
               {measurementHeatmap.valuesDbm.map((row, rowIdx) =>
                 row.map((value, colIdx) => {
                   const rows = measurementHeatmap.valuesDbm?.length ?? 1;
                   const cols = row.length || 1;
-                  const bounds = measurementHeatmap.bounds;
+                  const bounds = measurementHeatmap.bounds!;
                   const cellW = (bounds.max_x - bounds.min_x) / cols;
                   const cellH = (bounds.max_y - bounds.min_y) / rows;
                   const range = measurementHeatmap.rssiRange ?? { min: -90, max: -30 };
@@ -378,7 +378,7 @@ export function ApRecommendationCanvas({
                 }),
               )}
             </g>
-          ) : heatmapMode === 'measurement' && measurementHeatmap?.url && (
+          ) : heatmapMode === 'measurement' && measurementHeatmap?.url && measurementHeatmap.bounds && (
             <image
               href={measurementHeatmap.url}
               xlinkHref={measurementHeatmap.url}

--- a/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
+++ b/frontend/src/features/ap-recommendation/ApRecommendationCanvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { parseGeometry, type Coord } from '@/features/editor/geometry-utils';
 import {
   deriveImageExtent,
@@ -8,6 +8,7 @@ import type { ApRecommendationResult } from '@/types/ap-recommendation';
 import type { DraftObject, DraftOpening, DraftWall, SceneVersion } from '@/types/scene';
 import { cn } from '@/lib/utils';
 import { dbmToHeatmapColor } from '@/lib/rssi-colormap';
+import { DbmColorBar } from '@/features/simulation/DbmColorBar';
 import {
   clampCoord,
   clampMeterBBox,
@@ -137,6 +138,7 @@ export function ApRecommendationCanvas({
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [drag, setDrag] = useState<{ start: Coord; current: Coord } | null>(null);
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; dbm: number } | null>(null);
 
   const imageDims = useImageNaturalDimensions(backgroundImageUrl ?? null);
   const imageExtent = useMemo(
@@ -238,6 +240,58 @@ export function ApRecommendationCanvas({
     onAreasChange(selectedAreas.filter((area) => area.id !== id));
   };
 
+  const handleSvgMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      const svg = svgRef.current;
+      if (!svg) return;
+      const pt = svg.createSVGPoint();
+      pt.x = e.clientX;
+      pt.y = e.clientY;
+      const ctm = svg.getScreenCTM();
+      if (!ctm) return;
+      const sp = pt.matrixTransform(ctm.inverse());
+
+      if (heatmapMode === 'measurement' && measurementHeatmap?.valuesDbm) {
+        const { min_x, min_y, max_x, max_y } = measurementHeatmap.bounds;
+        const rows = measurementHeatmap.valuesDbm.length;
+        const cols = measurementHeatmap.valuesDbm[0]?.length ?? 0;
+        if (rows > 0 && cols > 0) {
+          const cellW = (max_x - min_x) / cols;
+          const cellH = (max_y - min_y) / rows;
+          const col = Math.floor((sp.x - min_x) / cellW);
+          const row = Math.floor((sp.y - min_y) / cellH);
+          if (row >= 0 && row < rows && col >= 0 && col < cols) {
+            const dbm = measurementHeatmap.valuesDbm[row][col];
+            if (dbm != null && Number.isFinite(dbm)) {
+              setTooltip({ x: e.clientX, y: e.clientY, dbm });
+              return;
+            }
+          }
+        }
+      } else if (heatmapMode === 'prediction' && predictionCells) {
+        const half = Math.max(predictionCells.cellW, predictionCells.cellH) * 0.6;
+        let best: { dist: number; dbm: number } | null = null;
+        for (const pt2 of predictionCells.points) {
+          if (Math.abs(pt2.x - sp.x) < half && Math.abs(pt2.y - sp.y) < half) {
+            const dist = Math.hypot(pt2.x - sp.x, pt2.y - sp.y);
+            if (!best || dist < best.dist) best = { dist, dbm: pt2.rssi_dbm };
+          }
+        }
+        if (best) { setTooltip({ x: e.clientX, y: e.clientY, dbm: best.dbm }); return; }
+      }
+      setTooltip(null);
+    },
+    [heatmapMode, measurementHeatmap, predictionCells],
+  );
+
+  const heatmapRssiRange = heatmapMode === 'measurement'
+    ? (measurementHeatmap?.rssiRange ?? null)
+    : predictionCells?.range ?? null;
+  const showLegend = heatmapRssiRange !== null && (
+    (heatmapMode === 'measurement' && !!measurementHeatmap) ||
+    (heatmapMode === 'prediction' && !!predictionCells)
+  );
+
   return (
     <div className="relative h-full w-full overflow-hidden bg-[#f8fafc] [background-image:radial-gradient(circle,oklch(0.92_0_0)_1px,transparent_1px)] bg-size-[18px_18px] bg-position-[0_0]">
       <svg
@@ -253,6 +307,8 @@ export function ApRecommendationCanvas({
         onPointerMove={handlePointerMove}
         onPointerUp={finishDrag}
         onPointerCancel={finishDrag}
+        onMouseMove={handleSvgMouseMove}
+        onMouseLeave={() => setTooltip(null)}
       >
         <defs>
           <clipPath id="ap-rec-scene-clip">
@@ -449,6 +505,28 @@ export function ApRecommendationCanvas({
           )}
         </g>
       </svg>
+
+      {/* 색 범례 — 히트맵이 보일 때만 표시 */}
+      {showLegend && heatmapRssiRange && (
+        <div className="pointer-events-none absolute left-2 top-2 z-10 w-52">
+          <DbmColorBar
+            vmin={heatmapRssiRange.min}
+            vmax={heatmapRssiRange.max}
+            label={heatmapMode === 'measurement' ? '실측/보정 RSSI' : '예측 RSSI'}
+            className="pointer-events-auto"
+          />
+        </div>
+      )}
+
+      {/* 마우스 호버 툴팁 */}
+      {tooltip && (
+        <div
+          className="pointer-events-none fixed z-50 rounded-md bg-slate-800/90 px-2 py-1 text-[11px] font-medium text-white shadow-lg"
+          style={{ left: tooltip.x + 14, top: tooltip.y - 28 }}
+        >
+          {tooltip.dbm.toFixed(1)} dBm
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/ap-recommendation/recommendation-utils.ts
+++ b/frontend/src/features/ap-recommendation/recommendation-utils.ts
@@ -5,6 +5,7 @@ import type {
   ApRecommendationResult,
   ApRecommendationRun,
 } from '@/types/ap-recommendation';
+import type { PhysicalAp, WifiBand } from '@/types/rf';
 import type { UUID } from '@/types/common';
 import { parseGeometry } from '@/features/editor/geometry-utils';
 import { CANVAS_BLUE } from '@/lib/canvas-scene-colors';
@@ -87,6 +88,8 @@ export function unionMeterBBoxes(bboxes: MeterBBox[]): MeterBBox | null {
   };
 }
 
+export type RecommendationMode = 'add' | 'replace' | 'relocate_all' | 'relocate_selected';
+
 /** POST /ap-recommendation 요청 본문 조립 (백엔드 default 필드는 생략). */
 export function buildApRecommendationPayload(params: {
   sceneVersionId: UUID;
@@ -95,6 +98,20 @@ export function buildApRecommendationPayload(params: {
   existingAps: { id: string; x_m: number; y_m: number }[];
   txPowerDbm?: number;
   nAps?: number;
+  /** Physical AP 구조. 있으면 existing_aps 보다 우선 처리. */
+  physicalAps?: PhysicalAp[];
+  targetBands?: WifiBand[];
+  combinePolicy?: 'max' | 'prefer_5g_then_2g' | 'weighted';
+  /** 추천 모드. 기본값: 'add'. */
+  recommendationMode?: RecommendationMode;
+  /** replace 모드: 교체할 AP ID 목록. */
+  replaceTargetApIds?: string[];
+  /** relocate_selected 모드: 고정 AP ID 목록. */
+  fixedApIds?: string[];
+  /** relocate_selected 모드: 재배치할 AP ID 목록. */
+  relocateTargetApIds?: string[];
+  /** relocate_all 모드: 새 레이아웃에서 AP 총 개수. */
+  targetTotalAps?: number;
 }): ApRecommendationRequest {
   const areas = validRecommendationAreas(params.areas);
   const legacyBboxes = validSelectionBBoxes(params.bboxes);
@@ -123,6 +140,7 @@ export function buildApRecommendationPayload(params: {
   if (candidateBBoxes.length === 0) {
     throw new Error('At least one installable candidate area is required.');
   }
+  const mode = params.recommendationMode ?? 'add';
   const request: ApRecommendationRequest = {
     scene_version_id: params.sceneVersionId,
     candidate_bboxes: candidateBBoxes,
@@ -134,6 +152,29 @@ export function buildApRecommendationPayload(params: {
     candidate_tx_power_dbm: params.txPowerDbm,
     existing_aps: mapToExistingAps(params.existingAps, params.txPowerDbm),
     ...(params.nAps && params.nAps > 1 ? { n_aps: params.nAps } : {}),
+    // Physical AP 구조 — 있으면 포함.
+    ...(params.physicalAps && params.physicalAps.length > 0
+      ? {
+          physical_aps: params.physicalAps,
+          recommendation_unit: 'physical_ap' as const,
+          target_bands: params.targetBands ?? ['5G'],
+          combine_policy: params.combinePolicy ?? 'prefer_5g_then_2g',
+        }
+      : {}),
+    // 추천 모드.
+    ...(mode !== 'add' ? { recommendation_mode: mode } : {}),
+    ...(mode === 'replace' && params.replaceTargetApIds?.length
+      ? { replace_target_ap_ids: params.replaceTargetApIds }
+      : {}),
+    ...(mode === 'relocate_selected' && params.relocateTargetApIds?.length
+      ? { relocate_target_ap_ids: params.relocateTargetApIds }
+      : {}),
+    ...(mode === 'relocate_selected' && params.fixedApIds?.length
+      ? { fixed_ap_ids: params.fixedApIds }
+      : {}),
+    ...(mode === 'relocate_all' && params.targetTotalAps != null
+      ? { target_total_aps: params.targetTotalAps }
+      : {}),
   };
   if (legacyUnion) {
     request.x_min = legacyUnion.x_min;

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -597,20 +597,46 @@ function shortId(id: string): string {
 
 /** Sionna 유효 재질 — DB 비어있을 때 fallback 으로도 사용. */
 const FALLBACK_MATERIALS = [
+  { code: 'wood', name: '목재' },
   { code: 'concrete', name: '콘크리트' },
+  { code: 'stone', name: '돌' },
   { code: 'brick', name: '벽돌' },
   { code: 'drywall', name: '석고보드' },
   { code: 'glass', name: '유리' },
-  { code: 'wood', name: '목재' },
   { code: 'metal', name: '금속' },
+  { code: 'plastic', name: '플라스틱' },
 ] as const;
 
 /** AI 추론이 반환하는 한국어 동의어 → material_code 매핑 (백엔드 MATERIAL_ALIASES 와 동기). */
 const KO_ALIASES: Record<string, string> = {
+  // wood
   '나무': 'wood',
+  '목재': 'wood',
   '합판': 'wood',
   '플라이우드': 'wood',
+  '원목': 'wood',
+  // concrete (대리석·시멘트·석재는 Sionna에 marble/stone 코드 없어 concrete 근사)
+  '콘크리트': 'concrete',
+  '시멘트': 'concrete',
+  '석재': 'concrete',
+  '돌': 'concrete',
   '대리석': 'concrete',
+  // brick
+  '벽돌': 'brick',
+  '적벽돌': 'brick',
+  // drywall
+  '석고보드': 'drywall',
+  '석고': 'drywall',
+  '내장재': 'drywall',
+  // glass
+  '유리': 'glass',
+  // metal
+  '금속': 'metal',
+  '철': 'metal',
+  '강철': 'metal',
+  '알루미늄': 'metal',
+  '스틸': 'metal',
+  // plastic
   '플라스틱': 'plastic',
 };
 
@@ -689,11 +715,7 @@ function MaterialSelect({
   sourceLabel?: string;
 }) {
   const codeValue = normalizeMaterialToCode(value, materials);
-  // DB 에 재질이 있으면 DB 기준, 없으면 fallback 사용
-  const options =
-    materials.length > 0
-      ? materials.map((m) => ({ code: m.material_code, name: m.material_name }))
-      : FALLBACK_MATERIALS.map((f) => ({ code: f.code, name: f.name }));
+  const options = FALLBACK_MATERIALS.map((f) => ({ code: f.code, name: f.name }));
   // 현재 값이 옵션에 없으면 추가 (레거시 데이터 대응)
   const hasCurrentCode = options.some((o) => o.code === codeValue);
   return (

--- a/frontend/src/features/editor/PropertiesPanel.tsx
+++ b/frontend/src/features/editor/PropertiesPanel.tsx
@@ -605,6 +605,15 @@ const FALLBACK_MATERIALS = [
   { code: 'metal', name: '금속' },
 ] as const;
 
+/** AI 추론이 반환하는 한국어 동의어 → material_code 매핑 (백엔드 MATERIAL_ALIASES 와 동기). */
+const KO_ALIASES: Record<string, string> = {
+  '나무': 'wood',
+  '합판': 'wood',
+  '플라이우드': 'wood',
+  '대리석': 'concrete',
+  '플라스틱': 'plastic',
+};
+
 /**
  * 다양한 형식(itu_ prefix, 한국어 이름, 영문 코드)의 재질 값을
  * material_code 로 정규화. `onChange` 가 항상 code 를 반환하도록.
@@ -618,6 +627,14 @@ function normalizeMaterialToCode(value: string, materials: Material[]): string {
   // DB name 매칭 (한국어)
   const byName = materials.find((m) => m.material_name === value);
   if (byName) return byName.material_code;
+  // 한국어 동의어 매핑 (AI 추론 반환값 대응)
+  const aliasCode = KO_ALIASES[value];
+  if (aliasCode) {
+    const byAlias = materials.find((m) => m.material_code === aliasCode);
+    if (byAlias) return byAlias.material_code;
+    const fbAlias = FALLBACK_MATERIALS.find((f) => f.code === aliasCode);
+    if (fbAlias) return fbAlias.code;
+  }
   // Fallback code/name 매칭
   const byFallback = FALLBACK_MATERIALS.find(
     (f) => f.code === stripped || f.name === value,

--- a/frontend/src/features/simulation/ApRadioPanel.tsx
+++ b/frontend/src/features/simulation/ApRadioPanel.tsx
@@ -1,0 +1,248 @@
+/**
+ * AP Radio 설정 패널.
+ * SimulationCanvas 위에 absolute overlay 로 표시 — AP 라벨 클릭 시 열린다.
+ * key={ap.id} 로 마운트해야 AP 전환 시 state 가 올바르게 리셋된다.
+ */
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import type { PlacedAp } from './SimulationCanvas';
+import type { RadioInterface } from '@/types/rf';
+import {
+  channelToMhz,
+  mhzToChannel,
+  inferBandFromMhz,
+  get24GChannels,
+  get5GChannels,
+  DEFAULT_RADIO_5G,
+  DEFAULT_RADIO_24G,
+} from '@/lib/wifi-channel';
+import { cn } from '@/lib/utils';
+
+type RadioMode = '5g-only' | '2.4g-only' | 'dual';
+
+function modeFromRadios(radios: RadioInterface[]): RadioMode {
+  const has5G = radios.some((r) => r.band === '5G' && r.enabled);
+  const has24G = radios.some((r) => r.band === '2.4G' && r.enabled);
+  if (has5G && has24G) return 'dual';
+  if (has24G) return '2.4g-only';
+  return '5g-only';
+}
+
+function buildRadiosFromMode(
+  mode: RadioMode,
+  apId: string,
+  existing: RadioInterface[],
+): RadioInterface[] {
+  const existing5G = existing.find((r) => r.band === '5G');
+  const existing24G = existing.find((r) => r.band === '2.4G');
+
+  const radio5G: RadioInterface = existing5G ?? {
+    id: `${apId}-5g`,
+    ...DEFAULT_RADIO_5G,
+  };
+  const radio24G: RadioInterface = existing24G ?? {
+    id: `${apId}-2.4g`,
+    ...DEFAULT_RADIO_24G,
+  };
+
+  switch (mode) {
+    case '5g-only':
+      return [{ ...radio5G, enabled: true }, { ...radio24G, enabled: false }];
+    case '2.4g-only':
+      return [{ ...radio5G, enabled: false }, { ...radio24G, enabled: true }];
+    case 'dual':
+      return [{ ...radio5G, enabled: true }, { ...radio24G, enabled: true }];
+  }
+}
+
+interface RadioCardProps {
+  radio: RadioInterface;
+  onChange: (updated: RadioInterface) => void;
+}
+
+function RadioCard({ radio, onChange }: RadioCardProps) {
+  const channels = radio.band === '5G' ? get5GChannels() : get24GChannels();
+
+  const handleChannelChange = (ch: number) => {
+    const freq = channelToMhz(ch, radio.band);
+    onChange({ ...radio, channel: ch, frequency_mhz: freq ?? radio.frequency_mhz });
+  };
+
+  const handleFreqChange = (raw: string) => {
+    const mhz = parseInt(raw, 10);
+    if (!Number.isFinite(mhz)) return;
+    const ch = mhzToChannel(mhz);
+    const band = inferBandFromMhz(mhz);
+    onChange({
+      ...radio,
+      frequency_mhz: mhz,
+      channel: ch ?? radio.channel,
+      ...(band ? { band } : {}),
+    });
+  };
+
+  const freqOutOfRange =
+    radio.frequency_mhz != null &&
+    inferBandFromMhz(radio.frequency_mhz) !== radio.band;
+
+  return (
+    <div className={cn('rounded-lg border p-3 text-xs', radio.enabled ? 'border-slate-200 bg-white' : 'border-slate-100 bg-slate-50 opacity-60')}>
+      <div className="mb-2.5 flex items-center justify-between">
+        <span className={cn('inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-bold text-white', radio.band === '5G' ? 'bg-[oklch(0.55_0.16_145)]' : 'bg-[oklch(0.60_0.15_55)]')}>
+          {radio.band}
+        </span>
+        <label className="flex cursor-pointer items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={radio.enabled}
+            onChange={(e) => onChange({ ...radio, enabled: e.target.checked })}
+            className="h-3.5 w-3.5 rounded accent-blue-500"
+          />
+          <span className="text-[11px] text-slate-600">{radio.enabled ? '활성' : '비활성'}</span>
+        </label>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <label className="flex flex-col gap-0.5">
+          <span className="text-[10px] text-slate-500">채널</span>
+          <select
+            value={radio.channel ?? ''}
+            onChange={(e) => handleChannelChange(Number(e.target.value))}
+            disabled={!radio.enabled}
+            className="h-6 rounded border border-slate-200 bg-white px-1 text-[11px] text-slate-800 focus:border-blue-300 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="">—</option>
+            {channels.map((ch) => (
+              <option key={ch} value={ch}>{ch}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-[10px] text-slate-500">주파수 (MHz)</span>
+          <input
+            type="number"
+            value={radio.frequency_mhz ?? ''}
+            onChange={(e) => handleFreqChange(e.target.value)}
+            disabled={!radio.enabled}
+            className={cn(
+              'h-6 rounded border bg-white px-1.5 text-[11px] tabular-nums text-slate-800 [appearance:textfield] focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:appearance-none',
+              freqOutOfRange ? 'border-amber-400 focus:border-amber-400' : 'border-slate-200 focus:border-blue-300',
+            )}
+          />
+          {freqOutOfRange && (
+            <span className="text-[10px] text-amber-600">band와 불일치</span>
+          )}
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-[10px] text-slate-500">출력 (dBm)</span>
+          <input
+            type="number"
+            min={0}
+            max={30}
+            value={radio.tx_power_dbm ?? ''}
+            onChange={(e) => onChange({ ...radio, tx_power_dbm: Number(e.target.value) })}
+            disabled={!radio.enabled}
+            className="h-6 rounded border border-slate-200 bg-white px-1.5 text-[11px] tabular-nums text-slate-800 [appearance:textfield] focus:border-blue-300 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:appearance-none"
+          />
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-[10px] text-slate-500">SSID</span>
+          <input
+            type="text"
+            value={radio.ssid ?? ''}
+            onChange={(e) => onChange({ ...radio, ssid: e.target.value || undefined })}
+            disabled={!radio.enabled}
+            placeholder="(선택)"
+            className="h-6 rounded border border-slate-200 bg-white px-1.5 text-[11px] text-slate-800 placeholder:text-slate-300 focus:border-blue-300 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+interface ApRadioPanelProps {
+  ap: PlacedAp;
+  onUpdateRadios: (id: string, radios: RadioInterface[]) => void;
+  onClose: () => void;
+}
+
+export function ApRadioPanel({ ap, onUpdateRadios, onClose }: ApRadioPanelProps) {
+  const [radios, setRadios] = useState<RadioInterface[]>(() => {
+    if (ap.radios && ap.radios.length > 0) return ap.radios;
+    return [{ id: `${ap.id}-5g`, ...DEFAULT_RADIO_5G }];
+  });
+
+  const mode = modeFromRadios(radios);
+
+  const handleModeChange = (newMode: RadioMode) => {
+    const updated = buildRadiosFromMode(newMode, ap.id, radios);
+    setRadios(updated);
+    onUpdateRadios(ap.id, updated);
+  };
+
+  const handleRadioChange = (updated: RadioInterface) => {
+    const next = radios.map((r) => (r.id === updated.id ? updated : r));
+    setRadios(next);
+    onUpdateRadios(ap.id, next);
+  };
+
+  const modeBtnClass = (active: boolean) =>
+    cn(
+      'inline-flex h-7 items-center rounded-md px-2.5 text-[11px] transition-colors',
+      active ? 'bg-blue-50 font-semibold text-blue-700' : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900',
+    );
+
+  const visibleRadios = radios.filter((r) => r.band === '5G' || r.band === '2.4G');
+
+  return (
+    <div className="absolute right-2 top-2 z-20 w-64 rounded-xl border border-slate-200 bg-white shadow-lg">
+      {/* header */}
+      <div className="flex items-center justify-between border-b border-slate-100 px-3 py-2.5">
+        <div>
+          <span className="text-sm font-semibold text-slate-800">{ap.id.toUpperCase()}</span>
+          <span className="ml-2 text-[11px] text-slate-400">
+            ({ap.x_m.toFixed(2)}, {ap.y_m.toFixed(2)}) · z={ap.z_m.toFixed(1)}m
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          aria-label="닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* radio mode */}
+      <div className="border-b border-slate-100 px-3 py-2">
+        <p className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-slate-400">라디오 모드</p>
+        <div className="inline-flex items-center rounded-lg bg-slate-50 p-0.5">
+          <button type="button" className={modeBtnClass(mode === '5g-only')} onClick={() => handleModeChange('5g-only')}>5GHz</button>
+          <button type="button" className={modeBtnClass(mode === '2.4g-only')} onClick={() => handleModeChange('2.4g-only')}>2.4GHz</button>
+          <button type="button" className={modeBtnClass(mode === 'dual')} onClick={() => handleModeChange('dual')}>Dual</button>
+        </div>
+      </div>
+
+      {/* radio cards */}
+      <div className="space-y-2 p-3">
+        {visibleRadios
+          .sort((a) => (a.band === '5G' ? -1 : 1))
+          .map((radio) => (
+            <RadioCard key={radio.id} radio={radio} onChange={handleRadioChange} />
+          ))}
+      </div>
+
+      {/* RSSI semantics hint */}
+      <div className="border-t border-slate-100 px-3 py-2">
+        <p className="text-[10px] leading-relaxed text-slate-400">
+          커버리지는 여러 AP의 RSSI를 합산하지 않고 각 위치에서 가장 강한 AP값으로 평가합니다.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/simulation/SimulationCanvas.tsx
+++ b/frontend/src/features/simulation/SimulationCanvas.tsx
@@ -13,6 +13,7 @@ import type {
   DraftWall,
   SceneVersion,
 } from '@/types/scene';
+import type { RadioInterface } from '@/types/rf';
 import { cn } from '@/lib/utils';
 
 export interface PlacedAp {
@@ -20,6 +21,8 @@ export interface PlacedAp {
   x_m: number;
   y_m: number;
   z_m: number;
+  /** Radio interface 목록. 없으면 기본 5G 단일 radio 로 취급. */
+  radios?: RadioInterface[];
 }
 
 /** 모든 AP 에 공통 적용되는 출력 파워 (백엔드 simulation.tx_power_dbm 으로 보냄). */
@@ -47,6 +50,10 @@ interface Props {
   heatmapBounds?: { minX: number; minY: number; maxX: number; maxY: number } | null;
   /** true 면 AP 추가/드래그/삭제 모두 비활성화 — 결과 보기 전용. */
   readOnly?: boolean;
+  /** AP 라벨 클릭 시 호출 — radio 설정 패널 열기용. */
+  onApClick?: (id: string) => void;
+  /** 현재 선택된 AP id (패널 열림 표시용). */
+  selectedApId?: string | null;
 }
 
 interface Bounds {
@@ -128,9 +135,10 @@ export function SimulationCanvas({
   heatmapUrl,
   heatmapBounds,
   readOnly = false,
+  onApClick,
+  selectedApId,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const sceneId = sceneVersion?.id ?? null;
 
   // 배경 이미지를 editor 와 동일한 좌표계로 배치하기 위해 imageExtent (미터) 계산.
   // 있으면 image 는 (0,0)~(extent.w, extent.h) 에 그림 → 벽과 정확히 정렬.
@@ -311,8 +319,10 @@ export function SimulationCanvas({
             key={ap.id}
             ap={ap}
             isDragging={dragId === ap.id}
+            isSelected={selectedApId === ap.id}
             onPointerDown={(e) => handleApPointerDown(e, ap)}
             onRemove={() => onRemove(ap.id)}
+            onSettings={onApClick ? () => onApClick(ap.id) : undefined}
           />
         ))}
         </g>
@@ -485,21 +495,53 @@ function ObjectShape({ object }: { object: DraftObject }) {
 function ApMarker({
   ap,
   isDragging,
+  isSelected,
   onPointerDown,
   onRemove,
+  onSettings,
 }: {
   ap: PlacedAp;
   isDragging: boolean;
+  isSelected?: boolean;
   onPointerDown: (e: React.PointerEvent) => void;
   onRemove: () => void;
+  onSettings?: () => void;
 }) {
-  const fill = 'oklch(0.55 0.22 254)';
+  const fill = isSelected ? 'oklch(0.45 0.22 254)' : 'oklch(0.55 0.22 254)';
   const r = AP_MARKER_RADIUS_M;
-  // lucide Wifi 아이콘 (24x24 viewBox) 을 r 안에 들어갈 크기로 스케일.
-  const iconSize = r * 1.1; // 원 지름의 약 55%
+  const iconSize = r * 1.1;
   const iconScale = iconSize / 24;
+
+  // enabled radio의 band badge 목록.
+  const enabledBands = (ap.radios ?? []).filter((radio) => radio.enabled).map((radio) => radio.band);
+  const badgesToShow = enabledBands.length > 0 ? [...new Set(enabledBands)] : ['5G'];
+
+  const badgeW = r * 0.9;
+  const badgeH = r * 0.46;
+  const badgeGap = r * 0.08;
+  const totalBadgeW = badgesToShow.length * badgeW + (badgesToShow.length - 1) * badgeGap;
+  const badgeStartX = ap.x_m - totalBadgeW / 2;
+  const labelBoxY = ap.y_m + r + 0.04;
+  const labelBoxH = r * 0.75;
+  const badgeRowY = labelBoxY + labelBoxH + r * 0.06;
+
   return (
     <g className={isDragging ? 'cursor-grabbing' : 'cursor-grab'}>
+      {/* 선택 링 (패널 열림 표시) */}
+      {isSelected && (
+        <circle
+          cx={ap.x_m}
+          cy={ap.y_m}
+          r={r + 0.06}
+          fill="none"
+          stroke="oklch(0.55 0.22 254)"
+          strokeWidth="2"
+          strokeDasharray={`${r * 0.4} ${r * 0.2}`}
+          vectorEffect="non-scaling-stroke"
+          pointerEvents="none"
+          opacity={0.7}
+        />
+      )}
       <circle
         cx={ap.x_m}
         cy={ap.y_m}
@@ -507,7 +549,7 @@ function ApMarker({
         fill={fill}
         onPointerDown={onPointerDown}
       />
-      {/* lucide Wifi 아이콘 path 인라인 — 우측 "AP 추가" 패널과 동일 모양. */}
+      {/* lucide Wifi 아이콘 path 인라인 */}
       <g
         transform={`translate(${ap.x_m - iconSize / 2}, ${ap.y_m - iconSize / 2}) scale(${iconScale})`}
         pointerEvents="none"
@@ -522,33 +564,69 @@ function ApMarker({
         <path d="M5 12.859a10 10 0 0 1 14 0" />
         <path d="M8.5 16.429a5 5 0 0 1 7 0" />
       </g>
-      {/* 라벨 박스 */}
-      <g pointerEvents="none">
+      {/* 라벨 박스 — 클릭으로 radio 설정 패널 열기. */}
+      <g
+        onPointerDown={onSettings ? (e) => { e.stopPropagation(); onSettings(); } : undefined}
+        className={onSettings ? 'cursor-pointer' : ''}
+      >
         <rect
           x={ap.x_m - 0.18}
-          y={ap.y_m + r + 0.04}
+          y={labelBoxY}
           width={r * 1.8}
-          height={r * 0.75}
+          height={labelBoxH}
           rx={r * 0.18}
-          fill="white"
-          stroke="oklch(0.85 0.02 240)"
+          fill={isSelected ? 'oklch(0.94 0.05 254)' : 'white'}
+          stroke={isSelected ? 'oklch(0.65 0.18 254)' : 'oklch(0.85 0.02 240)'}
           strokeWidth="1"
           vectorEffect="non-scaling-stroke"
         />
         <text
           x={ap.x_m}
-          y={ap.y_m + r + r * 0.38}
+          y={labelBoxY + labelBoxH / 2}
           textAnchor="middle"
           dominantBaseline="middle"
           fontSize={AP_LABEL_FONT_SIZE_M}
           fontWeight="600"
           fill="oklch(0.25 0.04 240)"
+          pointerEvents="none"
           style={{ userSelect: 'none' }}
         >
           {ap.id.toUpperCase()}
         </text>
       </g>
-      {/* 삭제 버튼 — AP 크기에 맞춰 우측 상단에 충분히 크게 표시. */}
+      {/* Band badge 행 */}
+      <g pointerEvents="none">
+        {badgesToShow.map((band, i) => {
+          const bx = badgeStartX + i * (badgeW + badgeGap);
+          const by = badgeRowY;
+          const badgeFill = band === '5G' ? 'oklch(0.55 0.16 145)' : 'oklch(0.60 0.15 55)';
+          return (
+            <g key={band}>
+              <rect
+                x={bx}
+                y={by}
+                width={badgeW}
+                height={badgeH}
+                rx={badgeH * 0.4}
+                fill={badgeFill}
+              />
+              <text
+                x={bx + badgeW / 2}
+                y={by + badgeH / 2}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize={badgeH * 0.62}
+                fontWeight="700"
+                fill="white"
+                style={{ userSelect: 'none' }}
+              >
+                {band}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+      {/* 삭제 버튼 */}
       <g
         onPointerDown={(e) => {
           e.stopPropagation();

--- a/frontend/src/lib/wifi-channel.ts
+++ b/frontend/src/lib/wifi-channel.ts
@@ -1,0 +1,63 @@
+/**
+ * IEEE 802.11 channel ↔ frequency 매핑 + band 추론 헬퍼.
+ * 백엔드 physical_ap.py 의 mhz_to_channel / infer_band_from_mhz 와 동일 로직.
+ */
+
+export type WifiBand = '2.4G' | '5G';
+
+const CHANNEL_MHZ_24G: Record<number, number> = {
+  1: 2412, 2: 2417, 3: 2422, 4: 2427, 5: 2432,
+  6: 2437, 7: 2442, 8: 2447, 9: 2452, 10: 2457, 11: 2462,
+};
+
+const CHANNEL_MHZ_5G: Record<number, number> = {
+  36: 5180, 40: 5200, 44: 5220, 48: 5240,
+  149: 5745, 153: 5765, 157: 5785, 161: 5805,
+};
+
+const MHZ_CHANNEL_24G = Object.fromEntries(
+  Object.entries(CHANNEL_MHZ_24G).map(([c, m]) => [m, Number(c)]),
+) as Record<number, number>;
+
+const MHZ_CHANNEL_5G = Object.fromEntries(
+  Object.entries(CHANNEL_MHZ_5G).map(([c, m]) => [m, Number(c)]),
+) as Record<number, number>;
+
+export function inferBandFromMhz(mhz: number): WifiBand | null {
+  if (mhz >= 2400 && mhz <= 2500) return '2.4G';
+  if (mhz >= 4900 && mhz <= 5900) return '5G';
+  return null;
+}
+
+export function mhzToChannel(mhz: number): number | null {
+  return MHZ_CHANNEL_24G[mhz] ?? MHZ_CHANNEL_5G[mhz] ?? null;
+}
+
+export function channelToMhz(channel: number, band: WifiBand): number | null {
+  if (band === '2.4G') return CHANNEL_MHZ_24G[channel] ?? null;
+  return CHANNEL_MHZ_5G[channel] ?? null;
+}
+
+export function get24GChannels(): number[] {
+  return Object.keys(CHANNEL_MHZ_24G).map(Number).sort((a, b) => a - b);
+}
+
+export function get5GChannels(): number[] {
+  return Object.keys(CHANNEL_MHZ_5G).map(Number).sort((a, b) => a - b);
+}
+
+export const DEFAULT_RADIO_5G = {
+  band: '5G' as WifiBand,
+  frequency_mhz: 5180,
+  channel: 36,
+  tx_power_dbm: 20,
+  enabled: true,
+} as const;
+
+export const DEFAULT_RADIO_24G = {
+  band: '2.4G' as WifiBand,
+  frequency_mhz: 2437,
+  channel: 6,
+  tx_power_dbm: 18,
+  enabled: true,
+} as const;

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -155,6 +155,8 @@ export default function MobileAppPage() {
   const [verificationRank, setVerificationRank] = useState<number | null>(null);
   const [recommendationUpdatedAt, setRecommendationUpdatedAt] = useState<string | null>(null);
   const [pageError, setPageError] = useState<string | null>(null);
+  const [showSimComparison, setShowSimComparison] = useState(false);
+  const [simComparisonTab, setSimComparisonTab] = useState<'baseline' | 'verification'>('verification');
 
   const recommendMutation = useApRecommendation();
   const recommendationRunsQuery = useApRecommendationRuns(sceneVersionId, 10);
@@ -162,6 +164,7 @@ export default function MobileAppPage() {
   const createVerificationRun = useCreateRfRun(floorId, { page_size: 5 });
   const verificationPoll = useRfRun(verificationRunId);
   const verificationMapsQuery = useRfMaps(verificationRunId, verificationPoll.isSucceeded);
+  const baselineRunDetail = useRfRun(latestRfRunId);
   const measurementSessionsQuery = useFloorMeasurementSessions(floorId);
   const storedMeasurementView = useMemo(
     () => readStoredMeasurementView(floorId),
@@ -322,8 +325,24 @@ export default function MobileAppPage() {
   );
   const comparisonHeatmap = verificationCalibratedHeatmap ?? verificationHeatmap ?? measurementHeatmap;
   const showComparisonHeatmap = compareWithMeasurement && !!comparisonHeatmap;
+
+  const baselineHeatmap = useMemo(
+    () =>
+      extractRadioMapHeatmap(baselineRunDetail.rfRun?.metrics_json) ??
+      extractRadioMapHeatmap(latestRfRun?.metrics_json),
+    [baselineRunDetail.rfRun?.metrics_json, latestRfRun?.metrics_json],
+  );
+  const baselineCoverageMetrics = useMemo(
+    () => computeGridCoverageMetricsFromValues(baselineHeatmap?.valuesDbm),
+    [baselineHeatmap],
+  );
   const verificationMatchesSelection =
     selectedRecommendation != null && verificationRank === selectedRecommendation.rank;
+
+  const canvasHeatmap = showSimComparison && verificationMatchesSelection
+    ? (simComparisonTab === 'baseline' ? baselineHeatmap : (verificationCalibratedHeatmap ?? verificationHeatmap))
+    : showComparisonHeatmap ? comparisonHeatmap : null;
+  const useComparisonMode = (showSimComparison && verificationMatchesSelection) || showComparisonHeatmap;
 
   const persistRecommendationSession = (patch: Partial<ApRecommendationSession>) => {
     if (!sceneVersionId) return;
@@ -571,40 +590,27 @@ export default function MobileAppPage() {
     }
 
     const selected = selectedRecommendation;
-    const originalAccessPoints = existingAps.map((ap, index) => ({
-      id: `ap${index + 1}`,
-      label: ap.label ?? ap.id,
-      x_m: ap.x_m,
-      y_m: ap.y_m,
+
+    // 선택된 순위의 모든 AP 위치만 검증에 사용.
+    // 모드/고정AP 분기 없이 추천 배치 자체의 커버리지를 측정.
+    const positions =
+      selected.ap_positions && selected.ap_positions.length > 0
+        ? selected.ap_positions.map((p) => ({ x: p.x, y: p.y }))
+        : [{ x: selected.recommended_x, y: selected.recommended_y }];
+
+    const originalAccessPoints = positions.map((p, i) => ({
+      id: `recommended_${i + 1}`,
+      label: `추천${selected.rank} AP${i + 1}`,
+      x_m: p.x,
+      y_m: p.y,
       z_m: AP_DEFAULT_Z_M,
     }));
     const accessPoints = originalAccessPoints.map((ap) => ({
       id: ap.id,
       x_m: ap.x_m,
       y_m: ap.y_m,
-      z_m: AP_DEFAULT_Z_M,
+      z_m: ap.z_m,
     }));
-    const candidateAlreadyPresent = existingAps.some(
-      (ap) =>
-        Math.abs(ap.x_m - selected.recommended_x) < 0.05 &&
-        Math.abs(ap.y_m - selected.recommended_y) < 0.05,
-    );
-    if (!candidateAlreadyPresent) {
-      const id = `ap${accessPoints.length + 1}`;
-      originalAccessPoints.push({
-        id,
-        label: `recommended-${selected.rank}`,
-        x_m: selected.recommended_x,
-        y_m: selected.recommended_y,
-        z_m: AP_DEFAULT_Z_M,
-      });
-      accessPoints.push({
-        id,
-        x_m: selected.recommended_x,
-        y_m: selected.recommended_y,
-        z_m: AP_DEFAULT_Z_M,
-      });
-    }
 
     setPageError(null);
     createVerificationRun.mutate(
@@ -619,18 +625,13 @@ export default function MobileAppPage() {
           source: 'ap_recommendation_verification',
           recommendation_rank: selected.rank,
           recommendation_score: selected.score,
+          recommendation_mode: recommendMutation.data?.recommendation_mode ?? null,
           baseline_rf_run_id: latestRfRunId,
           comparison_measurement_session_ids: comparisonEvaluationSessionIds,
           comparison_ap_bssid: comparisonApBssid,
-          original_access_points: originalAccessPoints.map((ap) => ({
-            id: ap.id,
-            label: ap.label,
-            x_m: ap.x_m,
-            y_m: ap.y_m,
-            z_m: ap.z_m,
-          })),
+          original_access_points: originalAccessPoints,
         },
-        apply_calibration: false,
+        apply_calibration: true,
         backend: inferenceMode as RfBackend,
       },
       {
@@ -852,19 +853,49 @@ export default function MobileAppPage() {
             ) : !sceneVersionId ? (
               <EmptyState message="도면 정보를 불러올 수 없습니다." />
             ) : (
-              <ApRecommendationCanvas
-                sceneVersion={versionDetail}
-                backgroundImageUrl={backgroundImageUrl}
-                existingAps={existingAps}
-                selectedAreas={selectedAreas}
-                activeAreaType={activeAreaType}
-                onAreasChange={handleAreasChange}
-                recommendations={recommendations}
-                selectedRecommendationRank={selectedRank}
-                heatmapMode={showComparisonHeatmap ? 'measurement' : 'prediction'}
-                measurementHeatmap={comparisonHeatmap}
-                disabled={recommendMutation.isPending || createLayout.isPending}
-              />
+              <>
+                {showSimComparison && verificationMatchesSelection && (
+                  <div className="absolute left-1/2 top-2 z-10 flex -translate-x-1/2 overflow-hidden rounded-lg border border-[#D8E3F0] bg-white shadow-sm">
+                    <button
+                      type="button"
+                      onClick={() => setSimComparisonTab('baseline')}
+                      className={cn(
+                        'px-4 py-1.5 text-xs font-semibold transition-colors',
+                        simComparisonTab === 'baseline'
+                          ? 'bg-slate-700 text-white'
+                          : 'text-slate-500 hover:bg-muted/60',
+                      )}
+                    >
+                      기존 시뮬
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setSimComparisonTab('verification')}
+                      className={cn(
+                        'px-4 py-1.5 text-xs font-semibold transition-colors',
+                        simComparisonTab === 'verification'
+                          ? 'bg-blue-600 text-white'
+                          : 'text-slate-500 hover:bg-muted/60',
+                      )}
+                    >
+                      추천 검증
+                    </button>
+                  </div>
+                )}
+                <ApRecommendationCanvas
+                  sceneVersion={versionDetail}
+                  backgroundImageUrl={backgroundImageUrl}
+                  existingAps={existingAps}
+                  selectedAreas={selectedAreas}
+                  activeAreaType={activeAreaType}
+                  onAreasChange={handleAreasChange}
+                  recommendations={recommendations}
+                  selectedRecommendationRank={selectedRank}
+                  heatmapMode={useComparisonMode ? 'measurement' : 'prediction'}
+                  measurementHeatmap={canvasHeatmap}
+                  disabled={recommendMutation.isPending || createLayout.isPending}
+                />
+              </>
             )}
           </div>
 
@@ -977,7 +1008,31 @@ export default function MobileAppPage() {
                   polling={verificationMatchesSelection && verificationPoll.isPolling}
                   canVerify={!!selectedRecommendation && !!sceneVersionId}
                   onVerify={handleVerifyRecommendation}
+                  canCompare={verificationMatchesSelection && verificationPoll.isSucceeded}
+                  showComparison={showSimComparison}
+                  onCompare={() => {
+                    setShowSimComparison((v) => !v);
+                    setSimComparisonTab('verification');
+                  }}
                 />
+                {showSimComparison && verificationMatchesSelection && (
+                  <SimComparisonCard
+                    baselineCoverage={
+                      baselineCoverageMetrics ??
+                      extractRunCoverageMetrics(baselineRunDetail.rfRun?.metrics_json) ??
+                      extractRunCoverageMetrics(latestRfRun?.metrics_json)
+                    }
+                    verificationCoverage={
+                      verificationCalibratedCoverageMetrics ??
+                      verificationCoverageMetrics ??
+                      extractRunCoverageMetrics(verificationPoll.rfRun?.metrics_json)
+                    }
+                    hasBaselineHeatmap={!!baselineHeatmap}
+                    hasVerificationHeatmap={!!(verificationCalibratedHeatmap ?? verificationHeatmap)}
+                    simComparisonTab={simComparisonTab}
+                    onTabChange={setSimComparisonTab}
+                  />
+                )}
                 {recommendations.map((rec) => (
                   <RecommendationCard
                     key={rec.rank}
@@ -1168,6 +1223,34 @@ function computeGridCoverageMetrics(
   return computeGridCoverageMetricsFromValues(evaluation?.maps.calibrated.values_dbm);
 }
 
+function extractRunCoverageMetrics(
+  metricsJson: Record<string, unknown> | null | undefined,
+): GridCoverageMetrics | null {
+  if (!metricsJson) return null;
+  const radioMap = metricsJson['radio_map'];
+  if (!radioMap || typeof radioMap !== 'object') return null;
+  const rm = radioMap as Record<string, unknown>;
+  // coverage_summary 에서 직접 추출 (values_dbm 불필요)
+  const cs = rm['coverage_summary'];
+  if (cs && typeof cs === 'object') {
+    const obj = cs as Record<string, unknown>;
+    const ratio = Number(obj['coverage_ratio'] ?? obj['coverage_fraction']);
+    const avg = Number(obj['avg_rssi_dbm'] ?? obj['mean_rssi_dbm'] ?? obj['average_rssi_dbm']);
+    const bot = Number(obj['p10_rssi_dbm'] ?? obj['bottom_10_percent_rssi_dbm'] ?? obj['p10_dbm']);
+    if (Number.isFinite(ratio)) {
+      return {
+        coverage_threshold_dbm: COVERAGE_THRESHOLD_DBM,
+        coverage_ratio: ratio,
+        coverage_score: ratio,
+        average_rssi_dbm: Number.isFinite(avg) ? avg : null,
+        bottom_10_percent_rssi_dbm: Number.isFinite(bot) ? bot : null,
+      };
+    }
+  }
+  // fallback: values_dbm 에서 계산
+  return computeGridCoverageMetricsFromValues(coerceNumberGrid(rm['values_dbm']));
+}
+
 function computeGridCoverageMetricsFromValues(
   values: number[][] | null | undefined,
 ): GridCoverageMetrics | null {
@@ -1344,6 +1427,9 @@ function SionnaVerificationCard({
   polling,
   canVerify,
   onVerify,
+  canCompare,
+  showComparison,
+  onCompare,
 }: {
   recommendation: ApRecommendationResult | null;
   integratedCoverage: GridCoverageMetrics | null;
@@ -1355,6 +1441,9 @@ function SionnaVerificationCard({
   polling: boolean;
   canVerify: boolean;
   onVerify: () => void;
+  canCompare: boolean;
+  showComparison: boolean;
+  onCompare: () => void;
 }) {
   const predictionCoverage = recommendation?.coverage_ratio ?? recommendation?.coverage_score ?? null;
   const sionnaRatio = sionnaCoverage?.coverage_ratio ?? sionnaCoverage?.coverage_score ?? null;
@@ -1381,17 +1470,18 @@ function SionnaVerificationCard({
         )}
       </div>
 
-      <button
-        type="button"
-        onClick={onVerify}
-        disabled={!canVerify || isBusy}
-        className={cn(
-          'mt-3 w-full rounded-lg border py-2.5 text-sm font-medium transition-colors',
-          canVerify && !isBusy
-            ? 'border-blue-500 bg-blue-600 text-white hover:bg-blue-700'
-            : 'cursor-not-allowed border-[#E5EAF2] bg-muted text-muted-foreground',
-        )}
-      >
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={onVerify}
+          disabled={!canVerify || isBusy}
+          className={cn(
+            'flex-1 rounded-lg border py-2.5 text-sm font-medium transition-colors',
+            canVerify && !isBusy
+              ? 'border-blue-500 bg-blue-600 text-white hover:bg-blue-700'
+              : 'cursor-not-allowed border-[#E5EAF2] bg-muted text-muted-foreground',
+          )}
+        >
         {starting ? (
           <span className="inline-flex items-center justify-center gap-1.5">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -1405,7 +1495,22 @@ function SionnaVerificationCard({
         ) : (
           '선택 후보 Sionna 검증'
         )}
-      </button>
+        </button>
+        {canCompare && (
+          <button
+            type="button"
+            onClick={onCompare}
+            className={cn(
+              'rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors',
+              showComparison
+                ? 'border-emerald-400 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                : 'border-[#D8E3F0] bg-white text-slate-600 hover:bg-muted/60',
+            )}
+          >
+            {showComparison ? '비교 종료' : '비교하기'}
+          </button>
+        )}
+      </div>
 
       <div className="mt-3 grid grid-cols-2 gap-2">
         <MetricTile label="간이 예측 커버리지" value={formatCoveragePercent(predictionCoverage)} />
@@ -1419,6 +1524,148 @@ function SionnaVerificationCard({
         <MetricTile label="실행 상태" value={runStatus ?? '-'} />
       </div>
     </section>
+  );
+}
+
+function SimComparisonCard({
+  baselineCoverage,
+  verificationCoverage,
+  hasBaselineHeatmap,
+  hasVerificationHeatmap,
+  simComparisonTab,
+  onTabChange,
+}: {
+  baselineCoverage: GridCoverageMetrics | null;
+  verificationCoverage: GridCoverageMetrics | null;
+  hasBaselineHeatmap: boolean;
+  hasVerificationHeatmap: boolean;
+  simComparisonTab: 'baseline' | 'verification';
+  onTabChange: (tab: 'baseline' | 'verification') => void;
+}) {
+  const bCov = baselineCoverage?.coverage_ratio ?? baselineCoverage?.coverage_score ?? null;
+  const vCov = verificationCoverage?.coverage_ratio ?? verificationCoverage?.coverage_score ?? null;
+  const covDelta = bCov != null && vCov != null ? vCov - bCov : null;
+  const rssiDelta =
+    baselineCoverage?.average_rssi_dbm != null && verificationCoverage?.average_rssi_dbm != null
+      ? verificationCoverage.average_rssi_dbm - baselineCoverage.average_rssi_dbm
+      : null;
+  const botDelta =
+    baselineCoverage?.bottom_10_percent_rssi_dbm != null &&
+    verificationCoverage?.bottom_10_percent_rssi_dbm != null
+      ? verificationCoverage.bottom_10_percent_rssi_dbm - baselineCoverage.bottom_10_percent_rssi_dbm
+      : null;
+
+  return (
+    <section className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+      <h3 className="text-sm font-bold text-emerald-800">기존 시뮬 vs 추천 검증 비교</h3>
+      <p className="mt-0.5 text-[11px] text-emerald-700">
+        좌측 지도 탭으로 기존/추천 맵을 전환하세요.
+      </p>
+
+      <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+        <div className="text-[10px] font-semibold text-muted-foreground" />
+        <div className="text-[10px] font-semibold text-slate-600">기존 시뮬</div>
+        <div className="text-[10px] font-semibold text-blue-600">추천 검증</div>
+
+        <div className="rounded-lg bg-white px-2 py-2 text-[10px] font-medium text-muted-foreground">커버리지</div>
+        <div className={cn('rounded-lg px-2 py-2 text-sm font-bold', simComparisonTab === 'baseline' ? 'bg-slate-100 text-slate-800' : 'bg-white text-slate-600')}>
+          {formatCoveragePercent(bCov)}
+        </div>
+        <div className={cn('rounded-lg px-2 py-2 text-sm font-bold', simComparisonTab === 'verification' ? 'bg-blue-100 text-blue-800' : 'bg-white text-blue-600')}>
+          {formatCoveragePercent(vCov)}
+        </div>
+
+        <div className="rounded-lg bg-white px-2 py-2 text-[10px] font-medium text-muted-foreground">평균 RSSI</div>
+        <div className={cn('rounded-lg px-2 py-2 text-sm font-bold', simComparisonTab === 'baseline' ? 'bg-slate-100 text-slate-800' : 'bg-white text-slate-600')}>
+          {formatDbm(baselineCoverage?.average_rssi_dbm)}
+        </div>
+        <div className={cn('rounded-lg px-2 py-2 text-sm font-bold', simComparisonTab === 'verification' ? 'bg-blue-100 text-blue-800' : 'bg-white text-blue-600')}>
+          {formatDbm(verificationCoverage?.average_rssi_dbm)}
+        </div>
+
+        <div className="rounded-lg bg-white px-2 py-2 text-[10px] font-medium text-muted-foreground">하위 10%</div>
+        <div className={cn('rounded-lg px-2 py-2 text-sm font-bold', simComparisonTab === 'baseline' ? 'bg-slate-100 text-slate-800' : 'bg-white text-slate-600')}>
+          {formatDbm(baselineCoverage?.bottom_10_percent_rssi_dbm)}
+        </div>
+        <div className={cn('rounded-lg px-2 py-2 text-sm font-bold', simComparisonTab === 'verification' ? 'bg-blue-100 text-blue-800' : 'bg-white text-blue-600')}>
+          {formatDbm(verificationCoverage?.bottom_10_percent_rssi_dbm)}
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-3 gap-2">
+        <DeltaTile label="커버리지 변화" delta={covDelta} isRatio />
+        <DeltaTile label="평균 RSSI 변화" delta={rssiDelta} unit="dBm" />
+        <DeltaTile label="하위 10% 변화" delta={botDelta} unit="dBm" />
+      </div>
+
+      {(hasBaselineHeatmap || hasVerificationHeatmap) && (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            disabled={!hasBaselineHeatmap}
+            onClick={() => onTabChange('baseline')}
+            className={cn(
+              'flex-1 rounded-md border py-1.5 text-xs font-medium transition-colors',
+              simComparisonTab === 'baseline'
+                ? 'border-slate-400 bg-slate-700 text-white'
+                : hasBaselineHeatmap
+                  ? 'border-[#D8E3F0] bg-white text-slate-500 hover:bg-muted/60'
+                  : 'cursor-not-allowed border-[#E5EAF2] bg-muted text-muted-foreground/50',
+            )}
+          >
+            기존 시뮬 보기
+          </button>
+          <button
+            type="button"
+            disabled={!hasVerificationHeatmap}
+            onClick={() => onTabChange('verification')}
+            className={cn(
+              'flex-1 rounded-md border py-1.5 text-xs font-medium transition-colors',
+              simComparisonTab === 'verification'
+                ? 'border-blue-500 bg-blue-600 text-white'
+                : hasVerificationHeatmap
+                  ? 'border-[#D8E3F0] bg-white text-slate-500 hover:bg-muted/60'
+                  : 'cursor-not-allowed border-[#E5EAF2] bg-muted text-muted-foreground/50',
+            )}
+          >
+            추천 검증 보기
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DeltaTile({
+  label,
+  delta,
+  isRatio,
+  unit,
+}: {
+  label: string;
+  delta: number | null;
+  isRatio?: boolean;
+  unit?: string;
+}) {
+  if (delta == null || !Number.isFinite(delta)) {
+    return (
+      <div className="rounded-lg bg-white px-2 py-2 text-center">
+        <p className="text-[10px] text-muted-foreground">{label}</p>
+        <p className="mt-0.5 text-sm font-bold text-foreground">-</p>
+      </div>
+    );
+  }
+  const positive = delta > 0;
+  const display = isRatio
+    ? `${positive ? '+' : ''}${(delta * 100).toFixed(1)}%`
+    : `${positive ? '+' : ''}${delta.toFixed(1)}${unit ?? ''}`;
+  return (
+    <div className="rounded-lg bg-white px-2 py-2 text-center">
+      <p className="text-[10px] text-muted-foreground">{label}</p>
+      <p className={cn('mt-0.5 text-sm font-bold', positive ? 'text-emerald-600' : delta < 0 ? 'text-red-500' : 'text-foreground')}>
+        {display}
+      </p>
+    </div>
   );
 }
 

--- a/frontend/src/pages/MobileAppPage.tsx
+++ b/frontend/src/pages/MobileAppPage.tsx
@@ -35,6 +35,7 @@ import {
   validRecommendationAreas,
   type ApRecommendationArea,
   type ApRecommendationAreaType,
+  type RecommendationMode,
 } from '@/features/ap-recommendation/recommendation-utils';
 import type { ApRecommendationResult, ApRecommendationRun } from '@/types/ap-recommendation';
 import { cn } from '@/lib/utils';
@@ -145,6 +146,10 @@ export default function MobileAppPage() {
   const [selectedRank, setSelectedRank] = useState<number | null>(null);
   const [savedRank, setSavedRank] = useState<number | null>(null);
   const [nAps, setNAps] = useState(1);
+  const [recommendationMode, setRecommendationMode] = useState<RecommendationMode>('add');
+  const [replaceTargetApIds, setReplaceTargetApIds] = useState<string[]>([]);
+  const [relocateTargetApIds, setRelocateTargetApIds] = useState<string[]>([]);
+  const [targetTotalAps, setTargetTotalAps] = useState<number | null>(null);
   const [compareWithMeasurement, setCompareWithMeasurement] = useState(false);
   const [verificationRunId, setVerificationRunId] = useState<string | null>(null);
   const [verificationRank, setVerificationRank] = useState<number | null>(null);
@@ -460,6 +465,10 @@ export default function MobileAppPage() {
       existingAps,
       txPowerDbm: DEFAULT_TX_POWER_DBM,
       nAps,
+      recommendationMode,
+      replaceTargetApIds: recommendationMode === 'replace' ? replaceTargetApIds : undefined,
+      relocateTargetApIds: recommendationMode === 'relocate_selected' ? relocateTargetApIds : undefined,
+      targetTotalAps: recommendationMode === 'relocate_all' ? (targetTotalAps ?? undefined) : undefined,
     });
 
     if (import.meta.env.DEV) {
@@ -665,6 +674,105 @@ export default function MobileAppPage() {
             </p>
           </div>
           <div className="flex shrink-0 flex-col items-stretch gap-1.5 sm:items-end">
+            {/* 추천 모드 */}
+            <div className="flex items-center gap-2 sm:justify-end">
+              <span className="text-[12px] text-slate-500">추천 모드</span>
+              <div className="inline-flex items-center rounded-lg bg-slate-100 p-0.5">
+                {(
+                  [
+                    { value: 'add', label: '추가' },
+                    { value: 'replace', label: '교체' },
+                    { value: 'relocate_all', label: '전체 재배치' },
+                    { value: 'relocate_selected', label: '선택 재배치' },
+                  ] as const
+                ).map(({ value, label }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setRecommendationMode(value)}
+                    className={cn(
+                      'inline-flex h-6 items-center rounded-md px-2 text-[11px] transition-colors',
+                      recommendationMode === value
+                        ? 'bg-white font-semibold text-blue-700 shadow-sm'
+                        : 'text-slate-500 hover:text-slate-800',
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* 모드별 부가 입력 */}
+            {recommendationMode === 'replace' && (
+              <div className="flex items-center gap-2 sm:justify-end">
+                <span className="text-[12px] text-slate-500">교체할 AP</span>
+                <select
+                  multiple
+                  value={replaceTargetApIds}
+                  onChange={(e) =>
+                    setReplaceTargetApIds(
+                      Array.from(e.target.selectedOptions, (o) => o.value),
+                    )
+                  }
+                  className="h-20 min-w-[120px] rounded border border-slate-200 bg-white px-1.5 py-1 text-[11px] text-slate-800 focus:border-blue-300 focus:outline-none"
+                >
+                  {existingAps.map((ap) => (
+                    <option key={ap.id} value={ap.id}>
+                      {ap.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {recommendationMode === 'relocate_selected' && (
+              <div className="flex items-center gap-2 sm:justify-end">
+                <span className="text-[12px] text-slate-500">재배치할 AP</span>
+                <select
+                  multiple
+                  value={relocateTargetApIds}
+                  onChange={(e) =>
+                    setRelocateTargetApIds(
+                      Array.from(e.target.selectedOptions, (o) => o.value),
+                    )
+                  }
+                  className="h-20 min-w-[120px] rounded border border-slate-200 bg-white px-1.5 py-1 text-[11px] text-slate-800 focus:border-blue-300 focus:outline-none"
+                >
+                  {existingAps.map((ap) => (
+                    <option key={ap.id} value={ap.id}>
+                      {ap.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {recommendationMode === 'relocate_all' && (
+              <div className="flex items-center gap-2 sm:justify-end">
+                <span className="text-[12px] text-slate-500">새 AP 총 개수</span>
+                <div className="flex gap-1">
+                  {[1, 2, 3, 4, 5].map((n) => (
+                    <button
+                      key={n}
+                      type="button"
+                      onClick={() => setTargetTotalAps(n)}
+                      className={cn(
+                        'h-7 w-7 rounded-md text-[12px] font-semibold transition-colors',
+                        (targetTotalAps ?? existingAps.length) === n
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                      )}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* add / replace 모드에서는 설치 개수 선택 유지 */}
+            {(recommendationMode === 'add' || recommendationMode === 'replace') && (
             <div className="flex items-center gap-2 sm:justify-end">
               <span className="text-[12px] text-slate-500">설치할 공유기 수</span>
               <div className="flex gap-1">
@@ -685,6 +793,7 @@ export default function MobileAppPage() {
                 ))}
               </div>
             </div>
+            )}
             <button
               type="button"
               onClick={handleRecommend}

--- a/frontend/src/pages/SimulationPage.tsx
+++ b/frontend/src/pages/SimulationPage.tsx
@@ -36,23 +36,44 @@ import {
   SimulationCanvas,
   type PlacedAp,
 } from '@/features/simulation/SimulationCanvas';
+import { ApRadioPanel } from '@/features/simulation/ApRadioPanel';
 import { extractColorScale } from '@/features/simulation/HeatmapColorLegend';
 import { DbmColorBar } from '@/features/simulation/DbmColorBar';
 import { FloorSpaceTypeSelector } from '@/features/floor/FloorSpaceTypeSelector';
 import { toast } from '@/stores/toast-store';
 import type { SceneVersion } from '@/types/scene';
 import type { ApCandidate, ApLayout } from '@/types/ap-layout';
-import type { RfBackend } from '@/types/rf';
+import type { RadioInterface, RfBackend, WifiBand } from '@/types/rf';
+import { DEFAULT_RADIO_5G } from '@/lib/wifi-channel';
 import { cn } from '@/lib/utils';
 import { nextApSequentialName } from '@/lib/ap-layout-naming';
 
 type SimulationState = 'idle' | 'running' | 'complete';
-type FrequencyBand = '2.4' | '5';
 
-const frequencyHzByBand: Record<FrequencyBand, number> = {
-  '2.4': 2.4e9,
-  '5': 5.0e9,
-};
+/** simBands[0] 를 simulation.frequency_hz 로 변환 (legacy compat). */
+function primaryFreqHz(bands: WifiBand[]): number {
+  return bands[0] === '2.4G' ? 2.4e9 : 5.0e9;
+}
+
+/** PlacedAp → physical_aps payload 항목. band 지정 시 해당 band의 enabled radio만 포함. */
+function toPhysicalApPayload(ap: PlacedAp, band?: WifiBand) {
+  const allEnabled: RadioInterface[] =
+    ap.radios && ap.radios.length > 0
+      ? ap.radios.filter((r) => r.enabled)
+      : [{ id: `${ap.id}-5g`, ...DEFAULT_RADIO_5G }];
+  const radios = band ? allEnabled.filter((r) => r.band === band) : allEnabled;
+  // band 필터 후 없으면 전체 enabled fallback (AP가 해당 band 라디오 미보유 시)
+  const finalRadios = radios.length > 0 ? radios : allEnabled;
+  return {
+    id: ap.id,
+    name: ap.id.toUpperCase(),
+    x: ap.x_m,
+    y: ap.y_m,
+    z: ap.z_m,
+    movable: true,
+    radios: finalRadios,
+  };
+}
 
 export default function SimulationPage() {
   const floorId = useAppStore((s) => s.selectedFloorId);
@@ -70,11 +91,13 @@ export default function SimulationPage() {
   // 사용자가 배치한 AP 목록 + 추가 모드(true 면 다음 클릭이 새 AP 추가).
   const [aps, setAps] = useState<PlacedAp[]>([]);
   const [pendingAdd, setPendingAdd] = useState(false);
+  // 선택된 AP id — radio 설정 패널 열림 관리.
+  const [selectedApId, setSelectedApId] = useState<string | null>(null);
 
   // 시뮬 실행 백엔드 토글 — local(기본, 로컬 ai_api) | sagemaker(클라우드).
-  // 로컬에서 분 단위로 결과 보는 게 dev 흐름이라 기본값을 local 로.
   const [backend, setBackend] = useState<RfBackend>('local');
-  const [frequencyBand, setFrequencyBand] = useState<FrequencyBand>('5');
+  // 시뮬 대상 band. 단일 5G | 단일 2.4G | dual.
+  const [simBands, setSimBands] = useState<WifiBand[]>(['5G']);
   const [txPowerDbm, setTxPowerDbm] = useState(20);
 
   // 층의 과거 RF Run 목록 (이력 카드 + 자동 복원용).
@@ -103,10 +126,19 @@ export default function SimulationPage() {
     setPickedRunId(id);
   };
 
+  // Dual 모드: 2.4GHz 전용 보조 run 추적.
+  const [secondaryRunId, setSecondaryRunId] = useState<string | null>(null);
+  // Dual 완료 후 어느 band 탭을 보여줄지.
+  const [bandTab, setBandTab] = useState<WifiBand>('5G');
+
+  const isDual = simBands.length > 1;
+
   const createRfRun = useCreateRfRun(floorId, { page_size: 20 });
   const deleteRfRun = useDeleteRfRun(floorId);
   const rfRunPoll = useRfRun(activeRunId);
   const rfMapsQuery = useRfMaps(activeRunId, rfRunPoll.isSucceeded);
+  const secondaryRunPoll = useRfRun(secondaryRunId);
+  const secondaryMapsQuery = useRfMaps(secondaryRunId, secondaryRunPoll.isSucceeded);
   const activeRunSceneVersionId = rfRunPoll.rfRun?.scene_version_id ?? null;
 
   const state: SimulationState = (() => {
@@ -136,27 +168,87 @@ export default function SimulationPage() {
     !!activeRunSceneVersionId &&
     activeRunSceneVersionId !== currentVersion.id;
 
-  // 활성 run(과거/자동복원 포함)의 AP 를 캔버스에 복원 — 결과 화면에 AP 마커가 보이도록.
-  // (aps state 는 사용자가 직접 찍은 것만 담기는데, 과거 run 을 불러올 땐 비어 있어 마커가 안 떴음)
+  // 활성 run(과거/자동복원 포함)의 AP 를 캔버스에 복원.
+  // physical_aps 우선, 없으면 access_points fallback.
   useEffect(() => {
     if (!activeRunId || !rfRunPoll.rfRun) return;
-    const aps_raw = (rfRunPoll.rfRun.request_json?.['access_points'] ?? []) as Array<
-      Record<string, unknown>
-    >;
-    if (!Array.isArray(aps_raw) || aps_raw.length === 0) return;
-    const restored: PlacedAp[] = aps_raw.map((a, i) => ({
-      id: String(a['id'] ?? `ap${i + 1}`),
-      x_m: Number(a['x_m'] ?? a['x'] ?? 0),
-      y_m: Number(a['y_m'] ?? a['y'] ?? 0),
-      z_m: Number(a['z_m'] ?? a['z'] ?? 2.5),
-    }));
-    setAps(restored);
-  }, [activeRunId, rfRunPoll.rfRun]);
+    const physRaw = (rfRunPoll.rfRun.request_json?.['physical_aps'] ?? []) as Array<Record<string, unknown>>;
+    const apsRaw = (rfRunPoll.rfRun.request_json?.['access_points'] ?? []) as Array<Record<string, unknown>>;
+    // setAps in effect: 서버 데이터 수신 후 동기화 — external state 반응이므로 의도된 패턴.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (Array.isArray(physRaw) && physRaw.length > 0) {
+      setAps(physRaw.map((a, i) => ({
+        id: String(a['id'] ?? `ap${i + 1}`),
+        x_m: Number(a['x'] ?? a['x_m'] ?? 0),
+        y_m: Number(a['y'] ?? a['y_m'] ?? 0),
+        z_m: Number(a['z'] ?? a['z_m'] ?? 2.5),
+        radios: Array.isArray(a['radios']) ? (a['radios'] as RadioInterface[]) : undefined,
+      })));
+    } else if (Array.isArray(apsRaw) && apsRaw.length > 0) {
+      setAps(apsRaw.map((a, i) => ({
+        id: String(a['id'] ?? `ap${i + 1}`),
+        x_m: Number(a['x_m'] ?? a['x'] ?? 0),
+        y_m: Number(a['y_m'] ?? a['y'] ?? 0),
+        z_m: Number(a['z_m'] ?? a['z'] ?? 2.5),
+      })));
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+  // rfRunPoll.rfRun?.id 만 의존 — run 내부 갱신마다 AP 덮어쓰기 방지.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeRunId, rfRunPoll.rfRun?.id]);
+
+  // Dual 동반 run 자동 복원 — 페이지 재진입 시 secondary가 날아가는 문제 해결.
+  // pastRuns는 created_at desc 정렬 → 2.4G run이 미세하게 늦게 생성돼 [0]에 올 수 있음.
+  // 따라서 5G primary 케이스와 2.4G primary 케이스를 모두 처리한다.
+  useEffect(() => {
+    if (secondaryRunId) return; // 이미 복원됨
+    if (!rfRunPoll.rfRun) return;
+
+    const getBandsFromRun = (r: { request_json?: Record<string, unknown> }): WifiBand[] | null => {
+      const meta = r.request_json?.['metadata'] as Record<string, unknown> | undefined;
+      const rfUi = meta?.['rf_physical_ui'] as Record<string, unknown> | undefined;
+      const bands = rfUi?.['sim_bands'] as WifiBand[] | undefined;
+      return bands && bands.length === 1 ? bands : null;
+    };
+
+    const primaryBands = getBandsFromRun(rfRunPoll.rfRun);
+    if (!primaryBands) return; // multi-band run이거나 metadata 없음 → Dual 아님
+
+    const primaryTime = new Date(rfRunPoll.rfRun.created_at).getTime();
+    const [wantedBand, primaryBand] = primaryBands[0] === '5G'
+      ? ['2.4G', '5G'] as const
+      : ['5G', '2.4G'] as const;
+
+    const companion = pastRuns.find((r) => {
+      if (r.id === activeRunId) return false;
+      if (r.status !== 'succeeded') return false;
+      if (r.scene_version_id !== rfRunPoll.rfRun!.scene_version_id) return false;
+      const rBands = getBandsFromRun(r as unknown as { request_json?: Record<string, unknown> });
+      if (!rBands || rBands[0] !== wantedBand) return false;
+      return Math.abs(new Date(r.created_at).getTime() - primaryTime) < 30_000;
+    });
+
+    if (!companion) return;
+
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (primaryBand === '5G') {
+      // 정상 케이스: 5G primary, 2.4G companion → secondary에 companion
+      setSecondaryRunId(companion.id);
+    } else {
+      // 역전 케이스: 2.4G가 auto-선택됨 → 5G companion을 primary로 교체
+      setActiveRunId(companion.id);
+      setSecondaryRunId(rfRunPoll.rfRun.id);
+    }
+    setSimBands(['5G', '2.4G']);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  // rfRunPoll.rfRun?.id + pastRuns 변경 시만 실행.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rfRunPoll.rfRun?.id, pastRuns]);
 
   const heatmapMap = useMemo(() => {
-    const maps = rfMapsQuery.data ?? [];
+    const maps = (isDual && bandTab === '2.4G' ? secondaryMapsQuery.data : rfMapsQuery.data) ?? [];
     return maps.find((m) => m.map_type === 'heatmap') ?? maps[0] ?? null;
-  }, [rfMapsQuery.data]);
+  }, [isDual, bandTab, rfMapsQuery.data, secondaryMapsQuery.data]);
   const heatmapSourceUrl = useMemo(() => {
     if (!heatmapMap) return null;
     if (heatmapMap.url) return heatmapMap.url;
@@ -183,35 +275,47 @@ export default function SimulationPage() {
       toast.info('공유기를 1개 이상 배치해주세요', '캔버스 우측의 "공유기 추가하기" 에서 종류를 선택하고 클릭하세요.');
       return;
     }
-    createRfRun.mutate(
-      {
+    // enabled radio가 하나도 없는 AP 경고.
+    const noRadioAps = aps.filter((ap) => {
+      if (!ap.radios || ap.radios.length === 0) return false;
+      return !ap.radios.some((r) => r.enabled);
+    });
+    if (noRadioAps.length > 0) {
+      toast.info(
+        '활성화된 radio가 없는 AP가 있습니다',
+        `${noRadioAps.map((a) => a.id.toUpperCase()).join(', ')} — 최소 1개 radio를 활성화해 주세요.`,
+      );
+      return;
+    }
+
+    const legacyAps = aps.map((ap) => ({ id: ap.id, x_m: ap.x_m, y_m: ap.y_m, z_m: ap.z_m }));
+
+    const makePayload = (bands: WifiBand[]) => {
+      const band = bands.length === 1 ? bands[0] : undefined;
+      const physicalAps = aps.map((ap) => toPhysicalApPayload(ap, band));
+      const freqHz = primaryFreqHz(bands);
+      return {
         scene_version_id: currentVersion.id,
         run_type: 'forward',
-        access_points: aps.map((ap) => ({
-          id: ap.id,
-          x_m: ap.x_m,
-          y_m: ap.y_m,
-          z_m: ap.z_m,
-        })),
-        // 모든 시뮬 파라미터는 backend `app/core/rf_defaults.py` 의 디폴트 사용 —
-        // 5GHz / 20dBm / max_depth=3 / samples=100k 등. UI 에서 사용자가 직접 정하는
-        // 값이 생기면 여기 채워 보내면 backend 가 우선 적용. 빈 `{}` 는 "new flow" 트리거.
-        simulation: {
-          frequency_hz: frequencyHzByBand[frequencyBand],
-          tx_power_dbm: txPowerDbm,
-        },
-        metadata: {
-          rf_physical_ui: {
-            frequency_band: frequencyBand,
-            frequency_hz: frequencyHzByBand[frequencyBand],
-            tx_power_dbm: txPowerDbm,
-          },
-        },
+        access_points: legacyAps,
+        physical_aps: physicalAps,
+        band_simulation: { bands },
+        simulation: { frequency_hz: freqHz, tx_power_dbm: txPowerDbm },
+        metadata: { rf_physical_ui: { sim_bands: bands, frequency_hz: freqHz, tx_power_dbm: txPowerDbm } },
         apply_calibration: false,
         backend,
-      },
-      { onSuccess: (data) => setActiveRunId(data.id) },
-    );
+      };
+    };
+
+    if (isDual) {
+      // Dual: 5GHz(primary) + 2.4GHz(secondary) 각각 별도 run.
+      setBandTab('5G');
+      setSecondaryRunId(null);
+      createRfRun.mutate(makePayload(['5G']), { onSuccess: (data) => setActiveRunId(data.id) });
+      createRfRun.mutate(makePayload(['2.4G']), { onSuccess: (data) => setSecondaryRunId(data.id) });
+    } else {
+      createRfRun.mutate(makePayload(simBands), { onSuccess: (data) => setActiveRunId(data.id) });
+    }
   };
 
   const handleReset = () => {
@@ -221,14 +325,30 @@ export default function SimulationPage() {
       activeRunSceneVersionId !== currentVersion?.id;
     setPickedRunId(null);
     setResetCleared(true);
+    setSecondaryRunId(null);
+    setBandTab('5G');
+    setSelectedApId(null);
     if (wasHistorical) setAps([]);
   };
 
-  const handleAddAp = (ap: PlacedAp) => setAps((prev) => [...prev, ap]);
+  const handleAddAp = (ap: PlacedAp) => {
+    // 새 AP는 기본 5G radio 1개를 가지고 시작.
+    const newAp: PlacedAp = {
+      ...ap,
+      radios: [{ id: `${ap.id}-5g`, ...DEFAULT_RADIO_5G, tx_power_dbm: txPowerDbm }],
+    };
+    setAps((prev) => [...prev, newAp]);
+  };
   const handleMoveAp = (id: string, x: number, y: number) =>
     setAps((prev) => prev.map((a) => (a.id === id ? { ...a, x_m: x, y_m: y } : a)));
-  const handleRemoveAp = (id: string) =>
+  const handleRemoveAp = (id: string) => {
     setAps((prev) => prev.filter((a) => a.id !== id));
+    if (selectedApId === id) setSelectedApId(null);
+  };
+  const handleUpdateApRadios = (id: string, radios: RadioInterface[]) =>
+    setAps((prev) => prev.map((a) => (a.id === id ? { ...a, radios } : a)));
+  const handleApClick = (id: string) =>
+    setSelectedApId((prev) => (prev === id ? null : id));
 
   // 메트릭 추출 (백엔드가 metrics_json 안에 다양한 키로 넣을 수 있어 유연하게)
   const metrics = parseMetrics(
@@ -282,8 +402,8 @@ export default function SimulationPage() {
         apsCount={aps.length}
         backend={backend}
         onBackendChange={setBackend}
-        frequencyBand={frequencyBand}
-        onFrequencyBandChange={setFrequencyBand}
+        simBands={simBands}
+        onSimBandsChange={setSimBands}
         txPowerDbm={txPowerDbm}
         onTxPowerDbmChange={setTxPowerDbm}
         floorId={floorId ?? null}
@@ -321,21 +441,38 @@ export default function SimulationPage() {
                   onRemove={handleRemoveAp}
                   pending={pendingAdd}
                   onClearPending={() => setPendingAdd(false)}
+                  onApClick={handleApClick}
+                  selectedApId={selectedApId}
                 />
                 <ApAddPanel
                   active={pendingAdd}
-                  onToggle={() => setPendingAdd((v) => !v)}
+                  onToggle={() => { setPendingAdd((v) => !v); setSelectedApId(null); }}
                   disabled={aps.length >= 8}
                 />
+                {selectedApId && aps.find((a) => a.id === selectedApId) && (
+                  <ApRadioPanel
+                    key={selectedApId}
+                    ap={aps.find((a) => a.id === selectedApId)!}
+                    onUpdateRadios={handleUpdateApRadios}
+                    onClose={() => setSelectedApId(null)}
+                  />
+                )}
               </>
             ) : state === 'running' ? (
               <div className="h-full p-4">
                 <SimulationVisualization state={state} />
               </div>
             ) : (
-              // 'complete' — 도형/AP + 히트맵 오버레이를 한 SVG 안에 겹쳐 표시 (read-only).
+              // 'complete' — 도형/AP + 히트맵 오버레이를 한 SVG 안에 겹쳐 표시.
               <>
                 {isViewingHistoricalRun && <HistoricalRunBubble />}
+                {isDual && (
+                  <BandTabBar
+                    bandTab={bandTab}
+                    onBandTabChange={setBandTab}
+                    secondaryLoading={!secondaryRunPoll.isSucceeded && !secondaryRunPoll.isFailed}
+                  />
+                )}
                 <SimulationCanvas
                   sceneVersion={canvasVersionQuery.data}
                   backgroundImageUrl={backgroundImageUrl}
@@ -348,6 +485,8 @@ export default function SimulationPage() {
                   heatmapUrl={heatmapUrl}
                   heatmapBounds={heatmapBounds}
                   readOnly
+                  onApClick={handleApClick}
+                  selectedApId={selectedApId}
                 />
                 {heatmapUrl && (
                   <div className="pointer-events-none absolute left-3 top-3 z-10 w-70">
@@ -357,6 +496,14 @@ export default function SimulationPage() {
                       label="예측 RSSI (시뮬)"
                     />
                   </div>
+                )}
+                {selectedApId && aps.find((a) => a.id === selectedApId) && (
+                  <ApRadioPanel
+                    key={selectedApId}
+                    ap={aps.find((a) => a.id === selectedApId)!}
+                    onUpdateRadios={handleUpdateApRadios}
+                    onClose={() => setSelectedApId(null)}
+                  />
                 )}
               </>
             )}
@@ -427,6 +574,42 @@ function HistoricalRunBubble() {
           className="absolute -bottom-1 right-5 h-2 w-2 rotate-45 border-b border-r border-sky-200 bg-sky-50/95"
           aria-hidden="true"
         />
+      </div>
+    </div>
+  );
+}
+
+/** Dual 모드 완료 시 캔버스 상단 band 탭 전환 바. */
+function BandTabBar({
+  bandTab,
+  onBandTabChange,
+  secondaryLoading,
+}: {
+  bandTab: WifiBand;
+  onBandTabChange: (b: WifiBand) => void;
+  secondaryLoading: boolean;
+}) {
+  return (
+    <div className="absolute left-1/2 top-3 z-10 -translate-x-1/2">
+      <div className="inline-flex h-8 items-center rounded-lg border border-slate-200 bg-white/95 p-0.5 shadow-sm backdrop-blur-sm">
+        {(['5G', '2.4G'] as WifiBand[]).map((b) => (
+          <button
+            key={b}
+            type="button"
+            onClick={() => onBandTabChange(b)}
+            className={cn(
+              'inline-flex h-7 items-center gap-1 rounded-md px-2.5 text-xs font-medium transition-colors',
+              bandTab === b
+                ? 'bg-blue-50 text-blue-700'
+                : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900',
+            )}
+          >
+            {b === '2.4G' ? '2.4GHz' : '5GHz'}
+            {b === '2.4G' && secondaryLoading && (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            )}
+          </button>
+        ))}
       </div>
     </div>
   );
@@ -507,8 +690,8 @@ function PageHeader({
   apsCount,
   backend,
   onBackendChange,
-  frequencyBand,
-  onFrequencyBandChange,
+  simBands,
+  onSimBandsChange,
   txPowerDbm,
   onTxPowerDbmChange,
   floorId,
@@ -522,8 +705,8 @@ function PageHeader({
   apsCount: number;
   backend: RfBackend;
   onBackendChange: (b: RfBackend) => void;
-  frequencyBand: FrequencyBand;
-  onFrequencyBandChange: (band: FrequencyBand) => void;
+  simBands: WifiBand[];
+  onSimBandsChange: (bands: WifiBand[]) => void;
   txPowerDbm: number;
   onTxPowerDbmChange: (value: number) => void;
   floorId: string | null;
@@ -556,8 +739,8 @@ function PageHeader({
             </div>
             <div className="flex flex-wrap items-center gap-1 border-b border-slate-100 px-1.5 py-0.5 sm:border-b-0 sm:border-r">
               <RfPhysicalControls
-                frequencyBand={frequencyBand}
-                onFrequencyBandChange={onFrequencyBandChange}
+                simBands={simBands}
+                onSimBandsChange={onSimBandsChange}
                 txPowerDbm={txPowerDbm}
                 onTxPowerDbmChange={onTxPowerDbmChange}
                 disabled={isStarting}
@@ -598,52 +781,62 @@ function PageHeader({
   );
 }
 
-/** Wi-Fi 대역 · AP 출력 — idle 시 설정 바에 노출. */
+/** Wi-Fi 시뮬 대역 선택 + AP 출력 — idle 시 설정 바에 노출. */
 function RfPhysicalControls({
-  frequencyBand,
-  onFrequencyBandChange,
+  simBands,
+  onSimBandsChange,
   txPowerDbm,
   onTxPowerDbmChange,
   disabled,
 }: {
-  frequencyBand: FrequencyBand;
-  onFrequencyBandChange: (band: FrequencyBand) => void;
+  simBands: WifiBand[];
+  onSimBandsChange: (bands: WifiBand[]) => void;
   txPowerDbm: number;
   onTxPowerDbmChange: (value: number) => void;
   disabled?: boolean;
 }) {
-  const bands: Array<{ key: FrequencyBand; label: string; hint: string }> = [
-    { key: '2.4', label: '2.4GHz', hint: 'Use this when Android measurements are on 2.4GHz Wi-Fi.' },
-    { key: '5', label: '5GHz', hint: 'Use this when Android measurements are on 5GHz Wi-Fi.' },
-  ];
+  type BandMode = '5g' | '2.4g' | 'dual';
+  const currentMode: BandMode =
+    simBands.length > 1 ? 'dual' : simBands[0] === '2.4G' ? '2.4g' : '5g';
+
+  const handleModeChange = (mode: BandMode) => {
+    if (mode === 'dual') onSimBandsChange(['5G', '2.4G']);
+    else if (mode === '2.4g') onSimBandsChange(['2.4G']);
+    else onSimBandsChange(['5G']);
+  };
+
   const handleTxPowerChange = (value: string) => {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return;
     onTxPowerDbmChange(Math.min(30, Math.max(0, parsed)));
   };
 
+  const modes: Array<{ key: BandMode; label: string; hint: string }> = [
+    { key: '5g', label: '5GHz', hint: '5GHz 시뮬' },
+    { key: '2.4g', label: '2.4GHz', hint: '2.4GHz 시뮬' },
+    { key: 'dual', label: 'Dual', hint: '5GHz + 2.4GHz 각각 시뮬 후 탭으로 비교' },
+  ];
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <div
         role="group"
-        aria-label="Wi-Fi 대역"
+        aria-label="시뮬 대역"
         className="inline-flex h-8 items-center rounded-md bg-slate-50 p-0.5"
+        title="2.4GHz와 5GHz는 전파 특성이 다르므로 band별로 따로 시뮬레이션됩니다."
       >
-        {bands.map((band) => {
-          const active = frequencyBand === band.key;
-          return (
-            <button
-              key={band.key}
-              type="button"
-              onClick={() => onFrequencyBandChange(band.key)}
-              disabled={disabled}
-              title={band.hint}
-              className={simSegmentBtn(active, disabled)}
-            >
-              {band.label}
-            </button>
-          );
-        })}
+        {modes.map((m) => (
+          <button
+            key={m.key}
+            type="button"
+            onClick={() => handleModeChange(m.key)}
+            disabled={disabled}
+            title={m.hint}
+            className={simSegmentBtn(currentMode === m.key, disabled)}
+          >
+            {m.label}
+          </button>
+        ))}
       </div>
       <label className="inline-flex h-8 items-center gap-1.5 px-1 text-xs">
         <span className="text-slate-500">출력</span>
@@ -770,7 +963,6 @@ function EmptyState({
  * RF Run 이 succeeded 된 후에만 표시되고, 후보 생성 + 후보 선택 → 배치 저장 흐름.
  * 백엔드 ap-candidates 미구현으로 시연 동안 사용처에서만 주석 처리됨 (정의 유지).
  */
-void ApPlacementPanel;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ApPlacementPanel({ rfRunId }: { rfRunId: string }) {
   const generate = useGenerateApCandidates();

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -121,7 +121,7 @@ export interface ApRecommendationResponse {
   /** band별 radio 개수 등 메타. */
   band_metadata?: Record<string, unknown> | null;
   /** 커버리지 평가 방식 설명. */
-  coverage_semantics?: string | null;
+  coverage_semantics?: Record<string, unknown> | null;
   recommendation_band?: WifiBand | null;
   /** 사용된 추천 모드. */
   recommendation_mode?: string;

--- a/frontend/src/types/ap-recommendation.ts
+++ b/frontend/src/types/ap-recommendation.ts
@@ -1,4 +1,5 @@
 import type { ISODateString, UUID } from './common';
+import type { PhysicalAp, WifiBand } from './rf';
 
 /** POST /ap-recommendation — existing_aps 항목. */
 export interface ExistingAp {
@@ -25,14 +26,24 @@ export interface ApRecommendationRequest {
   existing_aps?: ExistingAp[];
   calibration_run_id?: UUID | null;
   calibration_policy?: 'transfer_only' | 'best_params_only' | 'combined';
-  recommendation_mode?: 'add' | 'replace';
+  recommendation_mode?: 'add' | 'replace' | 'relocate_all' | 'relocate_selected';
   replace_target_ap_id?: string | null;
+  replace_target_ap_ids?: string[];
+  fixed_ap_ids?: string[];
+  relocate_target_ap_ids?: string[];
+  additional_ap_count?: number;
+  target_total_aps?: number | null;
   candidate_tx_power_dbm?: number;
   coverage_threshold_dbm?: number;
   weak_zone_threshold_dbm?: number;
   shadow_threshold_dbm?: number;
   shadow_penalty?: number;
   n_aps?: number;
+  /** Physical AP 구조. 있으면 existing_aps 보다 우선. */
+  physical_aps?: PhysicalAp[];
+  recommendation_unit?: 'physical_ap' | 'radio';
+  target_bands?: WifiBand[];
+  combine_policy?: 'max' | 'prefer_5g_then_2g' | 'weighted';
 }
 
 /** 멀티 AP 세트 내 개별 AP 위치. */
@@ -105,6 +116,27 @@ export interface ApRecommendationResponse {
   calibration?: ApRecommendationCalibrationInfo | null;
   score_weights?: Record<string, number>;
   created_at?: ISODateString | null;
+  /** Physical AP 스냅샷 (요청 시 넘긴 physical_aps). */
+  physical_aps_snapshot?: PhysicalAp[] | null;
+  /** band별 radio 개수 등 메타. */
+  band_metadata?: Record<string, unknown> | null;
+  /** 커버리지 평가 방식 설명. */
+  coverage_semantics?: string | null;
+  recommendation_band?: WifiBand | null;
+  /** 사용된 추천 모드. */
+  recommendation_mode?: string;
+  /** 모드 설명 문자열. */
+  mode_explanation?: string;
+  /** 이동 전 전체 AP 목록. */
+  baseline_aps_snapshot?: Array<{ id: string; x: number; y: number }>;
+  /** 고정 AP 목록. */
+  fixed_aps_snapshot?: Array<{ id: string; x: number; y: number }>;
+  /** 이동 대상 AP 목록 (이동 전 위치). */
+  movable_aps_snapshot?: Array<{ id: string; x: number; y: number }>;
+  /** 최종 AP 레이아웃 (fixed + 추천). */
+  final_aps?: Array<{ id: string; x: number; y: number; fixed: boolean }>;
+  /** AP 이동 기록 {ap_id, from_x, from_y, to_x, to_y}[]. */
+  relocation_moves?: Array<{ ap_id: string; from_x: number; from_y: number; to_x: number; to_y: number }>;
 }
 
 /** UI 표시용. */

--- a/frontend/src/types/rf.ts
+++ b/frontend/src/types/rf.ts
@@ -9,6 +9,38 @@ export type RfRunStatus =
   | 'failed'
   | string;
 
+/** Physical AP 의 2.4GHz / 5GHz radio band. */
+export type WifiBand = '2.4G' | '5G';
+
+/** Physical AP 내부의 단일 radio interface. 좌표는 parent PhysicalAp 를 사용한다. */
+export interface RadioInterface {
+  id: string;
+  band: WifiBand;
+  enabled: boolean;
+  frequency_mhz?: number;
+  frequency_ghz?: number;
+  channel?: number;
+  ssid?: string;
+  bssid?: string;
+  tx_power_dbm?: number;
+}
+
+/** 지도 위 AP 아이콘 1개 = Physical AP 1대 (장비 단위). */
+export interface PhysicalAp {
+  id: string;
+  name?: string;
+  x: number;
+  y: number;
+  z?: number;
+  movable?: boolean;
+  radios: RadioInterface[];
+}
+
+export interface BandSimulationParams {
+  bands: WifiBand[];
+  combine_policy?: 'max' | 'prefer_5g_then_2g' | 'weighted';
+}
+
 /** §13.1 시뮬 실행 백엔드. sagemaker(기본)=클라우드, local=로컬 ai_api(테스트용). */
 export type RfBackend = 'sagemaker' | 'local';
 
@@ -48,6 +80,10 @@ export interface RfRunCreate {
   backend?: RfBackend;
   /** Legacy 호환 (deprecated). */
   request_json?: Record<string, unknown>;
+  /** Physical AP + Radio Interface 구조. 있으면 access_points 보다 우선 처리. */
+  physical_aps?: PhysicalAp[];
+  /** band 별 시뮬 파라미터. 미지정 시 single 5G band 로 동작. */
+  band_simulation?: BandSimulationParams;
 }
 
 export interface RfRun {


### PR DESCRIPTION
## 개요
- Wi-Fi RF 시뮬레이션과 AP 추천에서 `Physical AP`와 `Radio Interface` 개념을 분리
- 기존에는 2.4GHz radio와 5GHz radio가 같은 물리 장비에 있어도 UI/시뮬레이션 상에서는 별도 AP처럼 다뤄질 수 있었습니다. 이로 인해 실제 설치 가능한 AP 단위와 RF 송신기 단위가 섞이고, AP 추천에서도 radio 단위와 장비 단위가 혼동되는 문제가 있었습니다.

이번 변경에서는 다음 기준으로 구조를 정리했습니다.

- Physical AP: 실제 설치/이동 가능한 공유기 장비 단위
- Radio Interface: Physical AP 내부의 2.4GHz / 5GHz 송신 radio 단위
- RF run: band별 radio만 transmitter로 사용
- Coverage 평가: 여러 AP/radio RSSI를 합산하지 않고 cell별 max RSSI 사용

## 변경 사항

### Backend
- `PhysicalApInput`, `RadioInterfaceInput` 스키마 추가
- radio별 `band`, `frequency_mhz`, `frequency_ghz`, `channel`, `ssid`, `bssid`, `tx_power_dbm`, `enabled` 지원
- 주파수 기반 band/channel 추론 헬퍼 추가
- `physical_aps` 요청 필드 추가
- 기존 `existing_aps`를 Physical AP 구조로 변환하는 backward compatibility 처리 추가
- 같은 `physical_ap_id`를 가진 AP 항목을 하나의 Physical AP로 그룹핑
- `physical_ap_id`가 없더라도 좌표가 가까운 AP 항목은 같은 물리 AP로 병합 가능
- band별 radio grouping helper 추가
- RF run 요청에 `band_simulation` 추가
- AP 추천 요청/응답에 physical AP 및 band metadata 추가
- AP 추천 모드를 `add`, `replace`, `relocate_all`, `relocate_selected`로 확장
- 멀티 AP 시뮬레이션 결과를 cell별 max RSSI 기준으로 병합
- local ai_api backend에서 AP별 Sionna 호출 후 element-wise max 병합 처리

### Frontend
- RF 타입에 `WifiBand`, `RadioInterface`, `PhysicalAp`, `BandSimulationParams` 추가
- 시뮬레이션 페이지에서 AP를 Physical AP 단위로 배치하도록 변경
- AP 하나에 5GHz / 2.4GHz radio 설정을 연결
- AP radio 설정 패널 추가
- 5GHz / 2.4GHz / Dual 시뮬레이션 모드 선택 UI 추가
- Dual 모드에서 5GHz와 2.4GHz를 각각 별도 RF run으로 실행하고 탭으로 비교
- AP 마커에 활성화된 band badge 표시
- 기존 RF run 복원 시 `physical_aps` 우선 복원, 없으면 legacy `access_points` fallback
- AP 추천 payload에 `physical_aps`, `target_bands`, `combine_policy` 포함
- AP 추천 결과에서 멀티 AP 위치 표시 지원

실제 Wi-Fi AP는 하나의 장비 안에 2.4GHz와 5GHz radio를 동시에 가질 수 있습니다.  
하지만 RF 시뮬레이션 관점에서는 2.4GHz와 5GHz가 서로 다른 주파수 특성을 가지므로 같은 파라미터로 한 번에 처리하면 물리적으로 부정확합니다.

따라서 이번 PR에서는 다음과 같이 책임을 분리했습니다.

```text
Physical AP = 설치/이동 가능한 장비 단위
Radio Interface = Sionna transmitter 단위
Recommendation = Physical AP 단위
RF Simulation = band/radio 단위
Coverage Merge = max RSSI per cell
```

이를 통해 UI에서는 AP가 중복으로 보이지 않으면서도, 내부적으로는 band별 시뮬레이션을 분리할 수 있습니다.

## 참고 사항
- RSSI는 dBm 값이므로 여러 AP/radio의 값을 단순 합산하지 않습니다.
- 동일 위치에 여러 radio가 있더라도 coverage 평가는 cell별 가장 강한 RSSI를 선택하는 방식으로 처리합니다.
- channel/congestion 완화 효과는 별도 capacity/congestion 평가로 분리할 예정입니다.
- 현재 Dual 모드는 5GHz와 2.4GHz를 별도 RF run으로 실행하고 탭으로 비교하는 구조입니다.